### PR TITLE
fix(confirm): survive hibernation and tell the device when the window closes

### DIFF
--- a/src/agents/__tests__/rpc.spec.ts
+++ b/src/agents/__tests__/rpc.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   deliverReminderPayloadSchema,
+  expireConfirmPayloadSchema,
   notifyBackgroundResultInputSchema,
 } from '@/agents/rpc';
 
@@ -68,5 +69,19 @@ describe('deliverReminderPayloadSchema', () => {
   it('rejects a completely malformed payload', () => {
     expect(() => deliverReminderPayloadSchema.parse('reminder')).toThrow();
     expect(() => deliverReminderPayloadSchema.parse(null)).toThrow();
+  });
+});
+
+describe('expireConfirmPayloadSchema', () => {
+  it('carries the id of the confirmation the timer was scheduled for', () => {
+    expect(expireConfirmPayloadSchema.parse({ confirmationId: 'confirm-1' })).toEqual({
+      confirmationId: 'confirm-1',
+    });
+  });
+
+  it('rejects a payload with no usable confirmation id', () => {
+    expect(() => expireConfirmPayloadSchema.parse({})).toThrow();
+    expect(() => expireConfirmPayloadSchema.parse({ confirmationId: '' })).toThrow();
+    expect(() => expireConfirmPayloadSchema.parse(undefined)).toThrow();
   });
 });

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -50,7 +50,7 @@ import {
 import { createDeskUiMachine, type DeskUiMachine } from '@/session/machine';
 import {
   deletePendingToolConfirmations,
-  readLatestPendingToolConfirmation,
+  readPendingToolConfirmation,
   savePendingToolConfirmation,
 } from '@/tools/pending';
 import type { PendingToolConfirmation } from '@/tools/types';
@@ -321,14 +321,23 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   async expireConfirm(payload: unknown): Promise<void> {
-    const { confirmationId } = expireConfirmPayloadSchema.parse(payload);
-    // A resolved confirmation leaves its timer behind, which would otherwise
-    // fire later and cancel whichever confirmation is live by then.
-    if (
-      this.state.pendingConfirmId === null ||
-      this.state.pendingConfirmId !== confirmationId
-    ) {
+    if (this.state.pendingConfirmId === null) {
       return;
+    }
+    // Timers scheduled before this payload existed still fire with `undefined`,
+    // so an unreadable payload falls back to the stored expiry. A resolved
+    // confirmation otherwise leaves its timer behind, and matching on the id
+    // stops it cancelling whichever confirmation is live by then.
+    const parsedPayload = expireConfirmPayloadSchema.safeParse(payload);
+    if (parsedPayload.success) {
+      if (this.state.pendingConfirmId !== parsedPayload.data.confirmationId) {
+        return;
+      }
+    } else {
+      const storedConfirmation = await readPendingToolConfirmation(this.#sqlExecutor());
+      if (storedConfirmation !== undefined && storedConfirmation.expiresAt > Date.now()) {
+        return;
+      }
     }
     this.#pendingConfirmation = undefined;
     await deletePendingToolConfirmations(this.#sqlExecutor());
@@ -548,7 +557,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   async #resolveConfirm(connection: Connection, isApproved: boolean): Promise<void> {
     const pendingConfirmation =
       this.#pendingConfirmation ??
-      (await readLatestPendingToolConfirmation(this.#sqlExecutor()));
+      (await readPendingToolConfirmation(this.#sqlExecutor()));
     if (pendingConfirmation === undefined) {
       return;
     }

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -50,6 +50,7 @@ import {
 import { createDeskUiMachine, type DeskUiMachine } from '@/session/machine';
 import {
   deletePendingToolConfirmations,
+  isPendingConfirmationOrphaned,
   readPendingToolConfirmation,
   savePendingToolConfirmation,
 } from '@/tools/pending';
@@ -339,6 +340,14 @@ export class Apollo extends Agent<Env, ApolloState> {
         return;
       }
     }
+    await this.#closePendingConfirmation('Confirmación expirada');
+  }
+
+  // Closing a confirmation is the same work however it ends: forget it in
+  // memory and on disk, leave the confirm UI state, and tell the device — which
+  // is sitting on the confirm screen and never learns the window closed unless
+  // it is told.
+  async #closePendingConfirmation(caption: string): Promise<void> {
     this.#pendingConfirmation = undefined;
     await deletePendingToolConfirmations(this.#sqlExecutor());
     this.#applyUiEvent('CANCEL');
@@ -346,11 +355,9 @@ export class Apollo extends Agent<Env, ApolloState> {
       ...this.state,
       pendingConfirmId: null,
       pendingConfirmSummary: null,
-      caption: 'Confirmación expirada',
+      caption,
       uiState: this.#uiMachine.state,
     });
-    // The device is sitting on the confirm screen and never learns the window
-    // closed unless it is told.
     for (const connection of this.getConnections()) {
       this.#pushUiState(connection);
     }
@@ -559,6 +566,16 @@ export class Apollo extends Agent<Env, ApolloState> {
       this.#pendingConfirmation ??
       (await readPendingToolConfirmation(this.#sqlExecutor()));
     if (pendingConfirmation === undefined) {
+      if (
+        isPendingConfirmationOrphaned({
+          restoredConfirmation: pendingConfirmation,
+          pendingConfirmIdInState: this.state.pendingConfirmId,
+        })
+      ) {
+        await this.#closePendingConfirmation(
+          'Se me perdió esa confirmación, pedímelo de nuevo.',
+        );
+      }
       return;
     }
     this.#pendingConfirmation = undefined;

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -15,6 +15,7 @@ import {
 } from '@/agents/notify';
 import {
   deliverReminderPayloadSchema,
+  expireConfirmPayloadSchema,
   notifyBackgroundResultInputSchema,
 } from '@/agents/rpc';
 import { concatenateArrayBufferList, executeApolloTurn } from '@/agents/runtime';
@@ -47,6 +48,11 @@ import {
   type AgentScheduleLike,
 } from '@/reminders/logic';
 import { createDeskUiMachine, type DeskUiMachine } from '@/session/machine';
+import {
+  deletePendingToolConfirmations,
+  readLatestPendingToolConfirmation,
+  savePendingToolConfirmation,
+} from '@/tools/pending';
 import type { PendingToolConfirmation } from '@/tools/types';
 import type { DeskWeatherSnapshot } from '@/weather/fetch';
 import {
@@ -152,6 +158,17 @@ export class Apollo extends Agent<Env, ApolloState> {
         list_name TEXT NOT NULL,
         content TEXT NOT NULL,
         created_at INTEGER NOT NULL
+      )
+    `;
+    // The confirm window is idle by nature, so the agent routinely hibernates
+    // mid-wait and loses the in-memory copy before the user answers.
+    void this.sql`
+      CREATE TABLE IF NOT EXISTS pending_confirmations (
+        id TEXT PRIMARY KEY,
+        tool_name TEXT NOT NULL,
+        args_json TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        expires_at INTEGER NOT NULL
       )
     `;
     this.#session = createApolloSession(this, this.env.MEDIA);
@@ -303,11 +320,18 @@ export class Apollo extends Agent<Env, ApolloState> {
     return this.state;
   }
 
-  async expireConfirm(): Promise<void> {
-    if (this.#pendingConfirmation === undefined) {
+  async expireConfirm(payload: unknown): Promise<void> {
+    const { confirmationId } = expireConfirmPayloadSchema.parse(payload);
+    // A resolved confirmation leaves its timer behind, which would otherwise
+    // fire later and cancel whichever confirmation is live by then.
+    if (
+      this.state.pendingConfirmId === null ||
+      this.state.pendingConfirmId !== confirmationId
+    ) {
       return;
     }
     this.#pendingConfirmation = undefined;
+    await deletePendingToolConfirmations(this.#sqlExecutor());
     this.#applyUiEvent('CANCEL');
     this.setState({
       ...this.state,
@@ -316,6 +340,11 @@ export class Apollo extends Agent<Env, ApolloState> {
       caption: 'Confirmación expirada',
       uiState: this.#uiMachine.state,
     });
+    // The device is sitting on the confirm screen and never learns the window
+    // closed unless it is told.
+    for (const connection of this.getConnections()) {
+      this.#pushUiState(connection);
+    }
   }
 
   async deliverReminder(payload: unknown): Promise<void> {
@@ -517,13 +546,18 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   async #resolveConfirm(connection: Connection, isApproved: boolean): Promise<void> {
-    if (this.#pendingConfirmation === undefined) {
+    const pendingConfirmation =
+      this.#pendingConfirmation ??
+      (await readLatestPendingToolConfirmation(this.#sqlExecutor()));
+    if (pendingConfirmation === undefined) {
       return;
     }
+    this.#pendingConfirmation = undefined;
+    await deletePendingToolConfirmations(this.#sqlExecutor());
     await this.#executeTurn(connection, {
       text: isApproved ? 'confirmado' : 'cancelado',
       confirmOk: isApproved,
-      pendingConfirmation: this.#pendingConfirmation,
+      pendingConfirmation,
     });
   }
 
@@ -602,8 +636,8 @@ export class Apollo extends Agent<Env, ApolloState> {
           setAgentState: (nextState) => {
             this.setState(nextState);
           },
-          scheduleConfirmExpiry: async () => {
-            await this.schedule(30, 'expireConfirm', undefined);
+          scheduleConfirmExpiry: async (confirmationId) => {
+            await this.schedule(30, 'expireConfirm', { confirmationId });
           },
           session: this.session,
           deviceId,
@@ -612,6 +646,9 @@ export class Apollo extends Agent<Env, ApolloState> {
         },
         turnPart,
       );
+      if (this.#pendingConfirmation !== undefined) {
+        await savePendingToolConfirmation(this.#sqlExecutor(), this.#pendingConfirmation);
+      }
     } catch (error) {
       console.error(
         JSON.stringify({

--- a/src/agents/rpc.ts
+++ b/src/agents/rpc.ts
@@ -9,3 +9,7 @@ export const notifyBackgroundResultInputSchema = z.object({
 export const deliverReminderPayloadSchema = z.object({
   message: z.string().min(1),
 });
+
+export const expireConfirmPayloadSchema = z.object({
+  confirmationId: z.string().min(1),
+});

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -28,7 +28,7 @@ export type ApolloTurnRuntimeDependencies = {
   readonly currentState: ApolloState;
   readonly getCurrentState: () => ApolloState;
   readonly setAgentState: (nextState: ApolloState) => void;
-  readonly scheduleConfirmExpiry: () => Promise<void>;
+  readonly scheduleConfirmExpiry: (confirmationId: string) => Promise<void>;
   readonly session: Session;
   readonly deviceId: string;
   readonly effects: DeskToolEffects;
@@ -158,7 +158,7 @@ export async function executeApolloTurn(
   }
 
   if (turnOutput.pendingConfirmation !== undefined) {
-    await dependencies.scheduleConfirmExpiry();
+    await dependencies.scheduleConfirmExpiry(turnOutput.pendingConfirmation.id);
   }
 
   // `set_focus`/`clear_focus` tool effects (see @/agents/effects) may have

--- a/src/configuration/testing.ts
+++ b/src/configuration/testing.ts
@@ -1,40 +1,32 @@
 import type { MemorySqlExecutor } from '@/memory/store';
 import type { DeskToolEffects } from '@/tools/types';
 
-type PendingConfirmationRow = {
-  id: string;
-  tool_name: string;
-  args_json: string;
-  summary: string;
-  expires_at: number;
-};
-
 export function createInMemoryPendingConfirmationSqlExecutor(): MemorySqlExecutor {
-  let rowList: PendingConfirmationRow[] = [];
+  let rowList: readonly Record<string, unknown>[] = [];
   return {
     execute<Row extends Record<string, unknown>>(
       query: string,
       ...bindValues: unknown[]
     ): readonly Row[] {
-      if (query.startsWith('INSERT INTO pending_confirmations')) {
-        const insertedRow: PendingConfirmationRow = {
-          id: String(bindValues[0]),
-          tool_name: String(bindValues[1]),
-          args_json: String(bindValues[2]),
-          summary: String(bindValues[3]),
-          expires_at: Number(bindValues[4]),
-        };
-        rowList = [...rowList.filter((row) => row.id !== insertedRow.id), insertedRow];
-        return [];
-      }
       if (query.startsWith('DELETE FROM pending_confirmations')) {
         rowList = [];
         return [];
       }
+      if (query.startsWith('INSERT INTO pending_confirmations')) {
+        rowList = [
+          ...rowList,
+          {
+            id: String(bindValues[0]),
+            tool_name: String(bindValues[1]),
+            args_json: String(bindValues[2]),
+            summary: String(bindValues[3]),
+            expires_at: Number(bindValues[4]),
+          },
+        ];
+        return [];
+      }
       if (query.includes('FROM pending_confirmations')) {
-        return [...rowList]
-          .toSorted((left, right) => right.expires_at - left.expires_at)
-          .slice(0, 1) as unknown as readonly Row[];
+        return rowList.slice(0, 1) as readonly Row[];
       }
       return [];
     },

--- a/src/configuration/testing.ts
+++ b/src/configuration/testing.ts
@@ -1,4 +1,45 @@
+import type { MemorySqlExecutor } from '@/memory/store';
 import type { DeskToolEffects } from '@/tools/types';
+
+type PendingConfirmationRow = {
+  id: string;
+  tool_name: string;
+  args_json: string;
+  summary: string;
+  expires_at: number;
+};
+
+export function createInMemoryPendingConfirmationSqlExecutor(): MemorySqlExecutor {
+  let rowList: PendingConfirmationRow[] = [];
+  return {
+    execute<Row extends Record<string, unknown>>(
+      query: string,
+      ...bindValues: unknown[]
+    ): readonly Row[] {
+      if (query.startsWith('INSERT INTO pending_confirmations')) {
+        const insertedRow: PendingConfirmationRow = {
+          id: String(bindValues[0]),
+          tool_name: String(bindValues[1]),
+          args_json: String(bindValues[2]),
+          summary: String(bindValues[3]),
+          expires_at: Number(bindValues[4]),
+        };
+        rowList = [...rowList.filter((row) => row.id !== insertedRow.id), insertedRow];
+        return [];
+      }
+      if (query.startsWith('DELETE FROM pending_confirmations')) {
+        rowList = [];
+        return [];
+      }
+      if (query.includes('FROM pending_confirmations')) {
+        return [...rowList]
+          .toSorted((left, right) => right.expires_at - left.expires_at)
+          .slice(0, 1) as unknown as readonly Row[];
+      }
+      return [];
+    },
+  };
+}
 
 export function createFakeApolloEnvironment(overrides: Partial<Env> = {}): Env {
   return {

--- a/src/tools/__tests__/pending.spec.ts
+++ b/src/tools/__tests__/pending.spec.ts
@@ -4,6 +4,7 @@ import { createInMemoryPendingConfirmationSqlExecutor } from '@/configuration/te
 import type { MemorySqlExecutor } from '@/memory/store';
 import {
   deletePendingToolConfirmations,
+  isPendingConfirmationOrphaned,
   readPendingToolConfirmation,
   savePendingToolConfirmation,
 } from '@/tools/pending';
@@ -101,5 +102,42 @@ describe('pending tool confirmation store', () => {
     });
 
     expect(await readPendingToolConfirmation(wrongShapeSqlExecutor)).toBeUndefined();
+  });
+});
+
+describe('isPendingConfirmationOrphaned', () => {
+  const confirmation = {
+    id: 'confirm-1',
+    toolName: 'sandbox_exec',
+    args: { command: 'pwd' },
+    summary: 'Ejecutar pwd',
+    expiresAt: 30_000,
+  };
+
+  it('flags an answer the server cannot resolve while state says one is pending', () => {
+    expect(
+      isPendingConfirmationOrphaned({
+        restoredConfirmation: undefined,
+        pendingConfirmIdInState: 'confirm-1',
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores a stray answer with nothing pending', () => {
+    expect(
+      isPendingConfirmationOrphaned({
+        restoredConfirmation: undefined,
+        pendingConfirmIdInState: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores an answer that restored a confirmation', () => {
+    expect(
+      isPendingConfirmationOrphaned({
+        restoredConfirmation: confirmation,
+        pendingConfirmIdInState: 'confirm-1',
+      }),
+    ).toBe(false);
   });
 });

--- a/src/tools/__tests__/pending.spec.ts
+++ b/src/tools/__tests__/pending.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createInMemoryPendingConfirmationSqlExecutor } from '@/configuration/testing';
+import {
+  deletePendingToolConfirmations,
+  readLatestPendingToolConfirmation,
+  savePendingToolConfirmation,
+} from '@/tools/pending';
+
+describe('pending tool confirmation store', () => {
+  it('round-trips a confirmation with its arguments intact', async () => {
+    const sqlExecutor = createInMemoryPendingConfirmationSqlExecutor();
+    await savePendingToolConfirmation(sqlExecutor, {
+      id: 'confirm-1',
+      toolName: 'sandbox_run_code',
+      args: { code: 'print(2 + 2)', language: 'python' },
+      summary: 'Ejecutar código python en sandbox',
+      expiresAt: 30_000,
+    });
+
+    const restored = await readLatestPendingToolConfirmation(sqlExecutor);
+
+    expect(restored).toEqual({
+      id: 'confirm-1',
+      toolName: 'sandbox_run_code',
+      args: { code: 'print(2 + 2)', language: 'python' },
+      summary: 'Ejecutar código python en sandbox',
+      expiresAt: 30_000,
+    });
+  });
+
+  it('reports nothing pending on an empty store and after a delete', async () => {
+    const sqlExecutor = createInMemoryPendingConfirmationSqlExecutor();
+    expect(await readLatestPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+
+    await savePendingToolConfirmation(sqlExecutor, {
+      id: 'confirm-1',
+      toolName: 'sandbox_exec',
+      args: { command: 'ls' },
+      summary: 'Ejecutar en sandbox: ls',
+      expiresAt: 30_000,
+    });
+    await deletePendingToolConfirmations(sqlExecutor);
+
+    expect(await readLatestPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+  });
+
+  it('keeps only the newest confirmation when one replaces another', async () => {
+    const sqlExecutor = createInMemoryPendingConfirmationSqlExecutor();
+    await savePendingToolConfirmation(sqlExecutor, {
+      id: 'confirm-1',
+      toolName: 'sandbox_exec',
+      args: { command: 'ls' },
+      summary: 'primero',
+      expiresAt: 10_000,
+    });
+    await savePendingToolConfirmation(sqlExecutor, {
+      id: 'confirm-2',
+      toolName: 'sandbox_exec',
+      args: { command: 'pwd' },
+      summary: 'segundo',
+      expiresAt: 20_000,
+    });
+
+    const restored = await readLatestPendingToolConfirmation(sqlExecutor);
+
+    expect(restored?.id).toBe('confirm-2');
+    expect(restored?.summary).toBe('segundo');
+  });
+});

--- a/src/tools/__tests__/pending.spec.ts
+++ b/src/tools/__tests__/pending.spec.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from 'bun:test';
 
 import { createInMemoryPendingConfirmationSqlExecutor } from '@/configuration/testing';
+import type { MemorySqlExecutor } from '@/memory/store';
 import {
   deletePendingToolConfirmations,
-  readLatestPendingToolConfirmation,
+  readPendingToolConfirmation,
   savePendingToolConfirmation,
 } from '@/tools/pending';
+
+function createSingleRowSqlExecutor(row: Record<string, unknown>): MemorySqlExecutor {
+  const rowList: readonly Record<string, unknown>[] = [row];
+  return {
+    execute: <Row extends Record<string, unknown>>(query: string): readonly Row[] =>
+      query.includes('FROM pending_confirmations') ? (rowList as readonly Row[]) : [],
+  };
+}
 
 describe('pending tool confirmation store', () => {
   it('round-trips a confirmation with its arguments intact', async () => {
@@ -18,7 +27,7 @@ describe('pending tool confirmation store', () => {
       expiresAt: 30_000,
     });
 
-    const restored = await readLatestPendingToolConfirmation(sqlExecutor);
+    const restored = await readPendingToolConfirmation(sqlExecutor);
 
     expect(restored).toEqual({
       id: 'confirm-1',
@@ -31,7 +40,7 @@ describe('pending tool confirmation store', () => {
 
   it('reports nothing pending on an empty store and after a delete', async () => {
     const sqlExecutor = createInMemoryPendingConfirmationSqlExecutor();
-    expect(await readLatestPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+    expect(await readPendingToolConfirmation(sqlExecutor)).toBeUndefined();
 
     await savePendingToolConfirmation(sqlExecutor, {
       id: 'confirm-1',
@@ -42,29 +51,55 @@ describe('pending tool confirmation store', () => {
     });
     await deletePendingToolConfirmations(sqlExecutor);
 
-    expect(await readLatestPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+    expect(await readPendingToolConfirmation(sqlExecutor)).toBeUndefined();
   });
 
-  it('keeps only the newest confirmation when one replaces another', async () => {
+  it('replaces the previous confirmation rather than accumulating rows', async () => {
     const sqlExecutor = createInMemoryPendingConfirmationSqlExecutor();
     await savePendingToolConfirmation(sqlExecutor, {
       id: 'confirm-1',
       toolName: 'sandbox_exec',
       args: { command: 'ls' },
       summary: 'primero',
-      expiresAt: 10_000,
+      expiresAt: 20_000,
     });
+    // Deliberately shorter-lived than the row it supersedes: ordering must not
+    // decide which confirmation is restored, replacement must.
     await savePendingToolConfirmation(sqlExecutor, {
       id: 'confirm-2',
       toolName: 'sandbox_exec',
       args: { command: 'pwd' },
       summary: 'segundo',
-      expiresAt: 20_000,
+      expiresAt: 10_000,
     });
 
-    const restored = await readLatestPendingToolConfirmation(sqlExecutor);
+    const restored = await readPendingToolConfirmation(sqlExecutor);
 
     expect(restored?.id).toBe('confirm-2');
-    expect(restored?.summary).toBe('segundo');
+    expect(restored?.args).toEqual({ command: 'pwd' });
+
+    await deletePendingToolConfirmations(sqlExecutor);
+    expect(await readPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+  });
+
+  it('treats a row it cannot read back as nothing pending', async () => {
+    const corruptRowSqlExecutor = createSingleRowSqlExecutor({
+      id: 'confirm-1',
+      tool_name: 'sandbox_exec',
+      args_json: '{not json',
+      summary: 'roto',
+      expires_at: 30_000,
+    });
+
+    expect(await readPendingToolConfirmation(corruptRowSqlExecutor)).toBeUndefined();
+  });
+
+  it('treats a row of the wrong shape as nothing pending', async () => {
+    const wrongShapeSqlExecutor = createSingleRowSqlExecutor({
+      id: 'confirm-1',
+      summary: 'incompleto',
+    });
+
+    expect(await readPendingToolConfirmation(wrongShapeSqlExecutor)).toBeUndefined();
   });
 });

--- a/src/tools/__tests__/router.spec.ts
+++ b/src/tools/__tests__/router.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import { createFakeApolloEnvironment } from '@/configuration/testing';
 import {
@@ -32,7 +33,27 @@ describe('tool router', () => {
     },
   };
 
-  const toolDefinitionMap = buildToolDefinitionMap([safeTool, unsafeTool]);
+  // Mirrors the real unsafe tools: the summary builder parses the arguments
+  // with the tool's schema, so bad arguments throw before a confirmation exists.
+  const strictUnsafeTool: ToolDefinition = {
+    name: 'strict_exec_test',
+    safety: 'unsafe',
+    description: 'unsafe',
+    parameters: { type: 'object', properties: {} },
+    buildConfirmSummary: (args) => {
+      const parsed = z.object({ command: z.string().min(1) }).parse(args);
+      return `Ejecutar ${parsed.command}`;
+    },
+    async handler() {
+      return { ok: true, summary: 'ejecutado' };
+    },
+  };
+
+  const toolDefinitionMap = buildToolDefinitionMap([
+    safeTool,
+    unsafeTool,
+    strictUnsafeTool,
+  ]);
 
   it('runs safe tool immediately', async () => {
     const outcome = await executeToolByName(
@@ -44,6 +65,36 @@ describe('tool router', () => {
     expect(outcome.status).toBe('done');
     if (outcome.status === 'done') {
       expect(outcome.result.summary).toBe('guardado');
+    }
+  });
+
+  it('rejects arguments the unsafe tool cannot accept without creating a confirmation', async () => {
+    const outcome = await executeToolByName(
+      toolDefinitionMap,
+      'strict_exec_test',
+      { command: '' },
+      { environment: fakeEnvironment, nowMilliseconds: 1000 },
+    );
+    // A tool error the turn can speak and retry, not an exception that sinks it
+    // — and nothing to persist, so the confirm screen never opens.
+    expect(outcome.status).toBe('done');
+    if (outcome.status === 'done') {
+      expect(outcome.result.ok).toBe(false);
+      expect(outcome.result.summary).toContain('argumentos inválidos');
+    }
+  });
+
+  it('still confirms when the unsafe tool accepts the arguments', async () => {
+    const outcome = await executeToolByName(
+      toolDefinitionMap,
+      'strict_exec_test',
+      { command: 'ls' },
+      { environment: fakeEnvironment, nowMilliseconds: 1000 },
+      () => 'confirm-strict',
+    );
+    expect(outcome.status).toBe('needs_confirm');
+    if (outcome.status === 'needs_confirm') {
+      expect(outcome.pending.summary).toBe('Ejecutar ls');
     }
   });
 

--- a/src/tools/pending.ts
+++ b/src/tools/pending.ts
@@ -67,3 +67,18 @@ export async function deletePendingToolConfirmations(
 ): Promise<void> {
   sqlExecutor.execute('DELETE FROM pending_confirmations');
 }
+
+// A confirm answer that restores nothing is one of two different situations. A
+// stray tap with no confirmation pending is noise and stays ignored; agent
+// state that still names a confirmation means the device is showing a confirm
+// screen the server can no longer resolve — reading the row back failed, or the
+// state outlived it. That one has to be closed out, or the answer is swallowed
+// and the screen stays up until the expiry timer fires.
+export function isPendingConfirmationOrphaned(input: {
+  readonly restoredConfirmation: PendingToolConfirmation | undefined;
+  readonly pendingConfirmIdInState: string | null;
+}): boolean {
+  return (
+    input.restoredConfirmation === undefined && input.pendingConfirmIdInState !== null
+  );
+}

--- a/src/tools/pending.ts
+++ b/src/tools/pending.ts
@@ -11,12 +11,16 @@ const pendingToolConfirmationRowSchema = z.object({
   expires_at: z.number().int().nonnegative(),
 });
 
+// The agent tracks a single pending confirmation, so the table holds at most
+// one row: replacing rather than upserting keeps a superseded confirmation from
+// being restored in place of the live one.
 export async function savePendingToolConfirmation(
   sqlExecutor: MemorySqlExecutor,
   confirmation: PendingToolConfirmation,
 ): Promise<void> {
+  sqlExecutor.execute('DELETE FROM pending_confirmations');
   sqlExecutor.execute(
-    'INSERT INTO pending_confirmations (id, tool_name, args_json, summary, expires_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET tool_name = excluded.tool_name, args_json = excluded.args_json, summary = excluded.summary, expires_at = excluded.expires_at',
+    'INSERT INTO pending_confirmations (id, tool_name, args_json, summary, expires_at) VALUES (?, ?, ?, ?, ?)',
     confirmation.id,
     confirmation.toolName,
     JSON.stringify(confirmation.args ?? null),
@@ -25,23 +29,36 @@ export async function savePendingToolConfirmation(
   );
 }
 
-export async function readLatestPendingToolConfirmation(
+export async function readPendingToolConfirmation(
   sqlExecutor: MemorySqlExecutor,
 ): Promise<PendingToolConfirmation | undefined> {
   const rows = sqlExecutor.execute<Record<string, unknown>>(
-    'SELECT id, tool_name, args_json, summary, expires_at FROM pending_confirmations ORDER BY expires_at DESC LIMIT 1',
+    'SELECT id, tool_name, args_json, summary, expires_at FROM pending_confirmations LIMIT 1',
   );
   const firstRow = rows[0];
   if (firstRow === undefined) {
     return undefined;
   }
-  const parsedRow = pendingToolConfirmationRowSchema.parse(firstRow);
+
+  // A row that cannot be read back is treated as nothing pending: the caller
+  // would otherwise hand unvalidated arguments to an unsafe tool.
+  const parsedRow = pendingToolConfirmationRowSchema.safeParse(firstRow);
+  if (!parsedRow.success) {
+    return undefined;
+  }
+  let storedArguments: unknown;
+  try {
+    storedArguments = JSON.parse(parsedRow.data.args_json);
+  } catch {
+    return undefined;
+  }
+
   return {
-    id: parsedRow.id,
-    toolName: parsedRow.tool_name,
-    args: JSON.parse(parsedRow.args_json),
-    summary: parsedRow.summary,
-    expiresAt: parsedRow.expires_at,
+    id: parsedRow.data.id,
+    toolName: parsedRow.data.tool_name,
+    args: storedArguments,
+    summary: parsedRow.data.summary,
+    expiresAt: parsedRow.data.expires_at,
   };
 }
 

--- a/src/tools/pending.ts
+++ b/src/tools/pending.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+import type { MemorySqlExecutor } from '@/memory/store';
+import type { PendingToolConfirmation } from '@/tools/types';
+
+const pendingToolConfirmationRowSchema = z.object({
+  id: z.string().min(1),
+  tool_name: z.string().min(1),
+  args_json: z.string(),
+  summary: z.string().min(1),
+  expires_at: z.number().int().nonnegative(),
+});
+
+export async function savePendingToolConfirmation(
+  sqlExecutor: MemorySqlExecutor,
+  confirmation: PendingToolConfirmation,
+): Promise<void> {
+  sqlExecutor.execute(
+    'INSERT INTO pending_confirmations (id, tool_name, args_json, summary, expires_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET tool_name = excluded.tool_name, args_json = excluded.args_json, summary = excluded.summary, expires_at = excluded.expires_at',
+    confirmation.id,
+    confirmation.toolName,
+    JSON.stringify(confirmation.args ?? null),
+    confirmation.summary,
+    confirmation.expiresAt,
+  );
+}
+
+export async function readLatestPendingToolConfirmation(
+  sqlExecutor: MemorySqlExecutor,
+): Promise<PendingToolConfirmation | undefined> {
+  const rows = sqlExecutor.execute<Record<string, unknown>>(
+    'SELECT id, tool_name, args_json, summary, expires_at FROM pending_confirmations ORDER BY expires_at DESC LIMIT 1',
+  );
+  const firstRow = rows[0];
+  if (firstRow === undefined) {
+    return undefined;
+  }
+  const parsedRow = pendingToolConfirmationRowSchema.parse(firstRow);
+  return {
+    id: parsedRow.id,
+    toolName: parsedRow.tool_name,
+    args: JSON.parse(parsedRow.args_json),
+    summary: parsedRow.summary,
+    expiresAt: parsedRow.expires_at,
+  };
+}
+
+export async function deletePendingToolConfirmations(
+  sqlExecutor: MemorySqlExecutor,
+): Promise<void> {
+  sqlExecutor.execute('DELETE FROM pending_confirmations');
+}

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -39,8 +39,23 @@ export async function executeToolByName(
   }
 
   if (toolDefinition.safety === 'unsafe') {
-    const summary =
-      toolDefinition.buildConfirmSummary?.(toolArgs) ?? `Confirmar ${toolName}`;
+    // Building the summary is also the gate on the arguments: it parses them
+    // with the tool's own schema, so no confirmation is ever created — or
+    // persisted, or shown to the user — for a call that could not run. Letting
+    // the parse failure escape would fail the whole turn; the model sending
+    // arguments a tool cannot accept is an ordinary tool error it can retry.
+    let summary: string;
+    try {
+      summary = toolDefinition.buildConfirmSummary?.(toolArgs) ?? `Confirmar ${toolName}`;
+    } catch {
+      return {
+        status: 'done',
+        result: {
+          ok: false,
+          summary: `No pude preparar la confirmación de ${toolName}: argumentos inválidos`,
+        },
+      };
+    }
     return {
       status: 'needs_confirm',
       pending: {


### PR DESCRIPTION
> Stacked on #4.

The confirmation round-trip had a hole that only shows up in real use, and it is the gate in front of every dangerous tool.

### A hibernating agent forgot what it had asked

The pending confirmation lived in a private field, `#pendingConfirmation`. `onStart()` runs when an agent **wakes from hibernation**, which resets every instance field — and a 30-second confirm window with no traffic is exactly when a Durable Object hibernates.

So: you ask for something dangerous → the device shows the prompt → the agent hibernates → you tap yes → `#resolveConfirm` finds `undefined` and returns **silently**. The tool never runs and the device sits on the confirm screen forever.

Now persisted to a `pending_confirmations` table and rehydrated on answer. Durable state already held the id and summary; what was missing was the tool name and arguments needed to actually run it.

### Two related fixes on the same path

`expireConfirm` mutated state without pushing `ui_state`, so on timeout the device kept showing a prompt it could no longer answer — the agent had moved on and it had no way to know.

The expiry timer carried no id, so a resolved confirmation's timer still fired 30 seconds later and cancelled whichever confirmation happened to be live by then. It now carries the id it was scheduled for.

### Why now

This matters more from here on: the next PRs put `sandbox_exec` and a coding agent behind exactly this gate.

`format:check`, `lint`, `typecheck`, `test` (184) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR persists pending tool confirmations across agent hibernation and synchronizes confirmation closure with connected devices.
- Adds durable storage and restoration for pending confirmations.
- Associates expiration callbacks with confirmation IDs and centralizes cleanup.
- Converts invalid initial unsafe-tool arguments into ordinary tool errors.
- Adds persistence, RPC-payload, orphan-detection, and router tests.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR does not appear safe to merge until restored arguments are validated against the selected unsafe tool’s schema before execution.

Persisted arguments still cross the restoration boundary as unvalidated JSON and are passed directly to an unsafe tool handler after approval, so malformed restored state can abort the confirmed turn and the required external-input validation boundary remains unenforced.

**Files Needing Attention:** src/tools/pending.ts, src/tools/router.ts
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(confirm): fail an unsafe call with b..."](https://github.com/galfrevn/apollo/commit/b613ba2e94b4e6f90f7e46c08a8a6d4e754174cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51870654)</sub>

<!-- /greptile_comment -->