### PR TITLE
feat(device): OTA from R2 and the device-side MCP bridge

### DIFF
--- a/documentation/operations/deploy.md
+++ b/documentation/operations/deploy.md
@@ -49,6 +49,37 @@ Use your usual Wrangler deploy flow after secrets and resources exist in the tar
 
 The `Sandbox` container image is built by the Docker CLI as part of every deploy, including `--dry-run`, so the daemon has to be running. To ship a Worker-only change without it, pass `--containers-rollout=none`.
 
+## Publishing firmware (OTA)
+
+The device self-updates from the `MEDIA` bucket (see [Protocol](../runtime/protocol.md#ota-endpoints)). Layout:
+
+- `firmware/latest.json` — `{ "version": "2.5.0", "key": "firmware/apollo-2.5.0.bin" }`
+- `firmware/apollo-<version>.bin` — the app image
+
+Rules that keep devices alive:
+
+- `version` must match `/^\d+(\.\d+)*$/` — digits and dots only. The worker refuses
+  anything else (`src/ota/manifest.ts`), because the device's version parser aborts on
+  non-numeric segments.
+- Upload the **app image** (`build/xiaozhi.bin`), never `build/merged-binary.bin` — the
+  merged binary contains the bootloader and partition table and would corrupt an OTA slot.
+- Upload the binary before the manifest, so a check never resolves a manifest whose
+  binary is not there yet.
+
+```sh
+bunx wrangler r2 object put apollo-media/firmware/apollo-2.5.0.bin \
+  --file firmware/apollo-firmware/build/xiaozhi.bin \
+  --content-type application/octet-stream --remote
+bunx wrangler r2 object put apollo-media/firmware/latest.json \
+  --file latest.json --content-type application/json --remote
+```
+
+The device checks at boot only, so a running device picks the update up on its next
+power cycle. Smoke-test after publishing:
+`curl -s "https://<worker>/ota/check?token=$TOKEN"` should answer with the new version,
+and `curl -sI "https://<worker>/ota/firmware.bin?token=$TOKEN"` with a 200 and the
+binary's exact `Content-Length`.
+
 ## Navigation
 
 Prev: [Setup](setup.md) · Next: [Auth](auth.md)

--- a/documentation/reference/roadmap.md
+++ b/documentation/reference/roadmap.md
@@ -24,14 +24,9 @@ The server already tracks `focus` state and sends `focusRemainingSec` on every `
 
 The firmware now remembers which mode started the listen (`listen_started_by_hold_` in `apollo_protocol.cc`) and ends it with the matching event: `hold_end` for push-to-talk, `audio_end` for wake-word turns. The server dispatches them as separate cases (identical behavior today) so timeouts or continuity can diverge without a flash.
 
-### 5. Device-side MCP: the agent with hands on the hardware
+### 5. Device-side MCP: the agent with hands on the hardware — ✅ implemented 2026-08-10 (pending flash)
 
-The most powerful piece. `application.cc` already has an `McpServer` (inherited from xiaozhi) with volume, brightness, and other tools, but:
-
-- `apollo_protocol.cc` never routes `"mcp"` messages — the branch exists in `application.cc` and is dead.
-- On the server side, the agents SDK's `cf_agent_mcp_servers` traffic is ignored on purpose.
-
-Connecting both ends would let the agent act by voice: "bajá el brillo", "subí el volumen", "apagá la pantalla", "poné cara de contento". Requires defining the bridge between the agents SDK tool format and the embedded MCP.
+Both ends are connected: `apollo_protocol.cc` routes `"mcp"` frames into the live `application.cc` branch (and overrides `SendMcpMessage` to speak the Apollo dialect: `{"type":"mcp","payload",…,"ts"}`), and the server bridges agent tools to the embedded MCP over the websocket (`src/mcp/bridge.ts`: integer JSON-RPC ids, 5 s timeout awaited inside the tool handler). Exposed to the LLM as `set_volume`, `set_brightness`, and `device_status` (`src/tools/device.ts`); the device's user-only tools (`self.reboot`, `self.upgrade_firmware`) stay callable from server code but hidden from the model. "Apagá la pantalla" and face control need tools the 1.85C build compiles out — a later firmware addition.
 
 ### 6. Voice timer with ring progress — server half ✅ (2026-08-08)
 
@@ -83,13 +78,13 @@ Still open: `long_press` is not in the gesture enum, so "hold to start a pomodor
 
 `{"type":"play_effect", "name":"ding"|"chime"|"error"|"low_battery"}` plays effects already burned into flash. The names are logical — the firmware maps them to assets (`ding`→success, `chime`→popup, `error`→exclamation) so the server can re-purpose sounds without a flash. Wired at three sites: reminder/timer delivery (the ding lands while the TTS is still synthesizing), confirm requests, and turn failures, plus the low-battery announcement from item 3.
 
-### 13. `set_volume` from the server
+### 13. `set_volume` from the server — ✅ implemented 2026-08-10 via item 5
 
-A trivial command for "bajá el volumen" by voice. It overlaps with device-side MCP (item 5, which already exposes volume and brightness): if item 5 lands soon this comes for free through it; if not, a simple message works as a bridge.
+Came for free through the MCP bridge, as predicted: `set_volume` is one of the three tools item 5 exposes to the agent.
 
-### 14. OTA from R2
+### 14. OTA from R2 — ✅ implemented 2026-08-10 (pending the last cable flash)
 
-The server hosts the firmware binary in the `MEDIA` bucket, the device checks its version at boot (HTTP + `esp_ota`) and updates itself. Given how risky cable flashing is on this board — never touch DTR/RTS — it pays for itself: one last manual flash, and from then on the firmware "deploys" too. Promoted from "Under consideration", where it was listed as "OTA over WiFi".
+The worker serves `/ota/check` and `/ota/firmware.bin` from the `MEDIA` bucket (`src/ota/`, token-authenticated, versions strictly `digits.and.dots` because the device's parser aborts on anything else). The device (2.5.0) checks once at boot right after time sync — single attempt, a failed check never blocks boot — and self-updates through the existing `esp_ota` path; `MarkCurrentVersionValid` now runs under Apollo so rollback no longer reverts OTA'd images. Publishing steps live in [Deploy](../operations/deploy.md#publishing-firmware-ota). Remaining: deploy the worker, upload 2.5.0 + manifest, one last cable flash; from then on firmware "deploys" too. Push-style updates (server calls `self.upgrade_firmware` over the item-5 bridge when telemetry shows a stale version) are the documented follow-up for devices that never reboot.
 
 ### 15. `tts_end` + playback acks (real streaming)
 

--- a/documentation/runtime/protocol.md
+++ b/documentation/runtime/protocol.md
@@ -15,6 +15,7 @@ Device and server speak a Zod-validated JSON protocol defined in `src/protocol/s
 | `text_input` | Typed fallback input |
 | `abort` | Stop the speech currently streaming (barge-in) |
 | `telemetry` | Battery, charging, volume, WiFi RSSI, firmware version |
+| `mcp` | JSON-RPC reply from the device's embedded MCP server |
 
 A listen session ends with the event matching how it started: `hold_end` when a finger
 lifts, `audio_end` when a wake-word turn hits its VAD timeout. Both run the turn today;
@@ -46,6 +47,7 @@ no-op (it used to mute the microphone and did so invisibly — see `#handleGestu
 | `background_result` | Completed async work summary |
 | `reminder` | Reminder delivery |
 | `play_effect` | Play a sound effect already burned into device flash |
+| `mcp` | JSON-RPC request for the device's embedded MCP server |
 
 `play_effect` carries a logical `name` — `ding` (timer/reminder landing), `chime`
 (confirmation request), `error` (turn failure), `low_battery` — and the firmware maps
@@ -56,6 +58,34 @@ TTS announcement is still being synthesized, and it costs no ElevenLabs credits.
 `tts_start` carries `format` (always `pcm` in production), `bytes` for the clip that
 follows, and optional `sampleRate` / `channels` — 24 000 Hz mono, so the ESP32 needs no
 decoder. The binary frames that follow belong to the clip just announced.
+
+## Device MCP bridge
+
+`mcp` frames carry a raw JSON-RPC object in `payload` and bridge the agent's tools to
+the hardware: the server sends `tools/call` requests (`self.audio_speaker.set_volume`,
+`self.screen.set_brightness`, `self.get_device_status`), the firmware routes them into
+its embedded `McpServer`, and the reply comes back as a device→server `mcp` frame.
+Correlation is by JSON-RPC `id`, which **must be an integer** — the device silently
+drops string ids. The server awaits each call inside the tool handler with a 5-second
+timeout (`src/mcp/bridge.ts`); a timeout or a disconnected device degrades to a spoken
+"no está conectado / no respondió" tool result. The firmware's user-only tools
+(`self.reboot`, `self.upgrade_firmware`) are callable over the bridge from server code
+but are not exposed to the LLM.
+
+## OTA endpoints
+
+Two token-authenticated HTTP routes (same `?token=` shared secret as the websocket URL;
+the token appears in device logs on both — an accepted exposure) serve firmware updates
+from the `MEDIA` R2 bucket (`src/ota/routes.ts`):
+
+- `GET|POST /ota/check` → `{ "firmware": { "version", "url", "force" } }`, or `{}` when
+  no manifest is published. The version is validated server-side against
+  `/^\d+(\.\d+)*$/` because the device's version parser aborts on anything else.
+- `GET /ota/firmware.bin` → the binary named by `firmware/latest.json`, with an explicit
+  `Content-Length` (the device refuses length-less downloads).
+
+The device checks once at boot, right after time sync; a failed check logs and boots
+normally. See [Deploy](../operations/deploy.md) for the R2 publishing steps.
 
 ## Design notes
 

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -27,6 +27,12 @@ import {
   tickDeskFocus,
   type DeskFocusState,
 } from '@/focus/logic';
+import {
+  buildDeviceToolCallPayload,
+  createDeviceMcpRequestRegistry,
+  DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS,
+  summarizeDeviceToolResult,
+} from '@/mcp/bridge';
 import { deletePendingDeviceMessage, listPendingDeviceMessages } from '@/memory/pending';
 import { createApolloSession } from '@/memory/session';
 import {
@@ -59,7 +65,7 @@ import {
   readPendingToolConfirmation,
   savePendingToolConfirmation,
 } from '@/tools/pending';
-import type { PendingToolConfirmation } from '@/tools/types';
+import type { PendingToolConfirmation, ToolExecutionResult } from '@/tools/types';
 import type { DeskWeatherSnapshot } from '@/weather/fetch';
 import {
   resolveDeskWeatherLocationFromPreferences,
@@ -132,6 +138,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #lastKnownWeatherSnapshot: DeskWeatherSnapshot | undefined;
   #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
   #isAnnouncingLowBattery = false;
+  #deviceMcpRequestRegistry = createDeviceMcpRequestRegistry();
 
   get session(): Session {
     if (this.#session === undefined) {
@@ -310,6 +317,10 @@ export class Apollo extends Agent<Env, ApolloState> {
       }
       case 'telemetry': {
         await this.#handleTelemetry(deviceMessage);
+        break;
+      }
+      case 'mcp': {
+        this.#deviceMcpRequestRegistry.resolvePendingRequest(deviceMessage.payload);
         break;
       }
     }
@@ -628,6 +639,28 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
   }
 
+  async #callDeviceTool(
+    deviceToolName: string,
+    argumentRecord: Record<string, unknown>,
+  ): Promise<ToolExecutionResult> {
+    const connectionList = [...this.getConnections()];
+    if (connectionList.length === 0) {
+      return { ok: false, summary: 'El dispositivo no está conectado.' };
+    }
+    const { requestId, responsePromise } =
+      this.#deviceMcpRequestRegistry.createPendingRequest(
+        DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS,
+      );
+    const encodedMessage = encodeServerToDeviceMessage({
+      type: 'mcp',
+      payload: buildDeviceToolCallPayload(requestId, deviceToolName, argumentRecord),
+    });
+    for (const connection of connectionList) {
+      connection.send(encodedMessage);
+    }
+    return summarizeDeviceToolResult(await responsePromise);
+  }
+
   #broadcastPlayEffect(effectName: DeskSoundEffectName): void {
     const encodedMessage = encodeServerToDeviceMessage({
       type: 'play_effect',
@@ -751,6 +784,8 @@ export class Apollo extends Agent<Env, ApolloState> {
           serializeWeatherLocation(location),
         );
       },
+      callDeviceTool: async ({ deviceToolName, argumentRecord }) =>
+        this.#callDeviceTool(deviceToolName, argumentRecord),
     });
 
     try {

--- a/src/agents/effects.ts
+++ b/src/agents/effects.ts
@@ -29,6 +29,7 @@ export function createDeskToolEffects(input: {
   readonly cancelReminders: DeskToolEffects['cancelReminders'];
   readonly resolveWeatherLocation: DeskToolEffects['resolveWeatherLocation'];
   readonly persistWeatherLocation: DeskToolEffects['persistWeatherLocation'];
+  readonly callDeviceTool: DeskToolEffects['callDeviceTool'];
 }): DeskToolEffects {
   return {
     persistMemory: async (content) => {
@@ -61,6 +62,7 @@ export function createDeskToolEffects(input: {
     cancelReminders: input.cancelReminders,
     resolveWeatherLocation: input.resolveWeatherLocation,
     persistWeatherLocation: input.persistWeatherLocation,
+    callDeviceTool: input.callDeviceTool,
     addListItem: async (item) => addListItemRecord(input.sqlExecutor, item),
     listListItems: async (listName) => listListItemRecords(input.sqlExecutor, listName),
     removeListItems: async (removal) => removeListItemRecords(input.sqlExecutor, removal),

--- a/src/configuration/testing.ts
+++ b/src/configuration/testing.ts
@@ -33,6 +33,51 @@ export function createInMemoryPendingConfirmationSqlExecutor(): MemorySqlExecuto
   };
 }
 
+export function createFakeMediaBucket(
+  initialObjectMap: Record<string, string | Uint8Array> = {},
+): Env['MEDIA'] {
+  const storedObjectMap = new Map<string, Uint8Array>(
+    Object.entries(initialObjectMap).map(([objectKey, content]) => [
+      objectKey,
+      typeof content === 'string' ? new TextEncoder().encode(content) : content,
+    ]),
+  );
+  const partialBucket = {
+    async get(objectKey: string) {
+      const storedBytes = storedObjectMap.get(objectKey);
+      if (storedBytes === undefined) {
+        return null;
+      }
+      const storedText = new TextDecoder().decode(storedBytes);
+      return {
+        size: storedBytes.byteLength,
+        body: new Response(storedBytes).body,
+        async arrayBuffer() {
+          return storedBytes.buffer.slice(
+            storedBytes.byteOffset,
+            storedBytes.byteOffset + storedBytes.byteLength,
+          );
+        },
+        async text() {
+          return storedText;
+        },
+        async json() {
+          return JSON.parse(storedText) as unknown;
+        },
+      };
+    },
+    async put(objectKey: string, content: string | ArrayBuffer | Uint8Array) {
+      const contentBytes =
+        typeof content === 'string'
+          ? new TextEncoder().encode(content)
+          : new Uint8Array(content instanceof ArrayBuffer ? content : content);
+      storedObjectMap.set(objectKey, contentBytes);
+      return null;
+    },
+  };
+  return partialBucket as Env['MEDIA'];
+}
+
 export function createFakeApolloEnvironment(overrides: Partial<Env> = {}): Env {
   return {
     OPENROUTER_MODEL: 'deepseek/deepseek-v4-flash-0731',
@@ -89,6 +134,7 @@ export function createStubDeskToolEffects(
     }),
     listListItems: async () => [],
     removeListItems: async () => ({ removedCount: 0, removedContentList: [] }),
+    callDeviceTool: async () => ({ ok: false, summary: 'stub' }),
     ...overrides,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { routeAgentRequest } from 'agents';
 import { Sandbox } from '@cloudflare/sandbox';
 
 import { authorizeApolloConnection, Apollo } from '@/agents/apollo';
+import { handleOtaRequest } from '@/ota/routes';
 import { consumeApolloQueueBatch } from '@/queues/consume';
 import { ApolloBackground } from '@/workflows/background';
 import { ApolloCoding } from '@/workflows/coding';
@@ -18,6 +19,10 @@ export default {
         name: 'apollo',
         features: ['session', 'vectorize', 'r2', 'queues', 'workflows'],
       });
+    }
+
+    if (requestUrl.pathname.startsWith('/ota/')) {
+      return handleOtaRequest(request, requestUrl, environment);
     }
 
     const agentResponse = await routeAgentRequest(request, environment, {

--- a/src/mcp/__tests__/bridge.spec.ts
+++ b/src/mcp/__tests__/bridge.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildDeviceToolCallPayload,
+  createDeviceMcpRequestRegistry,
+  summarizeDeviceToolResult,
+} from '@/mcp/bridge';
+
+describe('device mcp request registry', () => {
+  it('assigns monotonically increasing integer ids', () => {
+    const registry = createDeviceMcpRequestRegistry();
+    const firstRequest = registry.createPendingRequest(1000);
+    const secondRequest = registry.createPendingRequest(1000);
+    expect(firstRequest.requestId).toBe(1);
+    expect(secondRequest.requestId).toBe(2);
+  });
+
+  it('resolves a pending request by id', async () => {
+    const registry = createDeviceMcpRequestRegistry();
+    const { requestId, responsePromise } = registry.createPendingRequest(1000);
+    const didResolve = registry.resolvePendingRequest({
+      jsonrpc: '2.0',
+      id: requestId,
+      result: { content: [{ type: 'text', text: 'true' }], isError: false },
+    });
+    expect(didResolve).toBe(true);
+    await expect(responsePromise).resolves.toMatchObject({ id: requestId });
+  });
+
+  it('resolves with undefined on timeout', async () => {
+    const registry = createDeviceMcpRequestRegistry();
+    const { responsePromise } = registry.createPendingRequest(5);
+    await expect(responsePromise).resolves.toBeUndefined();
+  });
+
+  it('drops responses for unknown or already resolved ids', async () => {
+    const registry = createDeviceMcpRequestRegistry();
+    const { requestId, responsePromise } = registry.createPendingRequest(1000);
+    const responsePayload = { jsonrpc: '2.0' as const, id: requestId, result: {} };
+    expect(registry.resolvePendingRequest({ ...responsePayload, id: 999 })).toBe(false);
+    expect(registry.resolvePendingRequest(responsePayload)).toBe(true);
+    expect(registry.resolvePendingRequest(responsePayload)).toBe(false);
+    await responsePromise;
+  });
+});
+
+describe('device tool call payload', () => {
+  it('builds a tools/call request the firmware accepts', () => {
+    expect(
+      buildDeviceToolCallPayload(7, 'self.audio_speaker.set_volume', { volume: 40 }),
+    ).toEqual({
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'tools/call',
+      params: { name: 'self.audio_speaker.set_volume', arguments: { volume: 40 } },
+    });
+  });
+});
+
+describe('device tool result summary', () => {
+  it('reports a timeout when there is no response', () => {
+    expect(summarizeDeviceToolResult(undefined)).toEqual({
+      ok: false,
+      summary: 'El dispositivo no respondió a tiempo.',
+    });
+  });
+
+  it('reports the device error message', () => {
+    const summarized = summarizeDeviceToolResult({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { message: 'Unknown tool: nope' },
+    });
+    expect(summarized.ok).toBe(false);
+    expect(summarized.summary).toContain('Unknown tool: nope');
+  });
+
+  it('unwraps text content from a successful call', () => {
+    expect(
+      summarizeDeviceToolResult({
+        jsonrpc: '2.0',
+        id: 1,
+        result: { content: [{ type: 'text', text: '{"battery":80}' }], isError: false },
+      }),
+    ).toEqual({ ok: true, summary: '{"battery":80}' });
+  });
+
+  it('treats isError content as a failure', () => {
+    const summarized = summarizeDeviceToolResult({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { content: [{ type: 'text', text: 'se rompió' }], isError: true },
+    });
+    expect(summarized).toEqual({ ok: false, summary: 'se rompió' });
+  });
+
+  it('falls back to a generic success on unrecognized result shapes', () => {
+    expect(summarizeDeviceToolResult({ jsonrpc: '2.0', id: 1, result: 42 })).toEqual({
+      ok: true,
+      summary: 'Hecho.',
+    });
+  });
+});

--- a/src/mcp/bridge.ts
+++ b/src/mcp/bridge.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+
+import type { ToolExecutionResult } from '@/tools/types';
+
+export const DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS = 5_000;
+
+export type DeviceMcpRequestPayload = {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly method: string;
+  readonly params?: Record<string, unknown>;
+};
+
+export type DeviceMcpResponsePayload = {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly result?: unknown;
+  readonly error?: {
+    readonly code?: number;
+    readonly message: string;
+  };
+};
+
+export type DeviceMcpRequestRegistry = {
+  readonly createPendingRequest: (timeoutMilliseconds: number) => {
+    readonly requestId: number;
+    readonly responsePromise: Promise<DeviceMcpResponsePayload | undefined>;
+  };
+  readonly resolvePendingRequest: (responsePayload: DeviceMcpResponsePayload) => boolean;
+};
+
+export function createDeviceMcpRequestRegistry(): DeviceMcpRequestRegistry {
+  const pendingRequestMap = new Map<
+    number,
+    {
+      readonly resolveResponse: (
+        responsePayload: DeviceMcpResponsePayload | undefined,
+      ) => void;
+      readonly timeoutHandle: ReturnType<typeof setTimeout>;
+    }
+  >();
+  let nextRequestId = 1;
+
+  function settlePendingRequestById(
+    requestId: number,
+    responsePayload: DeviceMcpResponsePayload | undefined,
+  ): boolean {
+    const pendingRequest = pendingRequestMap.get(requestId);
+    if (pendingRequest === undefined) {
+      return false;
+    }
+    clearTimeout(pendingRequest.timeoutHandle);
+    pendingRequestMap.delete(requestId);
+    pendingRequest.resolveResponse(responsePayload);
+    return true;
+  }
+
+  return {
+    createPendingRequest(timeoutMilliseconds) {
+      const requestId = nextRequestId;
+      nextRequestId += 1;
+      const responsePromise = new Promise<DeviceMcpResponsePayload | undefined>(
+        (resolve) => {
+          const timeoutHandle = setTimeout(
+            () => settlePendingRequestById(requestId, undefined),
+            timeoutMilliseconds,
+          );
+          pendingRequestMap.set(requestId, { resolveResponse: resolve, timeoutHandle });
+        },
+      );
+      return { requestId, responsePromise };
+    },
+    resolvePendingRequest(responsePayload) {
+      return settlePendingRequestById(responsePayload.id, responsePayload);
+    },
+  };
+}
+
+export function buildDeviceToolCallPayload(
+  requestId: number,
+  deviceToolName: string,
+  argumentRecord: Record<string, unknown>,
+): DeviceMcpRequestPayload {
+  return {
+    jsonrpc: '2.0',
+    id: requestId,
+    method: 'tools/call',
+    params: { name: deviceToolName, arguments: argumentRecord },
+  };
+}
+
+// Shape produced by the firmware's McpTool::Call: text entries under content,
+// plus an isError flag.
+const deviceToolCallResultSchema = z.object({
+  content: z
+    .array(z.object({ type: z.string(), text: z.string().optional() }))
+    .optional(),
+  isError: z.boolean().optional(),
+});
+
+export function summarizeDeviceToolResult(
+  responsePayload: DeviceMcpResponsePayload | undefined,
+): ToolExecutionResult {
+  if (responsePayload === undefined) {
+    return { ok: false, summary: 'El dispositivo no respondió a tiempo.' };
+  }
+  if (responsePayload.error !== undefined) {
+    return {
+      ok: false,
+      summary: `El dispositivo rechazó la orden: ${responsePayload.error.message}`,
+    };
+  }
+  const parsedResult = deviceToolCallResultSchema.safeParse(responsePayload.result);
+  if (!parsedResult.success) {
+    return { ok: true, summary: 'Hecho.' };
+  }
+  const textContent = (parsedResult.data.content ?? [])
+    .map((contentEntry) => contentEntry.text)
+    .filter((text): text is string => typeof text === 'string')
+    .join('\n');
+  if (parsedResult.data.isError === true) {
+    return {
+      ok: false,
+      summary: textContent === '' ? 'El dispositivo devolvió un error.' : textContent,
+    };
+  }
+  return { ok: true, summary: textContent === '' ? 'Hecho.' : textContent };
+}

--- a/src/ota/__tests__/manifest.spec.ts
+++ b/src/ota/__tests__/manifest.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createFakeMediaBucket } from '@/configuration/testing';
+import { FIRMWARE_MANIFEST_OBJECT_KEY, readFirmwareManifest } from '@/ota/manifest';
+
+describe('firmware manifest', () => {
+  it('parses a valid manifest', async () => {
+    const mediaBucket = createFakeMediaBucket({
+      [FIRMWARE_MANIFEST_OBJECT_KEY]: JSON.stringify({
+        version: '2.5.0',
+        key: 'firmware/apollo-2.5.0.bin',
+      }),
+    });
+    await expect(readFirmwareManifest(mediaBucket)).resolves.toEqual({
+      version: '2.5.0',
+      key: 'firmware/apollo-2.5.0.bin',
+    });
+  });
+
+  it('returns undefined when the manifest object is missing', async () => {
+    await expect(readFirmwareManifest(createFakeMediaBucket())).resolves.toBeUndefined();
+  });
+
+  it('returns undefined on unparseable JSON', async () => {
+    const mediaBucket = createFakeMediaBucket({
+      [FIRMWARE_MANIFEST_OBJECT_KEY]: 'not json at all',
+    });
+    await expect(readFirmwareManifest(mediaBucket)).resolves.toBeUndefined();
+  });
+
+  it('rejects versions the device version parser would abort on', async () => {
+    for (const dangerousVersion of ['2.5.0-beta', 'latest', 'v2.5.0', '2..0', '']) {
+      const mediaBucket = createFakeMediaBucket({
+        [FIRMWARE_MANIFEST_OBJECT_KEY]: JSON.stringify({
+          version: dangerousVersion,
+          key: 'firmware/apollo.bin',
+        }),
+      });
+      await expect(readFirmwareManifest(mediaBucket)).resolves.toBeUndefined();
+    }
+  });
+
+  it('rejects a manifest without a key', async () => {
+    const mediaBucket = createFakeMediaBucket({
+      [FIRMWARE_MANIFEST_OBJECT_KEY]: JSON.stringify({ version: '2.5.0', key: '' }),
+    });
+    await expect(readFirmwareManifest(mediaBucket)).resolves.toBeUndefined();
+  });
+});

--- a/src/ota/__tests__/routes.spec.ts
+++ b/src/ota/__tests__/routes.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  createFakeApolloEnvironment,
+  createFakeMediaBucket,
+} from '@/configuration/testing';
+import { FIRMWARE_MANIFEST_OBJECT_KEY } from '@/ota/manifest';
+import { handleOtaRequest } from '@/ota/routes';
+
+const FIRMWARE_BINARY_CONTENT = 'pretend-firmware-bytes';
+
+function createEnvironmentWithFirmware(): Env {
+  return createFakeApolloEnvironment({
+    MEDIA: createFakeMediaBucket({
+      [FIRMWARE_MANIFEST_OBJECT_KEY]: JSON.stringify({
+        version: '2.5.0',
+        key: 'firmware/apollo-2.5.0.bin',
+      }),
+      'firmware/apollo-2.5.0.bin': FIRMWARE_BINARY_CONTENT,
+    }),
+  });
+}
+
+async function performOtaRequest(
+  environment: Env,
+  path: string,
+  method = 'GET',
+): Promise<Response> {
+  const requestUrl = new URL(`https://apollo.example${path}`);
+  return handleOtaRequest(new Request(requestUrl, { method }), requestUrl, environment);
+}
+
+describe('ota routes', () => {
+  it('rejects a missing or wrong token on both paths', async () => {
+    const environment = createEnvironmentWithFirmware();
+    expect((await performOtaRequest(environment, '/ota/check')).status).toBe(401);
+    expect((await performOtaRequest(environment, '/ota/check?token=wrong')).status).toBe(
+      401,
+    );
+    expect(
+      (await performOtaRequest(environment, '/ota/firmware.bin?token=wrong')).status,
+    ).toBe(401);
+  });
+
+  it('answers the check with the manifest version and a tokenized binary url', async () => {
+    const checkResponse = await performOtaRequest(
+      createEnvironmentWithFirmware(),
+      '/ota/check?token=secret',
+      'POST',
+    );
+    expect(checkResponse.status).toBe(200);
+    await expect(checkResponse.json()).resolves.toEqual({
+      firmware: {
+        version: '2.5.0',
+        url: 'https://apollo.example/ota/firmware.bin?token=secret',
+        force: 0,
+      },
+    });
+  });
+
+  it('answers the check with an empty object when no manifest is published', async () => {
+    const environment = createFakeApolloEnvironment({ MEDIA: createFakeMediaBucket() });
+    const checkResponse = await performOtaRequest(environment, '/ota/check?token=secret');
+    expect(checkResponse.status).toBe(200);
+    await expect(checkResponse.json()).resolves.toEqual({});
+  });
+
+  it('serves the firmware binary with an explicit content length', async () => {
+    const binaryResponse = await performOtaRequest(
+      createEnvironmentWithFirmware(),
+      '/ota/firmware.bin?token=secret',
+    );
+    expect(binaryResponse.status).toBe(200);
+    expect(binaryResponse.headers.get('Content-Length')).toBe(
+      String(FIRMWARE_BINARY_CONTENT.length),
+    );
+    expect(binaryResponse.headers.get('Content-Type')).toBe('application/octet-stream');
+    await expect(binaryResponse.text()).resolves.toBe(FIRMWARE_BINARY_CONTENT);
+  });
+
+  it('returns 404 when the manifest points at a missing binary', async () => {
+    const environment = createFakeApolloEnvironment({
+      MEDIA: createFakeMediaBucket({
+        [FIRMWARE_MANIFEST_OBJECT_KEY]: JSON.stringify({
+          version: '2.5.0',
+          key: 'firmware/not-uploaded.bin',
+        }),
+      }),
+    });
+    expect(
+      (await performOtaRequest(environment, '/ota/firmware.bin?token=secret')).status,
+    ).toBe(404);
+  });
+
+  it('returns 404 for unknown ota paths', async () => {
+    expect(
+      (await performOtaRequest(createEnvironmentWithFirmware(), '/ota/nope?token=secret'))
+        .status,
+    ).toBe(404);
+  });
+});

--- a/src/ota/manifest.ts
+++ b/src/ota/manifest.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const FIRMWARE_MANIFEST_OBJECT_KEY = 'firmware/latest.json';
+
+// The device's Ota::ParseVersion runs std::stoi per dot-segment with no
+// try/catch: a non-numeric version in the manifest aborts the firmware.
+const firmwareVersionPattern = /^\d+(\.\d+)*$/;
+
+export const firmwareManifestSchema = z.object({
+  version: z.string().regex(firmwareVersionPattern),
+  key: z.string().min(1),
+});
+
+export type FirmwareManifest = z.infer<typeof firmwareManifestSchema>;
+
+// A broken upload must degrade to "no update available", never to a malformed
+// firmware section the device would try to parse.
+export async function readFirmwareManifest(
+  mediaBucket: R2Bucket,
+): Promise<FirmwareManifest | undefined> {
+  try {
+    const manifestObject = await mediaBucket.get(FIRMWARE_MANIFEST_OBJECT_KEY);
+    if (manifestObject === null) {
+      return undefined;
+    }
+    const parsedManifest = firmwareManifestSchema.safeParse(await manifestObject.json());
+    return parsedManifest.success ? parsedManifest.data : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/ota/routes.ts
+++ b/src/ota/routes.ts
@@ -1,0 +1,68 @@
+import { isDeviceSharedSecretValid, readDeviceTokenFromRequestUrl } from '@/auth/token';
+import { readFirmwareManifest } from '@/ota/manifest';
+
+export async function handleOtaRequest(
+  request: Request,
+  requestUrl: URL,
+  environment: Env,
+): Promise<Response> {
+  const presentedToken = readDeviceTokenFromRequestUrl(requestUrl);
+  const isAuthorized = await isDeviceSharedSecretValid(
+    presentedToken,
+    environment.DEVICE_SHARED_SECRET,
+  );
+  if (!isAuthorized || presentedToken === null) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  // The device POSTs its system-info JSON on the check; the body is irrelevant
+  // to the answer, so both methods are accepted and the body is ignored.
+  if (requestUrl.pathname === '/ota/check') {
+    return respondWithVersionCheck(requestUrl, presentedToken, environment);
+  }
+  if (requestUrl.pathname === '/ota/firmware.bin' && request.method === 'GET') {
+    return respondWithFirmwareBinary(environment);
+  }
+  return new Response('Not found', { status: 404 });
+}
+
+async function respondWithVersionCheck(
+  requestUrl: URL,
+  presentedToken: string,
+  environment: Env,
+): Promise<Response> {
+  const firmwareManifest = await readFirmwareManifest(environment.MEDIA);
+  if (firmwareManifest === undefined) {
+    return Response.json({});
+  }
+  // The device fetches this URL verbatim with a bare HTTP client (no auth
+  // seam), so the token rides in the query like the websocket URL does.
+  const firmwareBinaryUrl = new URL('/ota/firmware.bin', requestUrl.origin);
+  firmwareBinaryUrl.searchParams.set('token', presentedToken);
+  return Response.json({
+    firmware: {
+      version: firmwareManifest.version,
+      url: firmwareBinaryUrl.toString(),
+      force: 0,
+    },
+  });
+}
+
+async function respondWithFirmwareBinary(environment: Env): Promise<Response> {
+  const firmwareManifest = await readFirmwareManifest(environment.MEDIA);
+  if (firmwareManifest === undefined) {
+    return new Response('No firmware published', { status: 404 });
+  }
+  const firmwareObject = await environment.MEDIA.get(firmwareManifest.key);
+  if (firmwareObject === null) {
+    return new Response('Firmware binary missing', { status: 404 });
+  }
+  // The device's Ota::Upgrade aborts on a missing Content-Length and uses it
+  // for download progress, so the size header is mandatory.
+  return new Response(firmwareObject.body, {
+    headers: {
+      'Content-Length': String(firmwareObject.size),
+      'Content-Type': 'application/octet-stream',
+    },
+  });
+}

--- a/src/protocol/__tests__/schema.spec.ts
+++ b/src/protocol/__tests__/schema.spec.ts
@@ -158,4 +158,78 @@ describe('protocol schema', () => {
       }),
     ).toThrow();
   });
+
+  it('parses mcp responses with result or error', () => {
+    expect(
+      parseDeviceToServerMessage({
+        type: 'mcp',
+        payload: {
+          jsonrpc: '2.0',
+          id: 3,
+          result: { content: [{ type: 'text', text: 'true' }], isError: false },
+        },
+        ts: 6,
+      }).type,
+    ).toBe('mcp');
+    expect(
+      parseDeviceToServerMessage({
+        type: 'mcp',
+        payload: { jsonrpc: '2.0', id: 4, error: { message: 'Unknown tool' } },
+        ts: 7,
+      }).type,
+    ).toBe('mcp');
+  });
+
+  it('rejects mcp responses without an integer id or without ts', () => {
+    expect(() =>
+      parseDeviceToServerMessage({
+        type: 'mcp',
+        payload: { jsonrpc: '2.0', id: 'abc', result: {} },
+        ts: 8,
+      }),
+    ).toThrow();
+    expect(() =>
+      parseDeviceToServerMessage({
+        type: 'mcp',
+        payload: { jsonrpc: '2.0', id: 5, result: {} },
+      }),
+    ).toThrow();
+  });
+
+  it('encodes mcp tool calls', () => {
+    expect(
+      JSON.parse(
+        encodeServerToDeviceMessage({
+          type: 'mcp',
+          payload: {
+            jsonrpc: '2.0',
+            id: 9,
+            method: 'tools/call',
+            params: { name: 'self.audio_speaker.set_volume', arguments: { volume: 40 } },
+          },
+        }),
+      ),
+    ).toEqual({
+      type: 'mcp',
+      payload: {
+        jsonrpc: '2.0',
+        id: 9,
+        method: 'tools/call',
+        params: { name: 'self.audio_speaker.set_volume', arguments: { volume: 40 } },
+      },
+    });
+  });
+
+  it('rejects outbound mcp calls with a string id', () => {
+    expect(() =>
+      encodeServerToDeviceMessage({
+        type: 'mcp',
+        payload: {
+          jsonrpc: '2.0',
+          id: '9' as never,
+          method: 'tools/call',
+        },
+      }),
+    ).toThrow();
+  });
 });

