### PR TITLE
feat(ci): deploy the worker on every push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 # Deploys the worker on every push to main, after a fresh test run in this
 # job — hermetic on purpose, so the gate holds even if ci.yml changes.
-# Doc-only merges skip it. Requires two repository secrets:
+# Doc-only merges skip it. Requires a `production` environment limited to the
+# main branch, holding two secrets:
 #   CLOUDFLARE_API_TOKEN   Workers deploy rights on the account
 #   CLOUDFLARE_ACCOUNT_ID  the Cloudflare account id
 name: Deploy
@@ -26,11 +27,19 @@ concurrency:
 jobs:
   deploy:
     name: Deploy worker
+    # workflow_dispatch lets the caller pick any ref, so the job refuses
+    # everything but main. The real gate is the `production` environment: its
+    # branch rule rejects other refs and the credentials live only there, so a
+    # branch that edits this file out of the way still can't reach them.
+    if: github.ref == 'refs/heads/main'
+    environment: production
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+# Deploys the worker on every push to main, after a fresh test run in this
+# job — hermetic on purpose, so the gate holds even if ci.yml changes.
+# Doc-only merges skip it. Requires two repository secrets:
+#   CLOUDFLARE_API_TOKEN   Workers deploy rights on the account
+#   CLOUDFLARE_ACCOUNT_ID  the Cloudflare account id
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'documentation/**'
+      - '.cursor/**'
+      - '.vscode/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run tests
+        run: bun test
+
+      # wrangler builds the Sandbox container image as part of the deploy,
+      # which is why this runs on the runner's Docker daemon.
+      - name: Deploy
+        run: bun run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What

The worker counterpart of [apollo-firmware#2](https://github.com/galfrevn/apollo-firmware/pull/2): merging to `main` deploys automatically, so both halves of the system now ship the same way — merge and it's live (the firmware after the device's next power cycle, the worker within a minute).

- Runs `bun test` inside the job before `bun run deploy` — hermetic on purpose, so the deploy gate holds regardless of how `ci.yml` evolves. Lint/format/secret-scan still run in parallel via the existing CI.
- `typecheck` is deliberately not in the gate, matching the existing CI (the generated `worker-configuration.d.ts` is gitignored and regenerating it needs manual fixups).
- Doc-only merges (`**.md`, `documentation/`, `.cursor/`, `.vscode/`) skip the deploy.
- `concurrency: deploy` serializes overlapping merges; `workflow_dispatch` allows manual runs, but only from `main`.
- The Sandbox container image builds on the runner's Docker daemon as part of the deploy, as it does locally.
- Only `main` ever deploys. A manual dispatch can name any ref, so the job carries `if: github.ref == 'refs/heads/main'` — and, more importantly, the credentials live in a `production` environment whose branch rule rejects everything but `main`. A branch that edits the guard out of the workflow still can't reach the token.
- `actions/checkout` is pinned to a full commit SHA so a moved upstream tag can't change what runs next to those credentials, and `persist-credentials: false` drops the `GITHUB_TOKEN` the deploy has no use for.

## Setup (before merging)

Create a `production` environment (Settings → Environments → New environment), set **Deployment branches** to *Selected branches* → `main`, and add two **environment** secrets to it:

| Secret | Value |
|---|---|
| `CLOUDFLARE_API_TOKEN` | token with Workers deploy rights (can be the same token as the firmware repo's if it also has R2 access) |
| `CLOUDFLARE_ACCOUNT_ID` | the Cloudflare account id |

Environment secrets rather than repository secrets on purpose: a repository secret is readable by any workflow on any branch, which would defeat the branch rule above.

Runtime secrets (`DEVICE_SHARED_SECRET`, API keys…) are untouched — they live on the worker and deploys don't modify them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a production deployment workflow that deploys the worker after tests pass on pushes to `main` or approved manual runs.
- Skips deployment for documentation-only changes.
- Serializes deployments through a shared concurrency group.
- Restricts the job to `main` and scopes credentials through the `production` environment.
- Pins checkout to a full commit SHA and disables persisted GitHub credentials.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the workflow now rejects non-main manual refs, uses the protected production environment, and pins checkout to a full commit SHA.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): gate the deploy job on a protec..."](https://github.com/galfrevn/apollo/commit/223e0a92ca5077253f4e75ef276bd162a64fbcbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52008604)</sub>

<!-- /greptile_comment -->