### PR TITLE
feat(protocol): server-triggered earcons, device telemetry, and semantic audio_end

### DIFF
--- a/documentation/reference/roadmap.md
+++ b/documentation/reference/roadmap.md
@@ -16,17 +16,13 @@ The server already tracks `focus` state and sends `focusRemainingSec` on every `
 - **Spoken notice**: ✅ done. `deliverDeskDeviceNotification` (`src/agents/notify.ts`) synthesizes and paces TTS for both `background_result` and `reminder`, queues them as pending messages when nobody is connected, and stays quiet during focus. What is left is cosmetic: the announcement speaks the summary directly rather than framing it ("terminé \<task\>: …").
 - **QR on screen**: when a `documentKey` is present, show a QR with the document URL. The gfx engine already has a QR widget (`emote_set_qrcode_data` in `emote_op.c`), so the firmware only needs to route a new message (say `"type": "qr"`) through to that widget, with an auto-close timeout. The reports are already emailed in parallel, so the QR is a convenience, not the only way to reach one.
 
-### 3. Device → server telemetry + agent reactions
+### 3. Device → server telemetry + agent reactions — ✅ shipped 2026-08-10
 
-The protocol has no device → server status message at all. The board already measures battery (`adc_battery_estimation`, and a local `low_battery.ogg` exists).
+`{"type":"telemetry", battery, charging, volume, wifiRssi, firmwareVersion, ts}` goes out on channel open, every 60 s, and immediately on a charging edge. The server keeps the snapshot in memory, stamps it into the system prompt while fresh, and announces low battery (≤15%, 30 min cooldown, hysteresis at 25%) piercing focus as `critical`. Battery sensing required wiring `AdcBatteryMonitor` into the 1.85C board — the schematic puts BAT_ADC on GPIO8 through a 200K/100K divider; there is no charge-status GPIO, so charging is the estimation library's voltage-trend guess. See `src/telemetry/logic.ts` and `Application::MaybeSendTelemetry`.
 
-- **Firmware**: a periodic `{"type":"telemetry", battery, charging, volume, ...}` message, plus an immediate push on sharp changes, along with WiFi signal and firmware version. (Mute state is no longer part of this: the silent double-tap mute that caused the original bug was removed on both sides — with push-to-talk the mic is only open while a finger is down, so there is nothing to mute.)
-- **Server**: keep the latest snapshot in agent state; expose it to the agent in the turn's system prompt; proactive reactions ("estás con 15% de batería, enchufame") over the notification channel.
-- **Schema**: add the message to `deviceToServerMessageSchema` in `src/protocol/schema.ts`.
+### 4. Semantic `audio_end` — ✅ shipped 2026-08-10
 
-### 4. Semantic `audio_end`
-
-The schema already distinguishes `hold_end` (finger released) from `audio_end` (VAD-detected end after a wake word), but the firmware always sends `hold_end` (`SendStopListening` in `apollo_protocol.cc`). Small change: remember which mode started the listen and send the matching event. It gives the server the signal it needs to adapt behavior, such as using different timeouts.
+The firmware now remembers which mode started the listen (`listen_started_by_hold_` in `apollo_protocol.cc`) and ends it with the matching event: `hold_end` for push-to-talk, `audio_end` for wake-word turns. The server dispatches them as separate cases (identical behavior today) so timeouts or continuity can diverge without a flash.
 
 ### 5. Device-side MCP: the agent with hands on the hardware
 
@@ -83,9 +79,9 @@ Touch barge-in shipped alongside it, through a dedicated `abort` message rather 
 
 Still open: `long_press` is not in the gesture enum, so "hold to start a pomodoro or a briefing" needs one enum entry on each side.
 
-### 12. Server-triggered earcons (`play_effect`)
+### 12. Server-triggered earcons (`play_effect`) — ✅ shipped 2026-08-10
 
-A `{"type":"play_effect", "name":"ding"|...}` message that plays effects already burned into flash — the ogg/opus pipeline with pitch variants already exists. Instant, free feedback: the timer sounds immediately while the announcement's TTS is still being synthesized, a confirmation chime, an error tone without spending ElevenLabs credits.
+`{"type":"play_effect", "name":"ding"|"chime"|"error"|"low_battery"}` plays effects already burned into flash. The names are logical — the firmware maps them to assets (`ding`→success, `chime`→popup, `error`→exclamation) so the server can re-purpose sounds without a flash. Wired at three sites: reminder/timer delivery (the ding lands while the TTS is still synthesizing), confirm requests, and turn failures, plus the low-battery announcement from item 3.
 
 ### 13. `set_volume` from the server
 

--- a/documentation/runtime/protocol.md
+++ b/documentation/runtime/protocol.md
@@ -9,11 +9,24 @@ Device and server speak a Zod-validated JSON protocol defined in `src/protocol/s
 | `hello` | Identify the device after connect |
 | `hold_start` / `hold_end` | Push-to-talk boundaries |
 | `wake` | Wake without a full hold gesture |