--- a/src/protocol/schema.ts
+++ b/src/protocol/schema.ts
@@ -84,6 +84,21 @@ export const deviceToServerMessageSchema = z.discriminatedUnion('type', [
     firmwareVersion: z.string().min(1).optional(),
     ts: z.number().int().nonnegative(),
   }),
+  z.object({
+    type: z.literal('mcp'),
+    payload: z.object({
+      jsonrpc: z.literal('2.0'),
+      id: z.number().int(),
+      result: z.unknown().optional(),
+      error: z
+        .object({
+          code: z.number().int().optional(),
+          message: z.string().min(1),
+        })
+        .optional(),
+    }),
+    ts: z.number().int().nonnegative(),
+  }),
 ]);
 
 export type DeviceToServerMessage = z.infer<typeof deviceToServerMessageSchema>;
@@ -145,6 +160,17 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('play_effect'),
     name: deskSoundEffectSchema,
+  }),
+  z.object({
+    type: z.literal('mcp'),
+    payload: z.object({
+      jsonrpc: z.literal('2.0'),
+      // The device's McpServer silently drops string ids, so the integer
+      // constraint here is what keeps every request answerable.
+      id: z.number().int(),
+      method: z.string().min(1),
+      params: z.record(z.unknown()).optional(),
+    }),
   }),
 ]);
 

