### PR TITLE
docs: realign the handbook with the code

### DIFF
--- a/documentation/capabilities/email.md
+++ b/documentation/capabilities/email.md
@@ -1,0 +1,34 @@
+# Email
+
+Email is Apollo's way of handing you something too long to speak: a research report, a
+note you dictated, a list you want off the device.
+
+## Tool
+
+- `send_email` — `subject` and `body`; the recipient is not a parameter
+
+## Why it needs no confirmation
+
+The recipient is pinned to the `APOLLO_OWNER_EMAIL` var (`wrangler.jsonc`), so the model
+cannot address anyone else. That is what keeps the tool `safe` in router terms: the
+blast radius of a hallucinated call is one email to your own inbox. Anything that could
+reach a third party would need `safety: 'unsafe'` and the confirmation flow described in
+[Tools](tools.md).
+
+## Delivery
+
+Resend, secret `RESEND_API_KEY` (`src/notifications/email.ts`). On the free tier without
+a verified domain, Resend only delivers to the account owner's own address — which is
+exactly the constraint above, enforced twice. Missing key returns a spoken "el email no
+está configurado todavía" instead of failing the turn.
+
+## Automatic report delivery
+
+Deep research does not wait to be asked: `src/workflows/background.ts` emails the full
+markdown report to the owner as a workflow step, while the device only speaks the short
+summary. The send is best-effort — a missing key or a failed send is logged and never
+sinks research that already succeeded. See [Research](research.md).
+
+## Navigation
+
+Prev: [Dollar rates](rates.md) · Next: [Sandbox](sandbox.md)

--- a/documentation/capabilities/lists.md
+++ b/documentation/capabilities/lists.md
@@ -1,0 +1,30 @@
+# Lists
+
+Lists are durable, spoken-first collections: the grocery list, a packing list, anything
+the user wants to add to by voice and hear back later.
+
+## Tools
+
+- `add_to_list` — `item` plus an optional `listName`
+- `read_list` — optional `listName`; with no name it reads everything
+- `remove_from_list` — `item` (fuzzy content match) or `clearAll: true`
+
+Every list tool defaults to the list named `super` (`DEFAULT_LIST_NAME` in
+`src/tools/list.ts`), because the grocery list is the one people actually use by voice.
+
+## Storage
+
+Rows live in the `list_items` SQL table on the Apollo Durable Object (created in
+`onStart`, `src/agents/apollo.ts`): `id`, `list_name`, `content`, `created_at`. Helpers
+are in `src/lists/store.ts`.
+
+## Speaking a list
+
+`formatListForSpeech` renders one list as "Lista super: café, pan, leche." and groups by
+name when several lists come back at once. Read-back is a sentence, not a bulleted dump —
+the device reads it literally, so markdown would be spoken out loud (see
+[Voice](../runtime/voice.md)).
+
+## Navigation
+
+Prev: [Timers](timers.md) · Next: [Dollar rates](rates.md)

--- a/documentation/capabilities/memory.md
+++ b/documentation/capabilities/memory.md
@@ -20,9 +20,17 @@ Both layers key off the **transcript**, not the raw input: a hold-to-talk turn a
 - `remember_fact` stores something worth recalling later
 - `recall_memory` searches memory instead of guessing
 
+Vector recall is skipped entirely when `MOCK_VOICE=1`, so local runs never spend
+embedding calls; keyword recall from the SQL store still works.
+
+## Tables on the Durable Object
+
+`memories`, `session_prefs`, `pending_device_messages`, and `list_items` (see
+[Lists](lists.md)) are created in `onStart` (`src/agents/apollo.ts`).
+
 ## Preferences
 
-Small durable preferences (for example default weather location) go through the store, not the vector index.
+Small durable preferences (default weather location, speech mode) go through the store, not the vector index.
 
 ## Navigation
 

