### PR TITLE
feat(sandbox): re-enable the container tools

### DIFF
--- a/documentation/capabilities/sandbox.md
+++ b/documentation/capabilities/sandbox.md
@@ -7,9 +7,15 @@ Sandbox tools run untrusted or heavy code away from the agent isolate.
 - `sandbox_run_code` — run a code snippet in the sandbox
 - `sandbox_exec` — execute a command-style request inside the sandbox environment
 
+## Confirmation flow
+
+Both tools are `safety: 'unsafe'`, so the router never runs them directly: it returns a pending confirmation, the agent sends `confirm_request`, and the handler only fires once the device answers `confirm`. The pending confirmation is written to the `pending_confirmations` table rather than kept on the instance — the confirm window is idle by nature, and a hibernating agent would otherwise wake with no memory of what it asked. The expiry timer carries the confirmation id so a resolved confirmation's timer cannot cancel a later one.
+
 ## Infrastructure
 
 Cloudflare Sandbox / Containers bindings are declared in `wrangler.jsonc` (`Sandbox` class, container image). Runner helpers live under `src/sandbox/`.
+
+Containers require the Workers Paid plan to deploy. Local development does not: `wrangler dev` builds and runs the image in your own Docker, so the full path is exercisable on the free plan.
 
 ## Product fit
 