--- a/src/tools/__tests__/device.spec.ts
+++ b/src/tools/__tests__/device.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  createFakeApolloEnvironment,
+  createStubDeskToolEffects,
+} from '@/configuration/testing';
+import {
+  DEVICE_BRIGHTNESS_TOOL_NAME,
+  DEVICE_STATUS_TOOL_NAME,
+  DEVICE_VOLUME_TOOL_NAME,
+  deviceStatusTool,
+  setBrightnessTool,
+  setVolumeTool,
+} from '@/tools/device';
+import type { ToolExecutionContext } from '@/tools/types';
+
+function createContextWithDeviceCallRecorder(
+  deviceResponse = { ok: true, summary: 'true' },
+): {
+  context: ToolExecutionContext;
+  readCallList: () => readonly {
+    deviceToolName: string;
+    argumentRecord: Record<string, unknown>;
+  }[];
+} {
+  const callList: { deviceToolName: string; argumentRecord: Record<string, unknown> }[] =
+    [];
+  const context: ToolExecutionContext = {
+    environment: createFakeApolloEnvironment(),
+    nowMilliseconds: 0,
+    effects: createStubDeskToolEffects({
+      callDeviceTool: async (input) => {
+        callList.push(input);
+        return deviceResponse;
+      },
+    }),
+  };
+  return { context, readCallList: () => callList };
+}
+
+describe('set_volume', () => {
+  it('calls the firmware volume tool and answers in percent', async () => {
+    const { context, readCallList } = createContextWithDeviceCallRecorder();
+    const result = await setVolumeTool.handler({ volume: 40 }, context);
+    expect(result).toEqual({ ok: true, summary: 'Volumen al 40%.' });
+    expect(readCallList()).toEqual([
+      { deviceToolName: DEVICE_VOLUME_TOOL_NAME, argumentRecord: { volume: 40 } },
+    ]);
+  });
+
+  it('rejects out-of-range volumes before touching the device', async () => {
+    const { context, readCallList } = createContextWithDeviceCallRecorder();
+    await expect(setVolumeTool.handler({ volume: 140 }, context)).rejects.toThrow();
+    expect(readCallList()).toHaveLength(0);
+  });
+
+  it('passes device failures through', async () => {
+    const { context } = createContextWithDeviceCallRecorder({
+      ok: false,
+      summary: 'El dispositivo no está conectado.',
+    });
+    await expect(setVolumeTool.handler({ volume: 10 }, context)).resolves.toEqual({
+      ok: false,
+      summary: 'El dispositivo no está conectado.',
+    });
+  });
+
+  it('fails without effects', async () => {
+    const result = await setVolumeTool.handler(
+      { volume: 10 },
+      { environment: createFakeApolloEnvironment(), nowMilliseconds: 0 },
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('set_brightness', () => {
+  it('calls the firmware brightness tool', async () => {
+    const { context, readCallList } = createContextWithDeviceCallRecorder();
+    const result = await setBrightnessTool.handler({ brightness: 20 }, context);
+    expect(result).toEqual({ ok: true, summary: 'Brillo al 20%.' });
+    expect(readCallList()).toEqual([
+      { deviceToolName: DEVICE_BRIGHTNESS_TOOL_NAME, argumentRecord: { brightness: 20 } },
+    ]);
+  });
+});
+
+describe('device_status', () => {
+  it('parses the status JSON into data', async () => {
+    const { context, readCallList } = createContextWithDeviceCallRecorder({
+      ok: true,
+      summary: '{"audio_speaker":{"volume":70},"battery":{"level":81}}',
+    });
+    const result = await deviceStatusTool.handler({}, context);
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      audio_speaker: { volume: 70 },
+      battery: { level: 81 },
+    });
+    expect(readCallList()).toEqual([
+      { deviceToolName: DEVICE_STATUS_TOOL_NAME, argumentRecord: {} },
+    ]);
+  });
+
+  it('keeps the raw summary when the status is not JSON', async () => {
+    const { context } = createContextWithDeviceCallRecorder({
+      ok: true,
+      summary: 'not json',
+    });
+    await expect(deviceStatusTool.handler({}, context)).resolves.toEqual({
+      ok: true,
+      summary: 'not json',
+    });
+  });
+});

--- a/src/tools/__tests__/intent.spec.ts
+++ b/src/tools/__tests__/intent.spec.ts
@@ -70,6 +70,10 @@ function createRecordingEffects(): DeskToolEffects & {
     enqueueCodingTask: async ({ repository, task }) => {
       calls.push(`coding:${repository}:${task}`);
     },
+    callDeviceTool: async ({ deviceToolName }) => {
+      calls.push(`device:${deviceToolName}`);
+      return { ok: true, summary: 'true' };
+    },
     scheduleReminder: async ({ delaySeconds, message }) => {
       calls.push(`remind:${delaySeconds}:${message}`);
     },

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -1,4 +1,5 @@
 import { startCodingTaskTool } from '@/tools/coding';
+import { deviceStatusTool, setBrightnessTool, setVolumeTool } from '@/tools/device';
 import { dollarRateTool } from '@/tools/dollar';
 import { sendEmailTool } from '@/tools/email';
 import { setFocusTool, clearFocusTool } from '@/tools/focus';
@@ -35,6 +36,9 @@ export function listBuiltinToolDefinitionList(): readonly ToolDefinition[] {
     readListTool,
     removeFromListTool,
     dollarRateTool,
+    setVolumeTool,
+    setBrightnessTool,
+    deviceStatusTool,
     sendEmailTool,
     sandboxRunCodeTool,
     sandboxExecTool,

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+
+import type { ToolDefinition, ToolExecutionResult } from '@/tools/types';
+
+export const DEVICE_VOLUME_TOOL_NAME = 'self.audio_speaker.set_volume';
+export const DEVICE_BRIGHTNESS_TOOL_NAME = 'self.screen.set_brightness';
+export const DEVICE_STATUS_TOOL_NAME = 'self.get_device_status';
+
+const setVolumeArgsSchema = z.object({
+  volume: z.number().int().min(0).max(100),
+});
+
+const setBrightnessArgsSchema = z.object({
+  brightness: z.number().int().min(0).max(100),
+});
+
+export const setVolumeTool: ToolDefinition = {
+  name: 'set_volume',
+  safety: 'safe',
+  description: 'Cambia el volumen del parlante del dispositivo (0 a 100)',
+  parameters: {
+    type: 'object',
+    properties: {
+      volume: { type: 'number', minimum: 0, maximum: 100 },
+    },
+    required: ['volume'],
+    additionalProperties: false,
+  },
+  async handler(args, context) {
+    if (!context.effects) {
+      return { ok: false, summary: 'Effects no disponibles' };
+    }
+    const parsedArgs = setVolumeArgsSchema.parse(args);
+    const deviceResult = await context.effects.callDeviceTool({
+      deviceToolName: DEVICE_VOLUME_TOOL_NAME,
+      argumentRecord: { volume: parsedArgs.volume },
+    });
+    if (!deviceResult.ok) {
+      return deviceResult;
+    }
+    return { ok: true, summary: `Volumen al ${parsedArgs.volume}%.` };
+  },
+};
+
+export const setBrightnessTool: ToolDefinition = {
+  name: 'set_brightness',
+  safety: 'safe',
+  description: 'Cambia el brillo de la pantalla del dispositivo (0 a 100)',
+  parameters: {
+    type: 'object',
+    properties: {
+      brightness: { type: 'number', minimum: 0, maximum: 100 },
+    },
+    required: ['brightness'],
+    additionalProperties: false,
+  },
+  async handler(args, context) {
+    if (!context.effects) {
+      return { ok: false, summary: 'Effects no disponibles' };
+    }
+    const parsedArgs = setBrightnessArgsSchema.parse(args);
+    const deviceResult = await context.effects.callDeviceTool({
+      deviceToolName: DEVICE_BRIGHTNESS_TOOL_NAME,
+      argumentRecord: { brightness: parsedArgs.brightness },
+    });
+    if (!deviceResult.ok) {
+      return deviceResult;
+    }
+    return { ok: true, summary: `Brillo al ${parsedArgs.brightness}%.` };
+  },
+};
+
+function parseDeviceStatusSummary(
+  deviceResult: ToolExecutionResult,
+): ToolExecutionResult {
+  try {
+    return {
+      ok: true,
+      summary: 'Estado del dispositivo obtenido.',
+      data: JSON.parse(deviceResult.summary) as unknown,
+    };
+  } catch {
+    return deviceResult;
+  }
+}
+
+export const deviceStatusTool: ToolDefinition = {
+  name: 'device_status',
+  safety: 'safe',
+  description: 'Lee el estado actual del dispositivo: volumen, brillo, batería y red',
+  parameters: {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  },
+  async handler(_args, context) {
+    if (!context.effects) {
+      return { ok: false, summary: 'Effects no disponibles' };
+    }
+    const deviceResult = await context.effects.callDeviceTool({
+      deviceToolName: DEVICE_STATUS_TOOL_NAME,
+      argumentRecord: {},
+    });
+    if (!deviceResult.ok) {
+      return deviceResult;
+    }
+    return parseDeviceStatusSummary(deviceResult);
+  },
+};

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -65,6 +65,10 @@ export type DeskToolEffects = {
     readonly removedCount: number;
     readonly removedContentList: readonly string[];
   }>;
+  readonly callDeviceTool: (input: {
+    readonly deviceToolName: string;
+    readonly argumentRecord: Record<string, unknown>;
+  }) => Promise<ToolExecutionResult>;
 };
 
 export type ToolExecutionContext = {


### PR DESCRIPTION
## What

Roadmap items **14 (OTA from R2)** and **5 (device-side MCP)** — item 13 (`set_volume`) comes free through the bridge. Firmware counterpart: [apollo-firmware#1](https://github.com/galfrevn/apollo-firmware/pull/1) (submodule bumped here to that branch's commit, version 2.5.0).

### OTA from R2 (`src/ota/`)
- `GET|POST /ota/check` — token-authenticated (same `?token=` shared secret as the websocket); answers `{"firmware":{"version","url","force":0}}` from `firmware/latest.json` in the `MEDIA` bucket, or `{}` when nothing is published. A missing/broken manifest always degrades to "no update", never to a malformed response.
- `GET /ota/firmware.bin` — streams the manifest's binary with an explicit `Content-Length` (the device's `Ota::Upgrade` aborts on length-less downloads).
- Manifest versions are validated against `/^\d+(\.\d+)*$/` — a device-safety control, not cosmetics: the firmware's version parser runs `std::stoi` per segment and a `2.5.0-beta` would abort the device.

### Device MCP bridge (`src/mcp/`, `src/tools/device.ts`)
- `mcp` frames added to both directions of the protocol schema, carrying raw JSON-RPC. Ids are constrained to **integers** — the device silently drops string ids.
- `createDeviceMcpRequestRegistry` correlates request/response by id with a 5 s timeout, awaited inside the tool handler (the turn loop awaits tools sequentially, so this is safe). Disconnected device or timeout become spoken "no está conectado / no respondió" results.
- Three tools exposed to the agent: `set_volume`, `set_brightness`, `device_status` (status JSON parsed into `data`). The device's user-only tools (`self.reboot`, `self.upgrade_firmware`) remain callable from server code — the future push-OTA path — but are not exposed to the LLM.

### Docs
`protocol.md` (wire contract for `mcp` + the OTA endpoints), `deploy.md` (R2 publishing steps, app-image-not-merged-binary warning), `roadmap.md` (items 5/13/14).

## Verification

- 297 tests pass (30 new: manifest, routes, bridge, device tools, schema), `tsc`, `oxlint`, `oxfmt` all clean.
- Firmware builds clean at 2.5.0 (2.6 MB, 35% free in the OTA slot).
- Remaining ops after merge, in order: deploy worker → upload `build/xiaozhi.bin` + manifest to R2 → curl smoke both endpoints → **last cable flash** of 2.5.0 → voice-test volume/brightness/status → publish 2.5.1 and watch the self-update, rebooting twice to confirm rollback stays cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds authenticated OTA delivery from R2 and bridges agent tools to the device's embedded MCP server.
- Adds manifest validation and OTA check/binary routes.
- Adds integer-ID MCP request correlation, timeout handling, and protocol schemas.
- Exposes volume, brightness, and device-status tools to the agent.
- Updates firmware, deployment, protocol, and roadmap documentation.
- Device status parsing still bypasses the repository's external-input validation requirement.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking need to validate device-status JSON before exposing it as tool data.

The OTA and MCP paths have no established blocking failure, but device_status currently accepts any syntactically valid JSON as successful structured status data.

**Files Needing Attention:** src/tools/device.ts
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Ftools%2Fdevice.ts%3A75%0A**Device%20status%20bypasses%20validation**%0A%0A%60device_status%60%20exposes%20the%20result%20of%20%60JSON.parse%60%20directly%20as%20tool%20data%2C%20so%20any%20syntactically%20valid%20but%20unsupported%20device%20response%20shape%20is%20treated%20as%20successful%20structured%20status%20data.%20Validate%20the%20parsed%20external%20input%20with%20a%20Zod%20schema%20before%20returning%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=galfrevn%2Fapollo&pr=13&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(device): OTA from R2 and the device..."](https://github.com/galfrevn/apollo/commit/3173d47943e87d705cad33d04b383d677f0fddac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51968510)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Type safety, comments, and modularity rules for al... ([source](https://github.com/galfrevn/apollo/blob/main/.cursor/rules/quality.mdc))

<!-- /greptile_comment -->