--- a/documentation/capabilities/rates.md
+++ b/documentation/capabilities/rates.md
@@ -1,0 +1,29 @@
+# Dollar rates
+
+"¿A cuánto está el blue?" is a daily question in Argentina, so it gets a dedicated client
+instead of going through web search: the answer is instant and costs no Tavily quota.
+
+## Tool
+
+- `dollar_rate` — optional `type`; with no type it speaks a summary of the main rates
+
+Supported types (`DOLLAR_RATE_TYPE_LIST` in `src/rates/dollar.ts`): `oficial`, `blue`,
+`bolsa`, `contadoconliqui`, `tarjeta`, `cripto`.
+
+## Source
+
+[dolarapi.com](https://dolarapi.com/v1/dolares) — free and keyless, so there is no secret
+to rotate. Responses are Zod-parsed (`casa`, `nombre`, `compra`, `venta`,
+`fechaActualizacion`); `compra`/`venta` are nullable because some rates quote only one
+side.
+
+## Speaking a rate
+
+`formatDollarRateForSpeech` produces "Dólar Blue a $1.480 para la venta y $1.450 para la
+compra", falling back to the sale price alone when there is no buy side. The no-argument
+summary reads only `blue`, `oficial`, and `tarjeta` (`SUMMARY_CASA_LIST` in
+`src/tools/dollar.ts`) rather than all six — six rates in a row is a wall of numbers.
+
+## Navigation
+
+Prev: [Lists](lists.md) · Next: [Email](email.md)

--- a/documentation/capabilities/reminders.md
+++ b/documentation/capabilities/reminders.md
@@ -14,4 +14,4 @@ When a reminder fires, the server sends a `reminder` protocol message (and may u
 
 ## Navigation
 
-Prev: [Focus](focus.md) · Next: [Sandbox](sandbox.md)
+Prev: [Focus](focus.md) · Next: [Timers](timers.md)

--- a/documentation/capabilities/research.md
+++ b/documentation/capabilities/research.md
@@ -8,7 +8,7 @@ Apollo distinguishes quick lookups from deep multi-source research.
 
 ## Deep research
 
-`start_research` enqueues a background workflow that makes a single call to Perplexity Sonar via OpenRouter (`src/search/deepresearch.ts`, model var `OPENROUTER_RESEARCH_MODEL`, default `perplexity/sonar-deep-research`). Sonar plans and runs its own multi-source searches and returns a cited markdown report; the workflow persists it to R2 and speaks a short summary as a `background_result`. Cost is pay-per-use (~USD 0.30–0.60 per research); if runs ever time out, `perplexity/sonar-reasoning-pro` is a faster config-only fallback.
+`start_research` enqueues a background workflow that makes a single call to Perplexity Sonar via OpenRouter (`src/search/deepresearch.ts`, model var `OPENROUTER_RESEARCH_MODEL`, default `perplexity/sonar-deep-research`). Sonar plans and runs its own multi-source searches and returns a cited markdown report; the workflow persists it to R2, emails the full report to `APOLLO_OWNER_EMAIL` (best-effort — see [Email](email.md)), and speaks a short summary as a `background_result`. Cost is pay-per-use (~USD 0.30–0.60 per research); if runs ever time out, `perplexity/sonar-reasoning-pro` is a faster config-only fallback.
 
 The old homemade pipeline (Cloudflare `WEBSEARCH` binding + fetch/extract/synthesize) was removed: the binding is `account_disabled` on the free plan.
 

--- a/documentation/capabilities/sandbox.md
+++ b/documentation/capabilities/sandbox.md
@@ -2,14 +2,26 @@
 
 Sandbox tools run untrusted or heavy code away from the agent isolate.
 
+> **Not currently active.** Cloudflare Containers require the Workers Paid plan, so the
+> container image and the `Sandbox` Durable Object binding are commented out in
+> `wrangler.jsonc`, and both tools are commented out of `src/tools/catalog.ts`. The code
+> is complete and tested — this chapter describes what re-enabling it restores.
+
 ## Tools
 
 - `sandbox_run_code` — run a code snippet in the sandbox
 - `sandbox_exec` — execute a command-style request inside the sandbox environment
 
+Both are `safety: 'unsafe'`, which makes them the only tools that trigger the
+confirmation flow — see [Tools](tools.md).
+
 ## Infrastructure
 
-Cloudflare Sandbox / Containers bindings are declared in `wrangler.jsonc` (`Sandbox` class, container image). Runner helpers live under `src/sandbox/`.
+Re-enabling means three edits: the `containers` block and the `Sandbox` durable object
+binding in `wrangler.jsonc`, and the two catalog entries. The `Sandbox` class stays
+exported from `src/index.ts` either way, because `Env['Sandbox']` in
+`worker-configuration.d.ts` needs it to resolve. Runner helpers live under
+`src/sandbox/`. Local runs need Docker.
 
 ## Product fit
 
@@ -17,4 +29,4 @@ Use the sandbox when the user needs computation or inspection that should not bl
 
 ## Navigation
 
-Prev: [Reminders](reminders.md) · Next: [Setup](../operations/setup.md)
+Prev: [Email](email.md) · Next: [Setup](../operations/setup.md)

--- a/documentation/capabilities/timers.md
+++ b/documentation/capabilities/timers.md
@@ -1,0 +1,38 @@
+# Timers
+
+Timers are countdowns you set by voice: "poné diez minutos". They are deliberately not a
+separate scheduler — a timer is a short reminder whose message announces itself, so it
+inherits delivery, focus gating, and cancellation from [Reminders](reminders.md).
+
+## Tools
+
+- `set_timer` — `durationSeconds` (5 s to 24 h) plus an optional `label`
+- `start_pomodoro` — `minutes` (5 to 120, default 25); also activates focus
+
+`cancel_reminder` cancels timers too, because they are reminder rows underneath.
+
+## Behavior
+
+`set_timer` schedules a reminder whose message is either "Timer de ⟨duración⟩ terminado."
+or "Timer terminado: ⟨label⟩." Durations are spoken back through
+`formatDurationForSpeech` (`src/tools/timer.ts`), which rounds to seconds, minutes, or
+"⟨n⟩ horas y ⟨m⟩ minutos" so the confirmation sounds natural rather than numeric.
+
+`start_pomodoro` does two things in one call: it applies focus for the requested minutes
+(so the desk quiets down — see [Focus](focus.md)) and schedules the "Pomodoro terminado.
+Tomate un descanso." announcement.
+
+## Device surface
+
+The server currently sends no timer-specific message: the device learns a timer exists
+only from the spoken confirmation, and learns it finished from the `reminder` message.
+Carrying duration/remaining on the wire so the device can draw a countdown arc is
+[Roadmap](../reference/roadmap.md) item 6.
+
+## Code
+
+`src/tools/timer.ts`, riding the scheduler in `src/reminders/logic.ts`.
+
+## Navigation
+
+Prev: [Reminders](reminders.md) · Next: [Lists](lists.md)

--- a/documentation/capabilities/tools.md
+++ b/documentation/capabilities/tools.md
@@ -20,6 +20,24 @@ Tools are how Apollo takes action beyond talking. Definitions live under `src/to
 
 The router resolves tool names to definitions, validates inputs, and coordinates confirmation when a tool is marked as needing it. Prefer extending the catalog with a new definition over special-casing in the agent class.
 
+## Confirmations
+
+A tool asks for confirmation when — and only when — its definition is `safety: 'unsafe'`
+(`src/tools/router.ts`). The router then returns `needs_confirm` instead of running the
+handler, the agent emits `confirm_request`, and the side effect waits for the device's
+`confirm` (or the 30 s expiry).
+
+**Nothing in the shipped catalog is `unsafe` today.** The only two unsafe tools are the
+disabled sandbox pair, so the confirmation path — protocol messages, UI `confirm` state,
+`questioning` face — is implemented end to end on both server and firmware but currently
+unreachable in production. Anything genuinely destructive or outward-facing added later
+should be `unsafe` with a `buildConfirmSummary`; the plumbing is already waiting.
+
+Tools that look risky but are `safe` earn it structurally rather than by review:
+`send_email` cannot choose a recipient, `set_weather_location` only persists after an
+explicit ask, and `remove_from_list` needs either an item match or an explicit
+`clearAll`.
+
 ## Product fit
 
 On a desk device, tools should be obvious in speech (“reminder set for six”) and safe when destructive or sticky (confirmations, explicit location saves).

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -27,16 +27,25 @@ This handbook is meant to be read in order. Later chapters assume the concepts i
 11. [Weather](capabilities/weather.md) — Location, forecast, dashboard
 12. [Focus](capabilities/focus.md) — Focus timer behavior
 13. [Reminders](capabilities/reminders.md) — Schedules and delivery
-14. [Sandbox](capabilities/sandbox.md) — Isolated code execution
+14. [Timers](capabilities/timers.md) — Countdowns and pomodoros
+15. [Lists](capabilities/lists.md) — Durable spoken lists
+16. [Dollar rates](capabilities/rates.md) — Argentine dollar quotes
+17. [Email](capabilities/email.md) — Reports and notes to the owner
+18. [Sandbox](capabilities/sandbox.md) — Isolated code execution (currently disabled)
 
 ### Part IV — Operations
 
-15. [Setup](operations/setup.md) — Local development
-16. [Deploy](operations/deploy.md) — Workers, bindings, and containers
-17. [Auth](operations/auth.md) — Device shared secret
-18. [Testing](operations/testing.md) — How this repo verifies behavior
+19. [Setup](operations/setup.md) — Local development
+20. [Deploy](operations/deploy.md) — Workers, bindings, secrets, and vars
+21. [Auth](operations/auth.md) — Device shared secret
+22. [Testing](operations/testing.md) — How this repo verifies behavior
 
 ### Part V — Reference
 
-19. [Mapping](reference/mapping.md) — Handbook topics to `src/` folders
-20. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
+23. [Mapping](reference/mapping.md) — Handbook topics to `src/` folders
+24. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
+
+## The firmware
+
+The device side lives in `firmware/apollo-firmware`, a git submodule with its own
+handbook. The contract between the two repos is [Protocol](runtime/protocol.md).

--- a/documentation/introduction/concepts.md
+++ b/documentation/introduction/concepts.md
@@ -20,7 +20,7 @@ Session state lives with the Apollo Durable Object: conversation memory, prefere
 
 ## Tools
 
-Tools are typed actions the model can request (weather, remember fact, start research, and so on). Some require explicit user confirmation before side effects run.
+Tools are typed actions the model can request (weather, remember fact, start research, and so on). A tool marked `unsafe` requires explicit user confirmation before its side effect runs — the machinery is in place, though no tool in the current catalog uses it (see [Tools](../capabilities/tools.md#confirmations)).
 
 ## Background work
 

--- a/documentation/introduction/purpose.md
+++ b/documentation/introduction/purpose.md
@@ -13,7 +13,7 @@ Apollo is a personal desk agent designed for an ESP32 device on your desk. The d
 
 - A general chat web app or dashboard product
 - A metrics / DORA analytics system
-- A full ESP32 firmware repository (this handbook covers the Workers side and the wire protocol the device speaks)
+- The firmware itself — that lives in `firmware/apollo-firmware`, a git submodule with its own handbook. This one covers the Workers side and the wire protocol the device speaks.
 
 ## Why ESP32
 

--- a/documentation/operations/deploy.md
+++ b/documentation/operations/deploy.md
@@ -2,19 +2,42 @@
 
 Apollo deploys as a Cloudflare Worker named `apollo` with several bindings.
 
-## Notable bindings
+## Bindings
 
 | Binding | Purpose |
 |---------|---------|
 | `Apollo` Durable Object | Per-desk agent session (SQLite) |
-| `Sandbox` | Sandbox container DO |
-| `MEDIA` R2 | Media objects |
-| `VECTORIZE` | Memory embeddings index |
-| `TAVILY_API_KEY` | Secret — Tavily search API (quick `web_search`) |
-| `APOLLO_QUEUE` | Background job queue |
-| Workflows | `apollo-background` long-running work |
+| `MEDIA` R2 | Media objects, TTS cache, research reports |
+| `VECTORIZE` | Memory embeddings index (`apollo-memory`) |
+| `APOLLO_QUEUE` | Background job queue (`apollo-jobs`) |
+| `BACKGROUND` | Workflow binding for `apollo-background` |
+| `Sandbox` | **Commented out** — Containers need the Workers Paid plan (see [Sandbox](../capabilities/sandbox.md)) |
 
-See `wrangler.jsonc` for the authoritative list, migrations, and model vars.
+## Secrets
+
+None of these live in `wrangler.jsonc`; set each with `bunx wrangler secret put <NAME>`
+(and mirror them in `.dev.vars` locally):
+
+| Secret | Used by |
+|--------|---------|
+| `DEVICE_SHARED_SECRET` | Device auth ([Auth](auth.md)) |
+| `OPENROUTER_API_KEY` | STT, reasoning, embeddings, deep research |
+| `ELEVENLABS_API_KEY` | TTS |
+| `TAVILY_API_KEY` | Quick `web_search` |
+| `RESEND_API_KEY` | `send_email` and research report delivery |
+
+## Vars
+
+Plain vars in `wrangler.jsonc`: `OPENROUTER_MODEL`, `OPENROUTER_STT_MODEL`,
+`OPENROUTER_RESEARCH_MODEL`, `OPENROUTER_EMBEDDING_MODEL`, `ELEVENLABS_TTS_MODEL`, and
+`APOLLO_OWNER_EMAIL` (the pinned recipient for [Email](../capabilities/email.md)).
+
+Changing a var means editing `wrangler.jsonc` and redeploying. `wrangler types` turns each
+var into a *literal* type, so `createFakeApolloEnvironment`
+(`src/configuration/testing.ts`) has to repeat the exact same string — a var change that
+skips it fails typecheck, not tests.
+
+See `wrangler.jsonc` for the authoritative list and the migration tags.
 
 ## Deploy command
 

--- a/documentation/operations/setup.md
+++ b/documentation/operations/setup.md
@@ -15,7 +15,9 @@ bun install
 cp .dev.vars.example .dev.vars
 ```
 
-Fill `.dev.vars` with at least `DEVICE_SHARED_SECRET` and `OPENROUTER_API_KEY` (leave `MOCK_VOICE=1` to skip real STT/TTS locally).
+Fill `.dev.vars` with at least `DEVICE_SHARED_SECRET` and `OPENROUTER_API_KEY`, and leave `MOCK_VOICE=1` — it skips real STT/TTS *and* vector recall locally, so a dev session costs nothing in ElevenLabs credits or embedding calls.
+
+`ELEVENLABS_API_KEY` is the one key with no graceful fallback: with `MOCK_VOICE` off and no key, ElevenLabs answers 401, `synthesizeSpeechWithElevenLabs` throws, and the turn fails with "no pude procesar ese pedido". The other two degrade to something the agent can say — `TAVILY_API_KEY` (`web_search`) returns a tool error, `RESEND_API_KEY` (`send_email`) returns "el email no está configurado todavía". Full list with prod instructions in [Deploy](deploy.md).
 
 ## Run locally
 
@@ -36,7 +38,9 @@ From `package.json`:
 | `bun run typecheck` | TypeScript `--noEmit` |
 | `bun run lint` | Oxlint with deny-warnings |
 | `bun run format` | Oxfmt write |
+| `bun run format:check` | Oxfmt check without writing |
 | `bun test` | Unit/integration tests |
+| `bun run test:coverage` | Tests with coverage |
 | `bun run types` | Regenerate Wrangler types |
 
 ## Configuration

--- a/documentation/reference/mapping.md
+++ b/documentation/reference/mapping.md
@@ -28,6 +28,7 @@ Thin map from handbook topics to code folders. Prefer the narrative chapters for
 | Media | `src/media/` |
 | Session UI machine | `src/session/` |
 | Config / env types | `src/configuration/`, `wrangler.jsonc` |
+| Firmware (separate repo) | `firmware/apollo-firmware` (git submodule, own handbook) |
 
 ## Navigation
 

--- a/documentation/reference/roadmap.md
+++ b/documentation/reference/roadmap.md
@@ -11,18 +11,16 @@ The server already tracks `focus` state and sends `focusRemainingSec` on every `
 - **Firmware**: render the remaining time. Candidates are a progress arc over the accent ring, or the center label of the emote engine. Parse `focusRemainingSec` in `HandleUiState` (`apollo_protocol.cc`).
 - **Server**: done — only the refresh cadence of the field needs verifying.
 
-### 2. Complete background result: spoken notice + document QR
+### 2. Complete background result: document QR
 
-Today `background_result` arrives as a generic alert carrying the summary. Missing:
-
-- **Spoken notice**: the agent should say "terminé \<task\>" when a background job completes (server: `src/workflows/background.ts` → TTS over the notification channel, respecting device state so it never interrupts a turn).
-- **QR on screen**: when a `documentKey` is present, show a QR with the document URL. The gfx engine already has a QR widget (`emote_set_qrcode_data` in `emote_op.c`), so the firmware only needs to route a new message (say `"type": "qr"`) through to that widget, with an auto-close timeout.
+- **Spoken notice**: ✅ done. `deliverDeskDeviceNotification` (`src/agents/notify.ts`) synthesizes and paces TTS for both `background_result` and `reminder`, queues them as pending messages when nobody is connected, and stays quiet during focus. What is left is cosmetic: the announcement speaks the summary directly rather than framing it ("terminé \<task\>: …").
+- **QR on screen**: when a `documentKey` is present, show a QR with the document URL. The gfx engine already has a QR widget (`emote_set_qrcode_data` in `emote_op.c`), so the firmware only needs to route a new message (say `"type": "qr"`) through to that widget, with an auto-close timeout. The reports are already emailed in parallel, so the QR is a convenience, not the only way to reach one.
 
 ### 3. Device → server telemetry + agent reactions
 
 The protocol has no device → server status message at all. The board already measures battery (`adc_battery_estimation`, and a local `low_battery.ogg` exists).
 
-- **Firmware**: a periodic `{"type":"telemetry", battery, charging, volume, ...}` message, plus an immediate push on sharp changes. Include **mute state** as well — the double tap is silent and invisible to the server today, which has already caused one bug — along with WiFi signal and firmware version.
+- **Firmware**: a periodic `{"type":"telemetry", battery, charging, volume, ...}` message, plus an immediate push on sharp changes, along with WiFi signal and firmware version. (Mute state is no longer part of this: the silent double-tap mute that caused the original bug was removed on both sides — with push-to-talk the mic is only open while a finger is down, so there is nothing to mute.)
 - **Server**: keep the latest snapshot in agent state; expose it to the agent in the turn's system prompt; proactive reactions ("estás con 15% de batería, enchufame") over the notification channel.
 - **Schema**: add the message to `deviceToServerMessageSchema` in `src/protocol/schema.ts`.
 
@@ -75,14 +73,15 @@ The idle face should not always be neutral: subtle variation by time of day and 
 
 Guiding principle: the firmware only gains **vocabulary** — new protocol events and commands — while the semantics always live in the server, which deploys in seconds.
 
-Suggested first round: 11 + 12, plus the telemetry from item 3. All three fit in a single flash and each one unblocks immediate server-side features. Second round: 14 (OTA), so that becomes the last flash over cable.
+Suggested first round: 12, plus the telemetry from item 3. Both fit in a single flash and each one unblocks immediate server-side features. Second round: 14 (OTA), so that becomes the last flash over cable.
 
-### 11. Gestures as raw events
+### 11. Gestures as raw events — ✅ already shipped
 
-The firmware sends `{"type":"gesture", "name":"tap"|"long_press"|...}` and the server decides what each one means. First mappings: single tap cuts off speech (touch barge-in, with no AEC involved), long press starts a pomodoro or a briefing. Changing the mapping becomes a worker deploy rather than a flash.
+The pattern landed: the firmware emits `{"type":"gesture","gesture":"tap"|"double_tap"|"swipe_left"|"swipe_right","ts":…}` from the touch driver with no local semantics, and the server decides what each one means in `#handleGesture` (`src/agents/apollo.ts`) — tap toggles the dashboard, swipes cycle the speech mode. Remapping is a worker deploy, not a flash.
 
-- **Firmware**: emit the events from the touch driver (`esp_lcd_touch_cst9217`) with no local semantics. The mute double tap can stay local or migrate.
-- **Server**: `deviceToServerMessageSchema` plus a gesture → action map in the agent.
+Touch barge-in shipped alongside it, through a dedicated `abort` message rather than a gesture: a tap while Apollo is speaking stops the stream within a chunk and the server answers `tts_aborted`.
+
+Still open: `long_press` is not in the gesture enum, so "hold to start a pomodoro or a briefing" needs one enum entry on each side.
 
 ### 12. Server-triggered earcons (`play_effect`)
 
@@ -109,8 +108,8 @@ Beyond face + caption: a circular timer countdown (which merges with item 6), we
 
 ## Under consideration (ideas, no commitment)
 
-- **Clock + weather dashboard on tap**: the server already assembles and sends the full payload; the firmware discards it ("dashboard has no UI yet"). Tapping while idle shows nothing today. If item 16 lands, this becomes just another card.
-- **Voice barge-in**: interrupting the assistant by talking over it. Untested; the raw mic path has no AEC (see the wake word notes). The tap from item 11 is the touch shortcut in the meantime.
+- **Clock + weather dashboard on tap**: the server half is done — a tap while idle enters `dashboard` state and pushes the payload, then refreshes it every 30 minutes for as long as that state holds. The firmware still discards it ("dashboard has no UI yet"), so tapping shows nothing. If item 16 lands, this becomes just another card.
+- **Voice barge-in**: interrupting the assistant by *talking* over it. Untested; the raw mic path has no AEC (see the wake word notes). Touch barge-in already works (item 11), so this is only about the hands-free case.
 - **Morning briefing**: weather plus the day's reminders by voice at a fixed hour, orchestrated on top of the existing reminder cron.
 - **Night mode**: minimum brightness, quieter effects, and silenced notifications within an hour range — a natural fit on top of MCP + telemetry.
 - **Web session console**: a page served by the worker with transcripts, tool calls, and errors, for debugging without serial.
@@ -118,7 +117,7 @@ Beyond face + caption: a circular timer countdown (which merges with item 6), we
 
 ## Context notes
 
-The per-mode accent color ring, the pitch variants for effects, and the PCM/Opus decode fix all landed on 2026-08-08 — see the firmware and server git logs for that day.
+The per-mode accent color ring, the pitch variants for effects, and the PCM/Opus decode fix all landed on 2026-08-08 — see the firmware and server git logs for that day. Timers, lists, dollar rates, email, and the streaming/speculative TTS path landed on 2026-08-10 (`444f324`); each now has its own chapter in Part III.
 
 ## Navigation
 

--- a/documentation/runtime/face.md
+++ b/documentation/runtime/face.md
@@ -31,11 +31,19 @@ Blinking and saccades stay autonomous on-device. The server never sends blink ev
 
 ## Talking / mouth sync
 
-There is no amplitude or viseme channel on the wire. TTS audio ships to the device as a single buffer (`tts_start` + binary payload — see [Voice](voice.md)); firmware should derive any mouth/talk animation from the decoded audio it's already playing, not from a server-computed signal.
+There is no amplitude or viseme channel on the wire. A reply ships as a *sequence* of
+clips — one `tts_start` plus its binary payload per speech segment (see
+[Voice](voice.md)) — so the device cannot treat `tts_start` as "the reply begins" either.
+Firmware should derive any mouth/talk animation from the audio it is already playing, not
+from a server-computed signal.
 
-## Firmware recommendation (not part of this repo)
+## Where rendering lives
 
-Rendering is a device-side concern; no firmware lives in this repository. For the two-eyes-blinking look, [FluxGarage RoboEyes](https://github.com/FluxGarage/RoboEyes) (MIT) draws eyes procedurally — no image assets, built-in blink/saccade timing, and an emotion set that maps cleanly onto the table above. [M5Stack-Avatar](https://github.com/meganetaaan/m5stack-avatar) is a heavier alternative that adds a breathing/talking mouth driven by audio amplitude, if a face-only look ever needs more life.
+Rendering is a device-side concern, implemented in the firmware repo
+(`firmware/apollo-firmware`, a git submodule of this one), which has its own handbook and
+its own emote engine. This chapter defines only what the server promises to send. The
+division to preserve: the server may add emotions to the vocabulary, the firmware decides
+what they look like.
 
 ## Navigation
 

--- a/documentation/runtime/loop.md
+++ b/documentation/runtime/loop.md
@@ -21,11 +21,22 @@ Primary wiring lives in `src/index.ts` and `src/agents/apollo.ts`.
 
 ## Confirmations
 
-When a tool needs confirmation, the server emits `confirm_request` and waits for a device `confirm` message before applying the side effect.
+When a tool needs confirmation, the server emits `confirm_request` and waits for a device `confirm` message before applying the side effect. A confirmation expires after 30 seconds.
+
+No tool in the shipped catalog currently requires this — see [Tools](../capabilities/tools.md#confirmations).
+
+## Interruption
+
+A device `abort` cuts the reply short: the pacing loop checks the flag between chunks and stops, then the server sends `tts_aborted`. See [Voice](voice.md#interruption).
 
 ## Dashboard refresh
 
-While idle/dashboard, Apollo can push periodic dashboard payloads (clock + weather) so the desk stays useful without a conversation.
+Apollo pushes a dashboard payload (clock + weather) on connect, on the tap that opens the dashboard, and then every 30 minutes — but the periodic refresh only fires while the UI is actually in `dashboard` state and someone is connected (`shouldPushDashboardOnWeatherRefresh` in `src/agents/dashboard.ts`). Idle receives no periodic push.
+
+## Guardrails
+
+- A turn needs at least 8000 bytes of audio (a quarter second at 16 kHz); below that the server answers "no llegué a escucharte" instead of sending an empty clip to the transcriber
+- A turn runs at most 3 tool rounds (`src/turn/run.ts`) before it has to answer with what it has
 
 ## Navigation
 

--- a/documentation/runtime/protocol.md
+++ b/documentation/runtime/protocol.md
@@ -13,6 +13,12 @@ Device and server speak a Zod-validated JSON protocol defined in `src/protocol/s
 | `gesture` | `tap`, `double_tap`, `swipe_left`, `swipe_right` |
 | `confirm` | Accept or reject a pending confirmation |
 | `text_input` | Typed fallback input |
+| `abort` | Stop the speech currently streaming (barge-in) |
+
+Gesture meaning lives on the server, not the device: `tap` toggles the dashboard,
+`swipe_left` / `swipe_right` cycle the speech mode, and `double_tap` is deliberately a
+no-op (it used to mute the microphone and did so invisibly — see `#handleGesture` in
+`src/agents/apollo.ts`).
 
 ## Server → device
 
@@ -20,18 +26,39 @@ Device and server speak a Zod-validated JSON protocol defined in `src/protocol/s
 |------|------|
 | `ui_state` | Mode, speech mode, caption, focus remaining, face emotion, accent color |
 | `confirm_request` | Ask the user to approve a tool side effect |
-| `tts_start` | Announce upcoming speech audio |
+| `tts_start` | Announce the next speech clip (one per segment, not one per reply) |
+| `tts_aborted` | The clip announced by `tts_start` was cut short and will never complete |
 | `error` | Structured failure |
 | `dashboard` | Clock + weather snapshot |
 | `background_result` | Completed async work summary |
 | `reminder` | Reminder delivery |
+
+`tts_start` carries `format` (always `pcm` in production), `bytes` for the clip that
+follows, and optional `sampleRate` / `channels` — 24 000 Hz mono, so the ESP32 needs no
+decoder. The binary frames that follow belong to the clip just announced.
 
 ## Design notes
 
 - Discriminated unions keep parsing strict on both sides
 - Optional fields stay optional — the device should tolerate missing captions, focus seconds, emotion, or accent color
 - `ui_state.emotion` and `ui_state.accentColor` tell the device what to render on the face; see [Face](face.md) for the full mapping
-- Firmware details beyond this wire contract are out of scope for this handbook
+- Every device message carries `ts`; `hello` also carries `deviceId`
+
+## Interruption
+
+`abort` and `tts_aborted` are the two halves of barge-in:
+
+1. The device sends `abort` (today: a tap while Apollo is speaking)
+2. The server sets a flag; the paced TTS loop checks it between chunks and stops sending
+3. The server sends `tts_aborted`
+
+Step 3 matters because `tts_start` promises a byte count and the device counts against it
+to know when a clip ends. After an abort that total never arrives, so without
+`tts_aborted` the device would wait forever for speech that was cancelled. See
+[Voice](voice.md#interruption).
+
+The device-side implementation lives in the firmware repo (`firmware/apollo-firmware`,
+a submodule); this chapter is the authoritative wire contract for both sides.
 
 ## Navigation
 

--- a/documentation/runtime/voice.md
+++ b/documentation/runtime/voice.md
@@ -26,6 +26,18 @@ Quota math (Starter ≈ 30k credits/mo): `eleven_multilingual_v2` burns ~1 credi
 
 Implementation details sit under `src/voice/`.
 
+## Interruption
+
+Speech is cancellable mid-reply. The device sends `abort`; the agent sets a flag that the
+paced loop checks between chunks (`shouldStop` in `src/voice/stream.ts`), so sending stops
+within one chunk instead of at the end of the clip. The server then sends `tts_aborted`,
+because `tts_start` promised a byte count the device is counting against — without it the
+device waits forever for audio that was cancelled.
+
+Two consequences worth knowing: an abort ends the *whole* reply, not just the current
+segment (remaining segments are never synthesized, which also saves the credits), and a
+new turn always clears the flag, so an abort can never leak into the next reply.
+
 ## Captions
 
 The server can attach a caption to `ui_state` so the ESP32 can show what is being said even when audio is hard to hear.


### PR DESCRIPTION
A full pass over `documentation/` against `src/`. The handbook was mostly accurate — tool names, speech modes, the emotion map, the voice pipeline numbers (280-char segments, 4 s backlog cap, `tts-cache/` SHA-256 keys), and the auth flow all matched. These are the places it had drifted.

## Contradicted by the code

| Chapter | Was | Now |
|---|---|---|
| `runtime/protocol.md` | Tables omitted `abort` and `tts_aborted` | Both documented, plus an Interruption section explaining why `tts_aborted` is required (the device counts bytes against `tts_start`'s promise) |
| `runtime/face.md` | "TTS audio ships to the device as a single buffer" | One `tts_start` per **segment** — `runtime.ts` loops |
| `runtime/face.md`, `introduction/purpose.md` | "no firmware lives in this repository", plus a suggestion to adopt RoboEyes | `firmware/apollo-firmware` is a submodule with its own handbook and emote engine |
| `capabilities/sandbox.md` | Described the bindings as declared | They're commented out in `wrangler.jsonc` and the tools are commented out of the catalog; the chapter now says so up front and lists what re-enabling takes |
| `operations/deploy.md` | Listed `Sandbox` as bound; named one secret | Split into bindings / secrets / vars; all five secrets named |
| `runtime/loop.md` | "While idle/dashboard, Apollo can push periodic dashboard payloads" | The periodic push only fires in `dashboard` state (`shouldPushDashboardOnWeatherRefresh`) |
| `capabilities/tools.md`, `introduction/concepts.md` | Confirmations described as a live path | They fire only for `safety: 'unsafe'`, and the only two unsafe tools are the disabled sandbox pair — so the path is currently unreachable in production, even though both server and firmware implement it |

## Shipped code that had no chapter

`444f324` added timers, lists, dollar rates, and email without docs. Four new chapters, renumbering Part III to 8–18:

- **Timers** — `set_timer` / `start_pomodoro` riding the reminder scheduler
- **Lists** — the `list_items` table and the `super` default
- **Dollar rates** — dolarapi.com, the six types, the three-rate spoken summary
- **Email** — why it's `safe` (recipient pinned to `APOLLO_OWNER_EMAIL`, enforced again by Resend's free tier)

Also added: barge-in in `voice.md`, the turn guardrails (8000-byte minimum, 3 tool rounds, 30 s confirm expiry, 30 min dashboard refresh) in `loop.md`, automatic report emailing in `research.md`, and the `MOCK_VOICE` vector-recall skip in `memory.md`.

## Roadmap re-baselined to 2026-08-10

- **Item 12 (gestures as raw events)** — already shipped end to end; only `long_press` is missing from the enum. Touch barge-in shipped too, via `abort`.
- **Item 2 (spoken notice)** — done in `notify.ts`; only the "terminé ⟨task⟩" phrasing remains.
- **Item 3** — dropped the mute-state rationale; the silent double-tap mute was removed on both sides.
- **Dashboard on tap** — server half exists; only the firmware UI is missing.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The handbook is realigned with current server and firmware behavior, including newly documented capabilities and corrected runtime, deployment, and roadmap details.
- Documents timers, lists, dollar rates, and email
- Corrects protocol, TTS segmentation, interruption, dashboard, confirmation, sandbox, and firmware descriptions
- Updates setup guidance to accurately warn that real TTS without an ElevenLabs key fails the turn

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains; the revised setup guidance accurately describes the previously reported missing-TTS-key failure.
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: realign the handbook with the code"](https://github.com/galfrevn/apollo/commit/5fa0223d0a64d372f08a8cbe4fbe1edfb7af51da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51881078)</sub>

<!-- /greptile_comment -->