### PR TITLE
docs: add the Greptile open source badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Agents][agents-shield]][agents-url]
 [![Zod][zod-shield]][zod-url]
 
+[![Greptile: The War on Bugs][greptile-shield]][greptile-url]
+
 <br />
 <div align="center">
   <img src=".github/assets/banner.jpeg" alt="Apollo banner" width="100%">
@@ -31,3 +33,5 @@
 [agents-url]: https://developers.cloudflare.com/agents/
 [zod-shield]: https://img.shields.io/badge/Zod-3E67B1?style=for-the-badge&logo=zod&logoColor=white
 [zod-url]: https://zod.dev/
+[greptile-shield]: https://www.greptile.com/badge.svg
+[greptile-url]: https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source


### PR DESCRIPTION
Adds the Greptile badge to the README for the Greptile Open Source program.

Placed on its own line below the tech-stack shields — the Greptile SVG is a different size than the `for-the-badge` row, so it doesn't sit well inline with them. Converted to the reference-link style the README already uses, with the definition alongside the others at the bottom; the URL and utm params are unchanged from what Greptile provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114qWHsweQDBkCYKiu9G9Q4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Greptile Open Source badge to the README using the existing reference-link style.

- Places the badge on a separate line below the technology shields.
- Adds reference definitions for the badge image and tracked Greptile URL.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The documentation-only change uses valid Markdown reference syntax, and no actionable defects or security concerns were identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add the Greptile open source badge"](https://github.com/galfrevn/apollo/commit/8a65363d846a73d983d93d7ce1e7a16827a875d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51956410)</sub>

<!-- /greptile_comment -->