### PR TITLE
feat(confirm): confirm_close tells the device the confirmation window ended

### DIFF
--- a/documentation/capabilities/tools.md
+++ b/documentation/capabilities/tools.md
@@ -26,7 +26,10 @@ The router resolves tool names to definitions, validates inputs, and coordinates
 A tool asks for confirmation when — and only when — its definition is `safety: 'unsafe'`
 (`src/tools/router.ts`). The router then returns `needs_confirm` instead of running the
 handler, the agent emits `confirm_request`, and the side effect waits for the device's
-`confirm` (or the 30 s expiry).
+`confirm` (or the 30 s expiry). On firmware with the confirm screen, that message
+replaces the face with the summary plus Sí/No touch buttons. However the window ends —
+button, dashboard RPC, expiry, orphan cleanup — the agent broadcasts `confirm_close`
+so the device never sits on a stale prompt.
 
 The unsafe tools in the shipped catalog are the sandbox pair and `start_coding_task`,
 so the confirmation path — protocol messages, UI `confirm` state, `questioning` face —

--- a/documentation/runtime/protocol.md
+++ b/documentation/runtime/protocol.md
@@ -40,6 +40,7 @@ no-op (it used to mute the microphone and did so invisibly — see `#handleGestu
 |------|------|
 | `ui_state` | Mode, speech mode, caption, focus remaining, face emotion, accent color |
 | `confirm_request` | Ask the user to approve a tool side effect |
+| `confirm_close` | The confirmation window ended (`resolved` / `expired` / `orphaned`), so the device drops its confirm screen |
 | `tts_start` | Announce the next speech clip (one per segment, not one per reply) |
 | `tts_aborted` | The clip announced by `tts_start` was cut short and will never complete |
 | `error` | Structured failure |

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -46,6 +46,7 @@ import { APOLLO_TTS_VOICE } from '@/persona/soul';
 import {
   encodeServerToDeviceMessage,
   parseDeviceToServerMessage,
+  type ConfirmCloseReasonName,
   type DeskSoundEffectName,
   type DeviceToServerMessage,
 } from '@/protocol/schema';
@@ -367,14 +368,22 @@ export class Apollo extends Agent<Env, ApolloState> {
         return;
       }
     }
-    await this.#closePendingConfirmation('Confirmación expirada');
+    await this.#closePendingConfirmation('Confirmación expirada', 'expired');
   }
 
   // Closing a confirmation is the same work however it ends: forget it in
   // memory and on disk, leave the confirm UI state, and tell the device — which
   // is sitting on the confirm screen and never learns the window closed unless
   // it is told.
-  async #closePendingConfirmation(caption: string): Promise<void> {
+  async #closePendingConfirmation(
+    caption: string,
+    reason: 'expired' | 'orphaned',
+  ): Promise<void> {
+    const closingConfirmId =
+      this.state.pendingConfirmId ?? this.#pendingConfirmation?.id ?? null;
+    if (closingConfirmId !== null) {
+      this.#broadcastConfirmClose(closingConfirmId, reason);
+    }
     this.#pendingConfirmation = undefined;
     await deletePendingToolConfirmations(this.#sqlExecutor());
     this.#applyUiEvent('CANCEL');
@@ -671,6 +680,17 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
   }
 
+  #broadcastConfirmClose(confirmId: string, reason: ConfirmCloseReasonName): void {
+    const encodedMessage = encodeServerToDeviceMessage({
+      type: 'confirm_close',
+      id: confirmId,
+      reason,
+    });
+    for (const connection of this.getConnections()) {
+      connection.send(encodedMessage);
+    }
+  }
+
   async #runTurnFromText(connection: Connection, text: string): Promise<void> {
     this.#applyUiEvent('START_LISTEN');
     await this.#executeTurn(connection, { text });
@@ -710,12 +730,14 @@ export class Apollo extends Agent<Env, ApolloState> {
       ) {
         await this.#closePendingConfirmation(
           'Se me perdió esa confirmación, pedímelo de nuevo.',
+          'orphaned',
         );
       }
       return;
     }
     this.#pendingConfirmation = undefined;
     await deletePendingToolConfirmations(this.#sqlExecutor());
+    this.#broadcastConfirmClose(pendingConfirmation.id, 'resolved');
     await this.#executeTurn(connection, {
       text: isApproved ? 'confirmado' : 'cancelado',
       confirmOk: isApproved,

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -811,7 +811,7 @@ export class Apollo extends Agent<Env, ApolloState> {
     });
 
     try {
-      this.#pendingConfirmation = await executeApolloTurn(
+      await executeApolloTurn(
         connection,
         {
           environment: this.env,
@@ -825,6 +825,10 @@ export class Apollo extends Agent<Env, ApolloState> {
           scheduleConfirmExpiry: async (confirmationId) => {
             await this.schedule(30, 'expireConfirm', { confirmationId });
           },
+          persistPendingConfirmation: async (confirmation) => {
+            this.#pendingConfirmation = confirmation;
+            await savePendingToolConfirmation(this.#sqlExecutor(), confirmation);
+          },
           session: this.session,
           deviceId,
           effects: deskToolEffects,
@@ -835,9 +839,6 @@ export class Apollo extends Agent<Env, ApolloState> {
         },
         turnPart,
       );
-      if (this.#pendingConfirmation !== undefined) {
-        await savePendingToolConfirmation(this.#sqlExecutor(), this.#pendingConfirmation);
-      }
     } catch (error) {
       console.error(
         JSON.stringify({
@@ -848,6 +849,10 @@ export class Apollo extends Agent<Env, ApolloState> {
         }),
       );
       this.#pendingConfirmation = undefined;
+      // The confirmation persists before the turn finishes streaming, so a
+      // failure after that point would otherwise leave a resolvable row for a
+      // request the user was just told failed.
+      await deletePendingToolConfirmations(this.#sqlExecutor());
       this.#applyUiEvent('CANCEL');
       this.setState({
         ...this.state,

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -30,6 +30,9 @@ export type ApolloTurnRuntimeDependencies = {
   readonly getCurrentState: () => ApolloState;
   readonly setAgentState: (nextState: ApolloState) => void;
   readonly scheduleConfirmExpiry: (confirmationId: string) => Promise<void>;
+  readonly persistPendingConfirmation: (
+    confirmation: PendingToolConfirmation,
+  ) => Promise<void>;
   readonly session: Session;
   readonly deviceId: string;
   readonly effects: DeskToolEffects;
@@ -46,7 +49,7 @@ export async function executeApolloTurn(
     readonly confirmOk?: boolean;
     readonly pendingConfirmation?: PendingToolConfirmation;
   },
-): Promise<PendingToolConfirmation | undefined> {
+): Promise<void> {
   const nowMilliseconds = Date.now();
   const focusState = tickDeskFocus(
     dependencies.currentState.focusEndsAt === null
@@ -164,6 +167,10 @@ export async function executeApolloTurn(
   }
 
   if (turnOutput.pendingConfirmation !== undefined) {
+    // Persisted before confirm_request goes out below: the device can answer
+    // the moment the screen appears, while the TTS at the bottom of this
+    // function is still streaming, and #resolveConfirm must find it by then.
+    await dependencies.persistPendingConfirmation(turnOutput.pendingConfirmation);
     await dependencies.scheduleConfirmExpiry(turnOutput.pendingConfirmation.id);
   }
 
@@ -289,8 +296,6 @@ export async function executeApolloTurn(
       parts: [{ type: 'text', text: turnOutput.spokenText }],
     });
   }
-
-  return turnOutput.pendingConfirmation;
 }
 
 export function concatenateArrayBufferList(

--- a/src/protocol/__tests__/schema.spec.ts
+++ b/src/protocol/__tests__/schema.spec.ts
@@ -140,6 +140,33 @@ describe('protocol schema', () => {
     ).toMatchObject({ type: 'reminder', message: 'Tomá agua' });
   });
 
+  it('encodes confirm_close for every reason', () => {
+    for (const reason of ['resolved', 'expired', 'orphaned'] as const) {
+      expect(
+        JSON.parse(
+          encodeServerToDeviceMessage({ type: 'confirm_close', id: 'c1', reason }),
+        ),
+      ).toEqual({ type: 'confirm_close', id: 'c1', reason });
+    }
+  });
+
+  it('rejects confirm_close with an empty id or unknown reason', () => {
+    expect(() =>
+      encodeServerToDeviceMessage({
+        type: 'confirm_close',
+        id: '',
+        reason: 'expired',
+      }),
+    ).toThrow();
+    expect(() =>
+      encodeServerToDeviceMessage({
+        type: 'confirm_close',
+        id: 'c1',
+        reason: 'nope' as never,
+      }),
+    ).toThrow();
+  });
+
   it('encodes play_effect for every catalog name', () => {
     for (const effectName of ['ding', 'chime', 'error', 'low_battery'] as const) {
       expect(

--- a/src/protocol/schema.ts
+++ b/src/protocol/schema.ts
@@ -34,6 +34,10 @@ export const deskSoundEffectSchema = z.enum(['ding', 'chime', 'error', 'low_batt
 
 export type DeskSoundEffectName = z.infer<typeof deskSoundEffectSchema>;
 
+export const confirmCloseReasonSchema = z.enum(['resolved', 'expired', 'orphaned']);
+
+export type ConfirmCloseReasonName = z.infer<typeof confirmCloseReasonSchema>;
+
 export const deviceToServerMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('hello'),
@@ -118,6 +122,11 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
     id: z.string().min(1),
     summary: z.string().min(1),
     expiresAt: z.number().int().nonnegative(),
+  }),
+  z.object({
+    type: z.literal('confirm_close'),
+    id: z.string().min(1),
+    reason: confirmCloseReasonSchema,
   }),
   z.object({
     type: z.literal('tts_start'),


### PR DESCRIPTION
Server half of the device confirm screen (firmware PR: galfrevn/apollo-firmware#3).

The device now renders `confirm_request` as a full-screen prompt with Sí/No touch buttons — but it could never learn the window closed elsewhere: the closing `ui_state`'s `state` field is ignored by the firmware, so a confirmation resolved from the dashboard RPC or expired server-side would leave the screen up until its local timer fired.

## What changed

- **`src/protocol/schema.ts`**: new server→device message `confirm_close { id, reason: 'resolved' | 'expired' | 'orphaned' }`.
- **`src/agents/apollo.ts`**: broadcast it at every ending — `#resolveConfirm` (device button, dashboard RPC) as `resolved`, expiry as `expired`, and orphan cleanup as `orphaned`. The id is captured before state is cleared.
- Tests: encode round-trip for every reason, rejection of empty id / unknown reason.

## Compatibility

Old firmware hits the "Ignoring message type" default and behaves exactly as today, so this deploys independently of the flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a server-to-device `confirm_close` protocol message and emits it when confirmation windows resolve, expire, or become orphaned.
- Persists pending confirmations before sending the device prompt.
- Clears persisted confirmations when turn execution subsequently fails.
- Updates protocol tests and documentation for all close reasons.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(confirm): persist the pending confir..."](https://github.com/galfrevn/apollo/commit/51b426a8550f4b4505d6e3ecafc71e5e9198e7e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52024761)</sub>

<!-- /greptile_comment -->