-| `audio_end` | End of an utterance |
+| `audio_end` | End of a wake-word utterance (VAD-detected) |
 | `gesture` | `tap`, `double_tap`, `swipe_left`, `swipe_right` |
 | `confirm` | Accept or reject a pending confirmation |
 | `text_input` | Typed fallback input |
 | `abort` | Stop the speech currently streaming (barge-in) |
+| `telemetry` | Battery, charging, volume, WiFi RSSI, firmware version |
+
+A listen session ends with the event matching how it started: `hold_end` when a finger
+lifts, `audio_end` when a wake-word turn hits its VAD timeout. Both run the turn today;
+the split exists so the server can diverge (timeouts, continuity) without a flash.
+
+`telemetry` goes out right after the channel opens, then every 60 seconds, and
+immediately on a charging edge. Every payload field is optional — the device omits what
+its hardware cannot measure (on the 1.85C the charging bit is a voltage-trend estimate;
+there is no charge-status GPIO). The server keeps the latest snapshot in memory, stamps
+it into the system prompt while fresh (5 minutes), and announces low battery (≤15%,
+30-minute cooldown, re-armed by charging or recovery to 25%) — that announcement pierces
+focus mode as `critical`.
 
 Gesture meaning lives on the server, not the device: `tap` toggles the dashboard,
 `swipe_left` / `swipe_right` cycle the speech mode, and `double_tap` is deliberately a
