### PR TITLE
Add Greptile badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Cloudflare][cloudflare-shield]][cloudflare-url]
 [![Agents][agents-shield]][agents-url]
 [![Zod][zod-shield]][zod-url]
+<a href="https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source"><img src="https://www.greptile.com/badge.svg" alt="Greptile: The War on Bugs" width="210"></a>
 
-[![Greptile: The War on Bugs][greptile-shield]][greptile-url]
 
 <br />
 <div align="center">


### PR DESCRIPTION
Added Greptile badge to the README file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a direct Greptile badge link to the README, replacing the previous reference-style badge markup.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The badge replacement is valid README markup and introduces no runtime, build, security, or documentation correctness issue.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Greptile badge to README"](https://github.com/galfrevn/apollo/commit/cb32096f54242bba3c267eafb3323236a483da77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51965190)</sub>

<!-- /greptile_comment -->