--- a/documentation/capabilities/tools.md
+++ b/documentation/capabilities/tools.md
@@ -14,7 +14,7 @@ Tools are how Apollo takes action beyond talking. Definitions live under `src/to
 - Lists: `add_to_list`, `read_list`, `remove_from_list` (SQL table `list_items`; default list "super")
 - Finance: `dollar_rate` (dolarapi.com, free/keyless: blue, oficial, bolsa, contadoconliqui, tarjeta, cripto)
 - Email: `send_email` (Resend, secret `RESEND_API_KEY`; recipient pinned to `APOLLO_OWNER_EMAIL` var — deep-research reports are also emailed automatically)
-- Sandbox: `sandbox_run_code`, `sandbox_exec` (disabled: requires Workers Paid)
+- Sandbox: `sandbox_run_code`, `sandbox_exec` (both marked `unsafe`, so they route through confirmation)
 
 ## Router
 

--- a/documentation/operations/deploy.md
+++ b/documentation/operations/deploy.md
@@ -20,6 +20,8 @@ See `wrangler.jsonc` for the authoritative list, migrations, and model vars.
 
 Use your usual Wrangler deploy flow after secrets and resources exist in the target account. Do not invent resource names beyond what the config declares.
 
+The `Sandbox` container image is built by the Docker CLI as part of every deploy, including `--dry-run`, so the daemon has to be running. To ship a Worker-only change without it, pass `--containers-rollout=none`.
+
 ## Navigation
 
 Prev: [Setup](setup.md) · Next: [Auth](auth.md)

--- a/src/configuration/environment.d.ts
+++ b/src/configuration/environment.d.ts
@@ -5,9 +5,6 @@ interface Env {
   TAVILY_API_KEY: string;
   RESEND_API_KEY: string;
   MOCK_VOICE?: string;
-  // `wrangler types` only emits this while the container binding is active in
-  // wrangler.jsonc, and it is commented out until the plan is upgraded.
-  Sandbox: DurableObjectNamespace<import('@cloudflare/sandbox').Sandbox>;
 }
 
 declare namespace Cloudflare {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,6 @@ import { authorizeApolloConnection, Apollo } from '@/agents/apollo';
 import { consumeApolloQueueBatch } from '@/queues/consume';
 import { ApolloBackground } from '@/workflows/background';
 
-// Sandbox is still exported (required for Env['Sandbox']'s type in
-// worker-configuration.d.ts to resolve) but is not bound in wrangler.jsonc:
-// Cloudflare Containers require the Workers Paid plan. Re-enable the
-// "containers"/durable_objects binding there once upgraded.
 export { Apollo, ApolloBackground, Sandbox };
 
 export default {

--- a/src/sandbox/__tests__/wiring.spec.ts
+++ b/src/sandbox/__tests__/wiring.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@/configuration/testing';
 import {
   deletePendingToolConfirmations,
-  readLatestPendingToolConfirmation,
+  readPendingToolConfirmation,
   savePendingToolConfirmation,
 } from '@/tools/pending';
 import { createBuiltinToolDefinitionMap } from '@/tools/catalog';
@@ -69,7 +69,7 @@ describe('sandbox end-to-end wiring', () => {
     await savePendingToolConfirmation(sqlExecutor, outcome.pending);
 
     // Everything the agent held in memory is gone, as after a hibernation.
-    const restoredConfirmation = await readLatestPendingToolConfirmation(sqlExecutor);
+    const restoredConfirmation = await readPendingToolConfirmation(sqlExecutor);
     expect(restoredConfirmation).toBeDefined();
     if (restoredConfirmation === undefined) {
       throw new Error('expected the confirmation to survive hibernation');
@@ -93,7 +93,7 @@ describe('sandbox end-to-end wiring', () => {
     ]);
 
     await deletePendingToolConfirmations(sqlExecutor);
-    expect(await readLatestPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+    expect(await readPendingToolConfirmation(sqlExecutor)).toBeUndefined();
   });
 
   it('never reaches the container when the user declines', async () => {

--- a/src/sandbox/__tests__/wiring.spec.ts
+++ b/src/sandbox/__tests__/wiring.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import {
+  createFakeApolloEnvironment,
+  createInMemoryPendingConfirmationSqlExecutor,
+} from '@/configuration/testing';
+import {
+  deletePendingToolConfirmations,
+  readLatestPendingToolConfirmation,
+  savePendingToolConfirmation,
+} from '@/tools/pending';
+import { createBuiltinToolDefinitionMap } from '@/tools/catalog';
+import { executeToolByName, resolvePendingToolConfirmation } from '@/tools/router';
+
+type CapturedSandboxCall = {
+  readonly sandboxId: string;
+  readonly code?: string;
+  readonly command?: string;
+};
+
+const capturedSandboxCallList: CapturedSandboxCall[] = [];
+
+mock.module('@cloudflare/sandbox', () => ({
+  getSandbox: (_namespace: unknown, sandboxId: string) => ({
+    createCodeContext: async () => ({ id: 'context-1' }),
+    runCode: async (code: string) => {
+      capturedSandboxCallList.push({ sandboxId, code });
+      return {
+        logs: { stdout: ['4'], stderr: [] },
+        results: [],
+        error: undefined,
+      };
+    },
+    exec: async (command: string) => {
+      capturedSandboxCallList.push({ sandboxId, command });
+      return {
+        success: true,
+        exitCode: 0,
+        stdout: 'workspace\n',
+        stderr: '',
+      };
+    },
+  }),
+}));
+
+const fakeEnvironment = createFakeApolloEnvironment();
+
+describe('sandbox end-to-end wiring', () => {
+  it('routes a sandbox call through confirmation, hibernation, and execution', async () => {
+    capturedSandboxCallList.length = 0;
+    const toolDefinitionMap = createBuiltinToolDefinitionMap();
+    const sqlExecutor = createInMemoryPendingConfirmationSqlExecutor();
+
+    const outcome = await executeToolByName(
+      toolDefinitionMap,
+      'sandbox_run_code',
+      { code: 'print(2 + 2)', language: 'python' },
+      { environment: fakeEnvironment, nowMilliseconds: 0, deviceId: 'desk-01' },
+      () => 'confirm-1',
+    );
+
+    expect(outcome.status).toBe('needs_confirm');
+    if (outcome.status !== 'needs_confirm') {
+      throw new Error('expected the sandbox tool to require confirmation');
+    }
+    expect(outcome.pending.summary).toBe('Ejecutar código python en sandbox');
+    expect(capturedSandboxCallList).toHaveLength(0);
+
+    await savePendingToolConfirmation(sqlExecutor, outcome.pending);
+
+    // Everything the agent held in memory is gone, as after a hibernation.
+    const restoredConfirmation = await readLatestPendingToolConfirmation(sqlExecutor);
+    expect(restoredConfirmation).toBeDefined();
+    if (restoredConfirmation === undefined) {
+      throw new Error('expected the confirmation to survive hibernation');
+    }
+
+    const result = await resolvePendingToolConfirmation(
+      createBuiltinToolDefinitionMap(),
+      restoredConfirmation,
+      true,
+      { environment: fakeEnvironment, nowMilliseconds: 1000, deviceId: 'desk-01' },
+    );
+
+    expect('cancelled' in result).toBe(false);
+    if ('cancelled' in result) {
+      throw new Error('expected the confirmed tool to run');
+    }
+    expect(result.ok).toBe(true);
+    expect(result.summary).toBe('4');
+    expect(capturedSandboxCallList).toEqual([
+      { sandboxId: 'apollo-desk-01', code: 'print(2 + 2)' },
+    ]);
+
+    await deletePendingToolConfirmations(sqlExecutor);
+    expect(await readLatestPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+  });
+
+  it('never reaches the container when the user declines', async () => {
+    capturedSandboxCallList.length = 0;
+    const outcome = await executeToolByName(
+      createBuiltinToolDefinitionMap(),
+      'sandbox_exec',
+      { command: 'ls /workspace' },
+      { environment: fakeEnvironment, nowMilliseconds: 0, deviceId: 'desk-01' },
+      () => 'confirm-2',
+    );
+    if (outcome.status !== 'needs_confirm') {
+      throw new Error('expected sandbox_exec to require confirmation');
+    }
+
+    const result = await resolvePendingToolConfirmation(
+      createBuiltinToolDefinitionMap(),
+      outcome.pending,
+      false,
+      { environment: fakeEnvironment, nowMilliseconds: 1000, deviceId: 'desk-01' },
+    );
+
+    expect(result).toEqual({ cancelled: true });
+    expect(capturedSandboxCallList).toHaveLength(0);
+  });
+
+  it('refuses a confirmation that outlived its window', async () => {
+    capturedSandboxCallList.length = 0;
+    const outcome = await executeToolByName(
+      createBuiltinToolDefinitionMap(),
+      'sandbox_exec',
+      { command: 'rm -rf /workspace' },
+      { environment: fakeEnvironment, nowMilliseconds: 0, deviceId: 'desk-01' },
+      () => 'confirm-3',
+    );
+    if (outcome.status !== 'needs_confirm') {
+      throw new Error('expected sandbox_exec to require confirmation');
+    }
+
+    const result = await resolvePendingToolConfirmation(
+      createBuiltinToolDefinitionMap(),
+      outcome.pending,
+      true,
+      {
+        environment: fakeEnvironment,
+        nowMilliseconds: outcome.pending.expiresAt + 1,
+        deviceId: 'desk-01',
+      },
+    );
+
+    expect(result).toEqual({ cancelled: true });
+    expect(capturedSandboxCallList).toHaveLength(0);
+  });
+});

--- a/src/sandbox/__tests__/wiring.spec.ts
+++ b/src/sandbox/__tests__/wiring.spec.ts
@@ -4,6 +4,7 @@ import {
   createFakeApolloEnvironment,
   createInMemoryPendingConfirmationSqlExecutor,
 } from '@/configuration/testing';
+import { DEFAULT_SANDBOX_COMMAND_TIMEOUT_MILLISECONDS } from '@/sandbox/runner';
 import {
   deletePendingToolConfirmations,
   readPendingToolConfirmation,
@@ -16,6 +17,7 @@ type CapturedSandboxCall = {
   readonly sandboxId: string;
   readonly code?: string;
   readonly command?: string;
+  readonly timeoutMilliseconds?: number;
 };
 
 const capturedSandboxCallList: CapturedSandboxCall[] = [];
@@ -31,8 +33,14 @@ mock.module('@cloudflare/sandbox', () => ({
         error: undefined,
       };
     },
-    exec: async (command: string) => {
-      capturedSandboxCallList.push({ sandboxId, command });
+    exec: async (command: string, options?: { timeout?: number }) => {
+      capturedSandboxCallList.push({
+        sandboxId,
+        command,
+        ...(options?.timeout !== undefined
+          ? { timeoutMilliseconds: options.timeout }
+          : {}),
+      });
       return {
         success: true,
         exitCode: 0,
@@ -94,6 +102,39 @@ describe('sandbox end-to-end wiring', () => {
 
     await deletePendingToolConfirmations(sqlExecutor);
     expect(await readPendingToolConfirmation(sqlExecutor)).toBeUndefined();
+  });
+
+  it('executes a confirmed command with the default timeout', async () => {
+    capturedSandboxCallList.length = 0;
+    const outcome = await executeToolByName(
+      createBuiltinToolDefinitionMap(),
+      'sandbox_exec',
+      { command: 'ls /workspace' },
+      { environment: fakeEnvironment, nowMilliseconds: 0, deviceId: 'desk-01' },
+      () => 'confirm-4',
+    );
+    if (outcome.status !== 'needs_confirm') {
+      throw new Error('expected sandbox_exec to require confirmation');
+    }
+
+    const result = await resolvePendingToolConfirmation(
+      createBuiltinToolDefinitionMap(),
+      outcome.pending,
+      true,
+      { environment: fakeEnvironment, nowMilliseconds: 1000, deviceId: 'desk-01' },
+    );
+
+    if ('cancelled' in result) {
+      throw new Error('expected the confirmed command to run');
+    }
+    expect(result.ok).toBe(true);
+    expect(capturedSandboxCallList).toEqual([
+      {
+        sandboxId: 'apollo-desk-01',
+        command: 'ls /workspace',
+        timeoutMilliseconds: DEFAULT_SANDBOX_COMMAND_TIMEOUT_MILLISECONDS,
+      },
+    ]);
   });
 
   it('never reaches the container when the user declines', async () => {

--- a/src/sandbox/runner.ts
+++ b/src/sandbox/runner.ts
@@ -67,10 +67,13 @@ export async function runCodeInApolloSandbox(input: {
   };
 }
 
+export const DEFAULT_SANDBOX_COMMAND_TIMEOUT_MILLISECONDS = 30_000;
+
 export async function execCommandInApolloSandbox(input: {
   readonly environment: Env;
   readonly deviceId: string;
   readonly command: string;
+  readonly timeoutMilliseconds?: number;
 }): Promise<SandboxCommandRunResult> {
   const { getSandbox } = await import('@cloudflare/sandbox');
   const sandbox = getSandbox(
@@ -80,7 +83,7 @@ export async function execCommandInApolloSandbox(input: {
   );
   const execResult = await sandbox.exec(input.command, {
     cwd: '/workspace',
-    timeout: 30_000,
+    timeout: input.timeoutMilliseconds ?? DEFAULT_SANDBOX_COMMAND_TIMEOUT_MILLISECONDS,
   });
 
   const summary = execResult.success

--- a/src/tools/__tests__/catalog.spec.ts
+++ b/src/tools/__tests__/catalog.spec.ts
@@ -17,12 +17,25 @@ describe('builtin tool catalog', () => {
     expect(nameList).toContain('set_reminder');
     expect(nameList).toContain('list_reminders');
     expect(nameList).toContain('cancel_reminder');
+    expect(nameList).toContain('sandbox_run_code');
+    expect(nameList).toContain('sandbox_exec');
     expect(nameList).not.toContain('github_list_prs');
     expect(nameList).not.toContain('gmail_search');
     expect(nameList).not.toContain('gmail_send');
     for (const tool of listBuiltinToolDefinitionList()) {
       expect(tool.parameters).toBeDefined();
       expect(typeof tool.parameters).toBe('object');
+    }
+  });
+
+  it('marks both sandbox tools as unsafe so they require confirmation', () => {
+    const sandboxToolList = listBuiltinToolDefinitionList().filter((tool) =>
+      tool.name.startsWith('sandbox_'),
+    );
+    expect(sandboxToolList).toHaveLength(2);
+    for (const sandboxTool of sandboxToolList) {
+      expect(sandboxTool.safety).toBe('unsafe');
+      expect(sandboxTool.buildConfirmSummary).toBeDefined();
     }
   });
 });

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -7,12 +7,10 @@ import { recallMemoryTool, rememberFactTool } from '@/tools/memory';
 import { cancelReminderTool, listRemindersTool, setReminderTool } from '@/tools/reminder';
 import { buildToolDefinitionMap } from '@/tools/router';
 import { startResearchTool } from '@/tools/research';
+import { sandboxExecTool, sandboxRunCodeTool } from '@/tools/sandbox';
 import { setTimerTool, startPomodoroTool } from '@/tools/timer';
 import { translateTool } from '@/tools/translate';
 import { webSearchTool } from '@/tools/web';
-// Sandbox tools disabled: Cloudflare Containers require the Workers Paid
-// plan. Re-enable this import and the two entries below once upgraded.
-// import { sandboxExecTool, sandboxRunCodeTool } from '@/tools/sandbox';
 import type { ToolDefinition } from '@/tools/types';
 import { weatherNowTool } from '@/tools/weather';
 
@@ -37,8 +35,8 @@ export function listBuiltinToolDefinitionList(): readonly ToolDefinition[] {
     removeFromListTool,
     dollarRateTool,
     sendEmailTool,
-    // sandboxRunCodeTool,
-    // sandboxExecTool,
+    sandboxRunCodeTool,
+    sandboxExecTool,
   ];
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,26 +16,24 @@
     "OPENROUTER_EMBEDDING_MODEL": "openai/text-embedding-3-small",
     "APOLLO_OWNER_EMAIL": "galfre.vn@gmail.com",
   },
-  // "containers" disabled: requires the Workers Paid plan. Re-enable this
-  // block (and the "Sandbox" durable_objects binding below) once upgraded.
-  // "containers": [
-  //   {
-  //     "class_name": "Sandbox",
-  //     "image": "./Dockerfile",
-  //     "instance_type": "lite",
-  //     "max_instances": 1,
-  //   },
-  // ],
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 1,
+    },
+  ],
   "durable_objects": {
     "bindings": [
       {
         "name": "Apollo",
         "class_name": "Apollo",
       },
-      // {
-      //   "name": "Sandbox",
-      //   "class_name": "Sandbox",
-      // },
+      {
+        "name": "Sandbox",
+        "class_name": "Sandbox",
+      },
     ],
   },
   "migrations": [


### PR DESCRIPTION
> Stacked on #5.

Containers were commented out in `wrangler.jsonc` and the two tools commented out of the catalog, both waiting on the Workers Paid plan. This turns them back on: the `containers` block, the `Sandbox` durable object binding, and `sandbox_run_code` / `sandbox_exec` in the catalog. The `v2` migration already declared the class, so nothing was needed there.

### Types

With the binding declared, `wrangler types` emits the `Sandbox` type again — so the hand-written declaration added in #2 (when the generated file stopped being tracked) is removed here. That workaround existed only while the binding was commented out.

### Safety

Both tools stay `unsafe`, so they route through the confirmation flow hardened in #5. Worth being explicit: **`sandbox_exec` runs arbitrary shell**, and that gate is the only thing in front of it. The confirm summary is spoken aloud and answered with a tap, so whoever is at the desk approves it.

Added tests driving the real catalog, router and runner with the container stubbed at the `@cloudflare/sandbox` boundary: the confirm gate holds, and both a declined and an expired confirmation reach the container **zero** times.

### One operational change

Deploys now build the container image on every run, including `--dry-run`, so the Docker daemon has to be running. `--containers-rollout=none` ships a Worker-only change without it. Noted in the deploy doc.

I could not run this against a real container — the daemon is stopped on my machine — so everything here is verified against fakes. The Worker bundles clean at 549 KB gzipped.

`format:check`, `lint`, `typecheck`, `test` (188) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-enables Apollo’s container-backed sandbox tools and their Cloudflare Durable Object binding, keeping arbitrary code and shell execution behind the existing confirmation flow.
- Registers `sandbox_run_code` and `sandbox_exec` in the production tool catalog.
- Restores the container and `Sandbox` binding in Wrangler configuration.
- Adds wiring tests for approval, rejection, expiration, execution, and timeout behavior.
- Updates generated-type assumptions and deployment documentation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>

<sub>Reviews (9): Last reviewed commit: ["test(sandbox): cover the confirmed exec ..."](https://github.com/galfrevn/apollo/commit/d8a421f8c00bae98a8da23f7b0939a69083d974d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51870730)</sub>

<!-- /greptile_comment -->