@@ -32,6 +45,13 @@ no-op (it used to mute the microphone and did so invisibly — see `#handleGestu
 | `dashboard` | Clock + weather snapshot |
 | `background_result` | Completed async work summary |
 | `reminder` | Reminder delivery |
+| `play_effect` | Play a sound effect already burned into device flash |
+
+`play_effect` carries a logical `name` — `ding` (timer/reminder landing), `chime`
+(confirmation request), `error` (turn failure), `low_battery` — and the firmware maps
+names to flash assets, so the server can re-purpose sounds without a flash. Unknown
+names are logged and ignored. The point is latency: the earcon plays instantly while the
+TTS announcement is still being synthesized, and it costs no ElevenLabs credits.
 
 `tts_start` carries `format` (always `pcm` in production), `bytes` for the clip that
 follows, and optional `sampleRate` / `channels` — 24 000 Hz mono, so the ESP32 needs no

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -595,11 +595,6 @@ export class Apollo extends Agent<Env, ApolloState> {
     if (!evaluation.shouldAnnounce || evaluation.message === undefined) {
       return;
     }
-    await setSessionPreference(
-      this.#sqlExecutor(),
-      LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
-      String(Date.now()),
-    );
     this.#broadcastPlayEffect('low_battery');
     await deliverDeskDeviceNotification({
       notification: { type: 'reminder', message: evaluation.message },
@@ -612,6 +607,14 @@ export class Apollo extends Agent<Env, ApolloState> {
       isMockVoice: this.env.MOCK_VOICE === '1',
       announceKind: 'critical',
     });
+    // The cooldown starts only after the announcement actually went out: a
+    // failed delivery retries on the next telemetry instead of going silent
+    // for half an hour.
+    await setSessionPreference(
+      this.#sqlExecutor(),
+      LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
+      String(Date.now()),
+    );
   }
 
   #broadcastPlayEffect(effectName: DeskSoundEffectName): void {

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -40,6 +40,7 @@ import { APOLLO_TTS_VOICE } from '@/persona/soul';
 import {
   encodeServerToDeviceMessage,
   parseDeviceToServerMessage,
+  type DeskSoundEffectName,
   type DeviceToServerMessage,
 } from '@/protocol/schema';
 import {
@@ -48,6 +49,10 @@ import {
   type AgentScheduleLike,
 } from '@/reminders/logic';
 import { createDeskUiMachine, type DeskUiMachine } from '@/session/machine';
+import {
+  evaluateLowBatteryAnnouncement,
+  type DeskTelemetrySnapshot,
+} from '@/telemetry/logic';
 import {
   deletePendingToolConfirmations,
   isPendingConfirmationOrphaned,
@@ -65,6 +70,8 @@ import {
 // A quarter second of 16 kHz mono 16-bit PCM. Below this there is no word to
 // transcribe, only the tail of a press that ended too early.
 const MINIMUM_TURN_AUDIO_BYTE_LENGTH = 8000;
+
+const LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY = 'lowBatteryLastAnnounceAt';
 
 function mapUnknownScheduleListToAgentScheduleLikeList(
   scheduleList: readonly {
@@ -123,6 +130,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #isSpeechAborted = false;
   #session: Session | undefined;
   #lastKnownWeatherSnapshot: DeskWeatherSnapshot | undefined;
+  #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
 
   get session(): Session {
     if (this.#session === undefined) {
@@ -273,7 +281,10 @@ export class Apollo extends Agent<Env, ApolloState> {
         this.#pushUiState(connection);
         break;
       }
-      case 'hold_end':
+      case 'hold_end': {
+        await this.#runTurnFromAudio(connection);
+        break;
+      }
       case 'audio_end': {
         await this.#runTurnFromAudio(connection);
         break;
@@ -294,6 +305,10 @@ export class Apollo extends Agent<Env, ApolloState> {
       }
       case 'gesture': {
         await this.#handleGesture(connection, deviceMessage.gesture);
+        break;
+      }
+      case 'telemetry': {
+        await this.#handleTelemetry(deviceMessage);
         break;
       }
     }
@@ -365,6 +380,9 @@ export class Apollo extends Agent<Env, ApolloState> {
 
   async deliverReminder(payload: unknown): Promise<void> {
     const parsedPayload = deliverReminderPayloadSchema.parse(payload);
+    // The earcon goes out before the notification so it lands while the TTS
+    // announcement is still being synthesized.
+    this.#broadcastPlayEffect('ding');
     await deliverDeskDeviceNotification({
       notification: { type: 'reminder', message: parsedPayload.message },
       connectionList: [...this.getConnections()],
@@ -535,6 +553,77 @@ export class Apollo extends Agent<Env, ApolloState> {
     this.#pushUiState(connection);
   }
 
+  async #handleTelemetry(
+    deviceMessage: Extract<DeviceToServerMessage, { type: 'telemetry' }>,
+  ): Promise<void> {
+    const snapshot: DeskTelemetrySnapshot = {
+      ...(deviceMessage.battery !== undefined ? { battery: deviceMessage.battery } : {}),
+      ...(deviceMessage.charging !== undefined
+        ? { charging: deviceMessage.charging }
+        : {}),
+      ...(deviceMessage.volume !== undefined ? { volume: deviceMessage.volume } : {}),
+      ...(deviceMessage.wifiRssi !== undefined
+        ? { wifiRssi: deviceMessage.wifiRssi }
+        : {}),
+      ...(deviceMessage.firmwareVersion !== undefined
+        ? { firmwareVersion: deviceMessage.firmwareVersion }
+        : {}),
+      receivedAtMs: Date.now(),
+    };
+    this.#lastTelemetrySnapshot = snapshot;
+
+    const storedAnnounceAt = await getSessionPreference(
+      this.#sqlExecutor(),
+      LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
+    );
+    const parsedAnnounceAt = Number(storedAnnounceAt);
+    const lastAnnounceAtMilliseconds =
+      Number.isFinite(parsedAnnounceAt) && parsedAnnounceAt > 0 ? parsedAnnounceAt : null;
+
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot,
+      lastAnnounceAtMilliseconds,
+      nowMilliseconds: Date.now(),
+    });
+    if (evaluation.shouldRearm) {
+      await setSessionPreference(
+        this.#sqlExecutor(),
+        LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
+        '0',
+      );
+    }
+    if (!evaluation.shouldAnnounce || evaluation.message === undefined) {
+      return;
+    }
+    await setSessionPreference(
+      this.#sqlExecutor(),
+      LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
+      String(Date.now()),
+    );
+    this.#broadcastPlayEffect('low_battery');
+    await deliverDeskDeviceNotification({
+      notification: { type: 'reminder', message: evaluation.message },
+      connectionList: [...this.getConnections()],
+      sqlExecutor: this.#sqlExecutor(),
+      focusState: this.#currentFocusState(),
+      environment: this.env,
+      deviceId: this.name ?? 'default',
+      ttsVoiceId: APOLLO_TTS_VOICE,
+      isMockVoice: this.env.MOCK_VOICE === '1',
+      announceKind: 'critical',
+    });
+  }
+
+  #broadcastPlayEffect(effectName: DeskSoundEffectName): void {
+    const encodedMessage = encodeServerToDeviceMessage({
+      type: 'play_effect',
+      name: effectName,
+    });
+    for (const connection of this.getConnections()) {
+      connection.send(encodedMessage);
+    }
+  }
+
   async #runTurnFromText(connection: Connection, text: string): Promise<void> {
     this.#applyUiEvent('START_LISTEN');
     await this.#executeTurn(connection, { text });
@@ -669,6 +758,9 @@ export class Apollo extends Agent<Env, ApolloState> {
           deviceId,
           effects: deskToolEffects,
           isSpeechAborted: () => this.#isSpeechAborted,
+          ...(this.#lastTelemetrySnapshot !== undefined
+            ? { telemetrySnapshot: this.#lastTelemetrySnapshot }
+            : {}),
         },
         turnPart,
       );
@@ -693,6 +785,9 @@ export class Apollo extends Agent<Env, ApolloState> {
         pendingConfirmId: null,
         pendingConfirmSummary: null,
       });
+      connection.send(
+        encodeServerToDeviceMessage({ type: 'play_effect', name: 'error' }),
+      );
       connection.send(
         encodeServerToDeviceMessage({
           type: 'error',

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -131,6 +131,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #session: Session | undefined;
   #lastKnownWeatherSnapshot: DeskWeatherSnapshot | undefined;
   #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
+  #isAnnouncingLowBattery = false;
 
   get session(): Session {
     if (this.#session === undefined) {
@@ -595,26 +596,36 @@ export class Apollo extends Agent<Env, ApolloState> {
     if (!evaluation.shouldAnnounce || evaluation.message === undefined) {
       return;
     }
-    this.#broadcastPlayEffect('low_battery');
-    await deliverDeskDeviceNotification({
-      notification: { type: 'reminder', message: evaluation.message },
-      connectionList: [...this.getConnections()],
-      sqlExecutor: this.#sqlExecutor(),
-      focusState: this.#currentFocusState(),
-      environment: this.env,
-      deviceId: this.name ?? 'default',
-      ttsVoiceId: APOLLO_TTS_VOICE,
-      isMockVoice: this.env.MOCK_VOICE === '1',
-      announceKind: 'critical',
-    });
-    // The cooldown starts only after the announcement actually went out: a
-    // failed delivery retries on the next telemetry instead of going silent
-    // for half an hour.
-    await setSessionPreference(
-      this.#sqlExecutor(),
-      LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
-      String(Date.now()),
-    );
+    // The cooldown is only persisted after delivery succeeds, so a failure
+    // retries on the next telemetry instead of going silent for half an hour.
+    // Delivery spans seconds of paced streaming, though, and a charging-edge
+    // telemetry arriving mid-announcement would read the still-expired
+    // cooldown — the in-flight flag closes that window.
+    if (this.#isAnnouncingLowBattery) {
+      return;
+    }
+    this.#isAnnouncingLowBattery = true;
+    try {
+      this.#broadcastPlayEffect('low_battery');
+      await deliverDeskDeviceNotification({
+        notification: { type: 'reminder', message: evaluation.message },
+        connectionList: [...this.getConnections()],
+        sqlExecutor: this.#sqlExecutor(),
+        focusState: this.#currentFocusState(),
+        environment: this.env,
+        deviceId: this.name ?? 'default',
+        ttsVoiceId: APOLLO_TTS_VOICE,
+        isMockVoice: this.env.MOCK_VOICE === '1',
+        announceKind: 'critical',
+      });
+      await setSessionPreference(
+        this.#sqlExecutor(),
+        LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
+        String(Date.now()),
+      );
+    } finally {
+      this.#isAnnouncingLowBattery = false;
+    }
   }
 
   #broadcastPlayEffect(effectName: DeskSoundEffectName): void {

--- a/src/agents/notify.ts
+++ b/src/agents/notify.ts
@@ -1,7 +1,7 @@
 import type { Connection } from 'agents';
 import { z } from 'zod';
 
-import type { DeskFocusState } from '@/focus/logic';
+import type { DeskAnnounceKind, DeskFocusState } from '@/focus/logic';
 import { shouldAnnounceDuringFocus } from '@/focus/logic';
 import {
   enqueuePendingDeviceMessage,
@@ -76,6 +76,7 @@ export async function deliverDeskDeviceNotification(input: {
   readonly deviceId: string;
   readonly ttsVoiceId: string;
   readonly isMockVoice: boolean;
+  readonly announceKind?: DeskAnnounceKind;
 }): Promise<void> {
   if (input.connectionList.length === 0) {
     await enqueuePendingDeviceMessage(input.sqlExecutor, {
@@ -90,7 +91,10 @@ export async function deliverDeskDeviceNotification(input: {
     connection.send(encodedMessage);
   }
 
-  const shouldAnnounce = shouldAnnounceDuringFocus(input.focusState, 'normal');
+  const shouldAnnounce = shouldAnnounceDuringFocus(
+    input.focusState,
+    input.announceKind ?? 'normal',
+  );
   if (!shouldAnnounce) {
     return;
   }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -11,6 +11,7 @@ import { resolveDeskFaceEmotion } from '@/persona/face';
 import { APOLLO_TTS_VOICE } from '@/persona/soul';
 import { encodeServerToDeviceMessage } from '@/protocol/schema';
 import type { DeskUiMachine } from '@/session/machine';
+import { buildTelemetryPromptNote, type DeskTelemetrySnapshot } from '@/telemetry/logic';
 import { createBuiltinToolDefinitionMap } from '@/tools/catalog';
 import type { DeskToolEffects, PendingToolConfirmation } from '@/tools/types';
 import { runDeskTurn, type VoiceAdapters } from '@/turn/run';
@@ -33,6 +34,7 @@ export type ApolloTurnRuntimeDependencies = {
   readonly deviceId: string;
   readonly effects: DeskToolEffects;
   readonly isSpeechAborted?: () => boolean;
+  readonly telemetrySnapshot?: DeskTelemetrySnapshot;
 };
 
 export async function executeApolloTurn(
@@ -72,6 +74,10 @@ export async function executeApolloTurn(
   const focusNote = focusState.active
     ? '\n\nFocus activo: evitá announces ruidosos; sé breve.'
     : '\n\nFocus inactivo.';
+  const telemetryNote = buildTelemetryPromptNote(
+    dependencies.telemetrySnapshot,
+    nowMilliseconds,
+  );
 
   const voiceAdapters: VoiceAdapters = isMockVoice
     ? {
@@ -121,7 +127,7 @@ export async function executeApolloTurn(
     confirmOk: turnPart.confirmOk,
     nowMilliseconds,
     deviceId: dependencies.deviceId,
-    systemPromptOverride: `${sessionSystemPrompt}${focusNote}`,
+    systemPromptOverride: `${sessionSystemPrompt}${focusNote}${telemetryNote}`,
     ...(isMockVoice ? {} : { recallSemanticMemoryContentList }),
     effects: dependencies.effects,
     onThinkingCaption: async (caption) => {
@@ -192,6 +198,7 @@ export async function executeApolloTurn(
   });
 
   if (turnOutput.pendingConfirmation !== undefined) {
+    connection.send(encodeServerToDeviceMessage({ type: 'play_effect', name: 'chime' }));
     connection.send(
       encodeServerToDeviceMessage({
         type: 'confirm_request',

--- a/src/protocol/__tests__/schema.spec.ts
+++ b/src/protocol/__tests__/schema.spec.ts
@@ -22,6 +22,41 @@ describe('protocol schema', () => {
     expect(() => parseDeviceToServerMessage(JSON.stringify({ type: 'nope' }))).toThrow();
   });
 
+  it('parses telemetry with every field', () => {
+    const message = parseDeviceToServerMessage({
+      type: 'telemetry',
+      battery: 87,
+      charging: false,
+      volume: 70,
+      wifiRssi: -52,
+      firmwareVersion: '2.4.2',
+      ts: 3,
+    });
+    expect(message).toEqual({
+      type: 'telemetry',
+      battery: 87,
+      charging: false,
+      volume: 70,
+      wifiRssi: -52,
+      firmwareVersion: '2.4.2',
+      ts: 3,
+    });
+  });
+
+  it('parses telemetry with only type and ts', () => {
+    const message = parseDeviceToServerMessage({ type: 'telemetry', ts: 4 });
+    expect(message).toEqual({ type: 'telemetry', ts: 4 });
+  });
+
+  it('rejects telemetry with battery out of range', () => {
+    expect(() =>
+      parseDeviceToServerMessage({ type: 'telemetry', battery: -1, ts: 5 }),
+    ).toThrow();
+    expect(() =>
+      parseDeviceToServerMessage({ type: 'telemetry', battery: 101, ts: 5 }),
+    ).toThrow();
+  });
+
   it('encodes ui_state', () => {
     const raw = encodeServerToDeviceMessage({
       type: 'ui_state',
@@ -103,5 +138,24 @@ describe('protocol schema', () => {
         }),
       ),
     ).toMatchObject({ type: 'reminder', message: 'Tomá agua' });
+  });
+
+  it('encodes play_effect for every catalog name', () => {
+    for (const effectName of ['ding', 'chime', 'error', 'low_battery'] as const) {
+      expect(
+        JSON.parse(
+          encodeServerToDeviceMessage({ type: 'play_effect', name: effectName }),
+        ),
+      ).toEqual({ type: 'play_effect', name: effectName });
+    }
+  });
+
+  it('rejects play_effect with an unknown name', () => {
+    expect(() =>
+      encodeServerToDeviceMessage({
+        type: 'play_effect',
+        name: 'nope' as never,
+      }),
+    ).toThrow();
   });
 });

--- a/src/protocol/schema.ts
+++ b/src/protocol/schema.ts
@@ -30,6 +30,10 @@ export const deviceGestureSchema = z.enum([
   'swipe_right',
 ]);
 
+export const deskSoundEffectSchema = z.enum(['ding', 'chime', 'error', 'low_battery']);
+
+export type DeskSoundEffectName = z.infer<typeof deskSoundEffectSchema>;
+
 export const deviceToServerMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('hello'),
@@ -69,6 +73,15 @@ export const deviceToServerMessageSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('abort'),
+    ts: z.number().int().nonnegative(),
+  }),
+  z.object({
+    type: z.literal('telemetry'),
+    battery: z.number().int().nonnegative().max(100).optional(),
+    charging: z.boolean().optional(),
+    volume: z.number().int().nonnegative().optional(),
+    wifiRssi: z.number().int().optional(),
+    firmwareVersion: z.string().min(1).optional(),
     ts: z.number().int().nonnegative(),
   }),
 ]);
@@ -128,6 +141,10 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('reminder'),
     message: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('play_effect'),
+    name: deskSoundEffectSchema,
   }),
 ]);
 

--- a/src/telemetry/__tests__/logic.spec.ts
+++ b/src/telemetry/__tests__/logic.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildTelemetryPromptNote,
+  evaluateLowBatteryAnnouncement,
+  LOW_BATTERY_ANNOUNCE_COOLDOWN_MS,
+  TELEMETRY_PROMPT_STALENESS_MS,
+  type DeskTelemetrySnapshot,
+} from '@/telemetry/logic';
+
+const NOW_MILLISECONDS = 1_754_830_000_000;
+
+function createSnapshot(
+  overrides: Partial<DeskTelemetrySnapshot> = {},
+): DeskTelemetrySnapshot {
+  return {
+    battery: 87,
+    charging: false,
+    volume: 70,
+    wifiRssi: -52,
+    firmwareVersion: '2.4.2',
+    receivedAtMs: NOW_MILLISECONDS,
+    ...overrides,
+  };
+}
+
+describe('buildTelemetryPromptNote', () => {
+  it('describes every field of a fresh snapshot', () => {
+    const note = buildTelemetryPromptNote(createSnapshot(), NOW_MILLISECONDS);
+    expect(note).toBe(
+      '\n\nEstado del dispositivo: batería 87% (con batería), volumen 70, WiFi -52 dBm, firmware 2.4.2.',
+    );
+  });
+
+  it('labels a charging battery', () => {
+    const note = buildTelemetryPromptNote(
+      createSnapshot({ charging: true }),
+      NOW_MILLISECONDS,
+    );
+    expect(note).toContain('batería 87% (cargando)');
+  });
+
+  it('omits absent fields', () => {
+    const note = buildTelemetryPromptNote(
+      {
+        volume: 55,
+        receivedAtMs: NOW_MILLISECONDS,
+      },
+      NOW_MILLISECONDS,
+    );
+    expect(note).toBe('\n\nEstado del dispositivo: volumen 55.');
+  });
+
+  it('returns empty for an undefined snapshot', () => {
+    expect(buildTelemetryPromptNote(undefined, NOW_MILLISECONDS)).toBe('');
+  });
+
+  it('returns empty for a stale snapshot', () => {
+    const note = buildTelemetryPromptNote(
+      createSnapshot({
+        receivedAtMs: NOW_MILLISECONDS - TELEMETRY_PROMPT_STALENESS_MS - 1,
+      }),
+      NOW_MILLISECONDS,
+    );
+    expect(note).toBe('');
+  });
+
+  it('returns empty for a snapshot with no reportable fields', () => {
+    expect(
+      buildTelemetryPromptNote({ receivedAtMs: NOW_MILLISECONDS }, NOW_MILLISECONDS),
+    ).toBe('');
+  });
+});
+
+describe('evaluateLowBatteryAnnouncement', () => {
+  it('announces at the threshold while discharging', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 12, charging: false }),
+      lastAnnounceAtMilliseconds: null,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldAnnounce).toBe(true);
+    expect(evaluation.message).toBe('Estás con 12% de batería, enchufame.');
+  });
+
+  it('stays quiet while charging', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 12, charging: true }),
+      lastAnnounceAtMilliseconds: null,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldAnnounce).toBe(false);
+  });
+
+  it('stays quiet above the threshold', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 16, charging: false }),
+      lastAnnounceAtMilliseconds: null,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldAnnounce).toBe(false);
+    expect(evaluation.shouldRearm).toBe(false);
+  });
+
+  it('stays quiet without a battery reading', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: { receivedAtMs: NOW_MILLISECONDS },
+      lastAnnounceAtMilliseconds: null,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldAnnounce).toBe(false);
+  });
+
+  it('respects the cooldown after an announcement', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 10, charging: false }),
+      lastAnnounceAtMilliseconds: NOW_MILLISECONDS - LOW_BATTERY_ANNOUNCE_COOLDOWN_MS + 1,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldAnnounce).toBe(false);
+  });
+
+  it('announces again once the cooldown expires', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 10, charging: false }),
+      lastAnnounceAtMilliseconds: NOW_MILLISECONDS - LOW_BATTERY_ANNOUNCE_COOLDOWN_MS,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldAnnounce).toBe(true);
+  });
+
+  it('re-arms when charging is observed', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 12, charging: true }),
+      lastAnnounceAtMilliseconds: NOW_MILLISECONDS - 60_000,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldRearm).toBe(true);
+  });
+
+  it('re-arms when the battery recovers past the hysteresis band', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 25, charging: false }),
+      lastAnnounceAtMilliseconds: NOW_MILLISECONDS - 60_000,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldRearm).toBe(true);
+  });
+
+  it('does not re-arm when there is nothing to clear', () => {
+    const evaluation = evaluateLowBatteryAnnouncement({
+      snapshot: createSnapshot({ battery: 90, charging: true }),
+      lastAnnounceAtMilliseconds: null,
+      nowMilliseconds: NOW_MILLISECONDS,
+    });
+    expect(evaluation.shouldRearm).toBe(false);
+  });
+});

--- a/src/telemetry/logic.ts
+++ b/src/telemetry/logic.ts
@@ -1,0 +1,88 @@
+export type DeskTelemetrySnapshot = {
+  readonly battery?: number;
+  readonly charging?: boolean;
+  readonly volume?: number;
+  readonly wifiRssi?: number;
+  readonly firmwareVersion?: string;
+  readonly receivedAtMs: number;
+};
+
+export const LOW_BATTERY_ANNOUNCE_THRESHOLD_PERCENT = 15;
+export const LOW_BATTERY_REARM_THRESHOLD_PERCENT = 25;
+export const LOW_BATTERY_ANNOUNCE_COOLDOWN_MS = 30 * 60_000;
+export const TELEMETRY_PROMPT_STALENESS_MS = 5 * 60_000;
+
+export function buildTelemetryPromptNote(
+  snapshot: DeskTelemetrySnapshot | undefined,
+  nowMilliseconds: number,
+): string {
+  if (snapshot === undefined) {
+    return '';
+  }
+  if (nowMilliseconds - snapshot.receivedAtMs > TELEMETRY_PROMPT_STALENESS_MS) {
+    return '';
+  }
+  const fragmentList: string[] = [];
+  if (snapshot.battery !== undefined) {
+    const chargingLabel =
+      snapshot.charging === undefined
+        ? ''
+        : snapshot.charging
+          ? ' (cargando)'
+          : ' (con batería)';
+    fragmentList.push(`batería ${snapshot.battery}%${chargingLabel}`);
+  }
+  if (snapshot.volume !== undefined) {
+    fragmentList.push(`volumen ${snapshot.volume}`);
+  }
+  if (snapshot.wifiRssi !== undefined) {
+    fragmentList.push(`WiFi ${snapshot.wifiRssi} dBm`);
+  }
+  if (snapshot.firmwareVersion !== undefined) {
+    fragmentList.push(`firmware ${snapshot.firmwareVersion}`);
+  }
+  if (fragmentList.length === 0) {
+    return '';
+  }
+  return `\n\nEstado del dispositivo: ${fragmentList.join(', ')}.`;
+}
+
+export type LowBatteryEvaluationInput = {
+  readonly snapshot: DeskTelemetrySnapshot;
+  readonly lastAnnounceAtMilliseconds: number | null;
+  readonly nowMilliseconds: number;
+};
+
+export type LowBatteryEvaluation = {
+  readonly shouldAnnounce: boolean;
+  readonly shouldRearm: boolean;
+  readonly message?: string;
+};
+
+export function evaluateLowBatteryAnnouncement(
+  input: LowBatteryEvaluationInput,
+): LowBatteryEvaluation {
+  const { snapshot, lastAnnounceAtMilliseconds, nowMilliseconds } = input;
+  if (snapshot.battery === undefined) {
+    return { shouldAnnounce: false, shouldRearm: false };
+  }
+  const isRecovered =
+    snapshot.charging === true || snapshot.battery >= LOW_BATTERY_REARM_THRESHOLD_PERCENT;
+  if (isRecovered) {
+    return { shouldAnnounce: false, shouldRearm: lastAnnounceAtMilliseconds !== null };
+  }
+  if (snapshot.battery > LOW_BATTERY_ANNOUNCE_THRESHOLD_PERCENT) {
+    return { shouldAnnounce: false, shouldRearm: false };
+  }
+  const isCoolingDown =
+    lastAnnounceAtMilliseconds !== null &&
+    nowMilliseconds - lastAnnounceAtMilliseconds < LOW_BATTERY_ANNOUNCE_COOLDOWN_MS;
+  if (isCoolingDown) {
+    return { shouldAnnounce: false, shouldRearm: false };
+  }
+  return {
+    shouldAnnounce: true,
+    shouldRearm: false,
+    message: `Estás con ${snapshot.battery}% de batería, enchufame.`,
+  };
+}


### PR DESCRIPTION
Ships roadmap items 3, 4, and 12 as one bundle — the firmware half is already flashed and verified on the device (apollo-firmware `3cf390a`).

## What changed

- **`play_effect`** (server → device): logical effect names (`ding`, `chime`, `error`, `low_battery`) sent at three sites — reminder/timer delivery (the earcon lands while ElevenLabs is still synthesizing), confirm requests, and turn failures. The firmware maps names to flash assets, so sounds can be re-purposed with a worker deploy.
- **`telemetry`** (device → server): battery, charging, volume, WiFi RSSI, and firmware version. The snapshot lives in a private agent field (no `setState` churn), a device-state line is stamped into the system prompt while fresh (5 min), and low battery (≤15%, discharging) announces with a persisted 30-minute cooldown and 25% re-arm hysteresis, piercing focus as `critical`.
- **Semantic `audio_end`**: `hold_end` and `audio_end` now dispatch as separate cases so wake-word turns can diverge from push-to-talk later without a flash.
- Docs: protocol tables updated; roadmap items 3, 4, 12 marked shipped.

## Verification

- 265 tests pass (20 new: schema round-trips + telemetry logic), typecheck/lint/format clean
- Verified live end to end: device telemetry reaches the system prompt (Apollo answered a battery question from it on first boot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds server-triggered earcons, device telemetry with prompt and low-battery handling, and separate dispatch for semantic `audio_end`.
- Adds telemetry schema, formatting, freshness, cooldown, and hysteresis logic.
- Sends logical sound effects for reminders, confirmations, failures, and low battery.
- Updates protocol and roadmap documentation and advances the firmware submodule.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported cooldown ordering and overlapping-announcement paths are addressed by persisting after delivery and guarding in-flight announcements.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(telemetry): guard against overlappin..."](https://github.com/galfrevn/apollo/commit/68254734885d3b18b0a318425fd298be160bec19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51944208)</sub>

<!-- /greptile_comment -->