### PR TITLE
feat(coding): resolve spoken repository names against the App's installations

### DIFF
--- a/documentation/capabilities/coding.md
+++ b/documentation/capabilities/coding.md
@@ -15,6 +15,19 @@ Apollo can clone a GitHub repository, change it, run its tests, and open a pull 
 
 The result comes back through the same path as deep research: a short spoken summary, the full run log in R2, and a `background_result` on the wire.
 
+## Naming a repository by voice
+
+Nobody dictates `owner/repo` out loud, so the tool accepts the name however the
+user says it — "apollo", "apollo firmware" — and resolves it against the App's
+installation list (`resolveSpokenRepositoryReference`, `src/github/repository.ts`),
+ignoring case and separators. An exact name wins over a containment; an ambiguous
+name comes back as a spoken question listing the candidates, and an unknown one
+lists what is available instead of asking for a URL. A reference that already
+parses as `owner/repo` or a GitHub URL skips the lookup entirely. The agent can
+also enumerate the options with `list_coding_repositories` — the same
+installation list that acts as the allowlist, read through the App credentials
+(`listGithubAppRepositoryFullNameList`, `src/github/app.ts`).
+
 ## Why the sandbox is disposable
 
 Container disk is ephemeral — when an instance sleeps, it restarts with a fresh disk from the image. So there is nowhere to "leave work in progress": **the git remote is the source of truth**. Every run clones from scratch and ends in a pushed branch. The sandbox runs with `keepAlive` so a 10-minute sleep cannot wipe the workspace mid-run, and is destroyed at the end because billing runs while it is alive.

--- a/src/configuration/testing.ts
+++ b/src/configuration/testing.ts
@@ -78,6 +78,33 @@ export function createFakeMediaBucket(
   return partialBucket as Env['MEDIA'];
 }
 
+export async function buildTestRsaPrivateKeyPem(): Promise<string> {
+  const generatedKey = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  );
+  if (!('privateKey' in generatedKey)) {
+    throw new Error('generateKey did not return a key pair');
+  }
+  const exportedKey = await crypto.subtle.exportKey('pkcs8', generatedKey.privateKey);
+  if (!(exportedKey instanceof ArrayBuffer)) {
+    throw new Error('exportKey did not return pkcs8 bytes');
+  }
+  const pkcs8Bytes = new Uint8Array(exportedKey);
+  let binaryText = '';
+  for (const byte of pkcs8Bytes) {
+    binaryText += String.fromCharCode(byte);
+  }
+  const base64Body = btoa(binaryText).replaceAll(/(.{64})/g, '$1\n');
+  return `-----BEGIN PRIVATE KEY-----\n${base64Body}\n-----END PRIVATE KEY-----`;
+}
+
 export function createFakeApolloEnvironment(overrides: Partial<Env> = {}): Env {
   return {
     OPENROUTER_MODEL: 'deepseek/deepseek-v4-flash-0731',

--- a/src/github/__tests__/app.spec.ts
+++ b/src/github/__tests__/app.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'bun:test';
 
+import { buildTestRsaPrivateKeyPem } from '@/configuration/testing';
 import {
   createGithubInstallationTokenForRepository,
+  listGithubAppRepositoryFullNameList,
   resolveGithubInstallationId,
   signGithubAppJsonWebToken,
 } from '@/github/app';
@@ -11,33 +13,6 @@ type CapturedRequest = {
   readonly url: string;
   readonly init: RequestInit;
 };
-
-async function buildTestPrivateKeyPem(): Promise<string> {
-  const generatedKey = await crypto.subtle.generateKey(
-    {
-      name: 'RSASSA-PKCS1-v1_5',
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: 'SHA-256',
-    },
-    true,
-    ['sign', 'verify'],
-  );
-  if (!('privateKey' in generatedKey)) {
-    throw new Error('generateKey did not return a key pair');
-  }
-  const exportedKey = await crypto.subtle.exportKey('pkcs8', generatedKey.privateKey);
-  if (!(exportedKey instanceof ArrayBuffer)) {
-    throw new Error('exportKey did not return pkcs8 bytes');
-  }
-  const pkcs8Bytes = new Uint8Array(exportedKey);
-  let binaryText = '';
-  for (const byte of pkcs8Bytes) {
-    binaryText += String.fromCharCode(byte);
-  }
-  const base64Body = btoa(binaryText).replaceAll(/(.{64})/g, '$1\n');
-  return `-----BEGIN PRIVATE KEY-----\n${base64Body}\n-----END PRIVATE KEY-----`;
-}
 
 function decodeBase64UrlJson(segment: string): Record<string, unknown> {
   const base64Text = segment.replaceAll('-', '+').replaceAll('_', '/');
@@ -79,7 +54,7 @@ function createFetchMock(
 
 describe('signGithubAppJsonWebToken', () => {
   it('signs an RS256 token whose claims GitHub will accept', async () => {
-    const privateKeyPem = await buildTestPrivateKeyPem();
+    const privateKeyPem = await buildTestRsaPrivateKeyPem();
     const nowMilliseconds = 1_700_000_000_000;
 
     const jsonWebToken = await signGithubAppJsonWebToken({
@@ -117,7 +92,7 @@ describe('signGithubAppJsonWebToken', () => {
   });
 
   it('tolerates a PEM pasted as a single line with escaped newlines', async () => {
-    const privateKeyPem = await buildTestPrivateKeyPem();
+    const privateKeyPem = await buildTestRsaPrivateKeyPem();
     const singleLinePem = privateKeyPem.replaceAll('\n', '\\n');
     await expect(
       signGithubAppJsonWebToken({
@@ -147,7 +122,7 @@ describe('resolveGithubInstallationId', () => {
 
 describe('createGithubInstallationTokenForRepository', () => {
   it('exchanges the app key for an installation token', async () => {
-    const privateKeyPem = await buildTestPrivateKeyPem();
+    const privateKeyPem = await buildTestRsaPrivateKeyPem();
     const { fetchImplementation, callList } = createFetchMock([
       { fragment: '/installation', status: 200, body: { id: 42 } },
       {
@@ -177,6 +152,122 @@ describe('createGithubInstallationTokenForRepository', () => {
     await expect(
       createGithubInstallationTokenForRepository({
         repository: parseGithubRepositoryReference('galfrevn/apollo'),
+        appId: '',
+        privateKeyPem: '',
+        nowMilliseconds: 0,
+        fetchImplementation,
+      }),
+    ).rejects.toThrow(/GITHUB_APP_ID/);
+    expect(callList).toHaveLength(0);
+  });
+});
+
+describe('listGithubAppRepositoryFullNameList', () => {
+  it('aggregates the repositories of every installation', async () => {
+    const privateKeyPem = await buildTestRsaPrivateKeyPem();
+    const { fetchImplementation } = createFetchMock([
+      {
+        fragment: '/app/installations?per_page=100&page=1',
+        status: 200,
+        body: [{ id: 7 }, { id: 9 }],
+      },
+      {
+        fragment: '/access_tokens',
+        status: 201,
+        body: { token: 'ghs_token', expires_at: '2026-08-10T13:00:00Z' },
+      },
+      {
+        fragment: '/installation/repositories?per_page=100&page=1',
+        status: 200,
+        body: {
+          repositories: [
+            { full_name: 'galfrevn/apollo' },
+            { full_name: 'galfrevn/dotfiles' },
+          ],
+        },
+      },
+    ]);
+
+    const fullNameList = await listGithubAppRepositoryFullNameList({
+      appId: '123456',
+      privateKeyPem,
+      nowMilliseconds: 1_700_000_000_000,
+      fetchImplementation,
+    });
+
+    expect(fullNameList).toEqual([
+      'galfrevn/apollo',
+      'galfrevn/dotfiles',
+      'galfrevn/apollo',
+      'galfrevn/dotfiles',
+    ]);
+  });
+
+  it('follows pagination past the first page of repositories', async () => {
+    const privateKeyPem = await buildTestRsaPrivateKeyPem();
+    const firstPageRepositoryList = Array.from({ length: 100 }, (_, index) => ({
+      full_name: `galfrevn/repo-${index}`,
+    }));
+    const { fetchImplementation, callList } = createFetchMock([
+      {
+        fragment: '/app/installations?per_page=100&page=1',
+        status: 200,
+        body: [{ id: 7 }],
+      },
+      {
+        fragment: '/access_tokens',
+        status: 201,
+        body: { token: 'ghs_token', expires_at: '2026-08-10T13:00:00Z' },
+      },
+      {
+        fragment: '/installation/repositories?per_page=100&page=1',
+        status: 200,
+        body: { repositories: firstPageRepositoryList },
+      },
+      {
+        fragment: '/installation/repositories?per_page=100&page=2',
+        status: 200,
+        body: { repositories: [{ full_name: 'galfrevn/repo-100' }] },
+      },
+    ]);
+
+    const fullNameList = await listGithubAppRepositoryFullNameList({
+      appId: '123456',
+      privateKeyPem,
+      nowMilliseconds: 1_700_000_000_000,
+      fetchImplementation,
+    });
+
+    expect(fullNameList).toHaveLength(101);
+    expect(fullNameList.at(-1)).toBe('galfrevn/repo-100');
+    expect(
+      callList.some((request) =>
+        request.url.includes('/installation/repositories?per_page=100&page=2'),
+      ),
+    ).toBe(true);
+  });
+
+  it('surfaces a failed installations listing as an error', async () => {
+    const privateKeyPem = await buildTestRsaPrivateKeyPem();
+    const { fetchImplementation } = createFetchMock([
+      { fragment: '/app/installations', status: 500, body: {} },
+    ]);
+
+    await expect(
+      listGithubAppRepositoryFullNameList({
+        appId: '123456',
+        privateKeyPem,
+        nowMilliseconds: 1_700_000_000_000,
+        fetchImplementation,
+      }),
+    ).rejects.toThrow(/instalaciones/);
+  });
+
+  it('refuses to call GitHub when the app is not configured', async () => {
+    const { fetchImplementation, callList } = createFetchMock([]);
+
+    await expect(
+      listGithubAppRepositoryFullNameList({
         appId: '',
         privateKeyPem: '',
         nowMilliseconds: 0,

--- a/src/github/__tests__/repository.spec.ts
+++ b/src/github/__tests__/repository.spec.ts
@@ -62,6 +62,17 @@ describe('resolveSpokenRepositoryReference', () => {
     });
   });
 
+  it('prefers the longer match when a generically named repository also matches', () => {
+    const listWithGenericName = ['galfrevn/repo', 'galfrevn/apollo'];
+    expect(
+      resolveSpokenRepositoryReference('el repo apollo', listWithGenericName),
+    ).toEqual({ kind: 'match', fullName: 'galfrevn/apollo' });
+    expect(resolveSpokenRepositoryReference('el repo', listWithGenericName)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/repo',
+    });
+  });
+
   it('reports ambiguity instead of guessing', () => {
     const resolution = resolveSpokenRepositoryReference('apol', installedList);
     expect(resolution.kind).toBe('ambiguous');

--- a/src/github/__tests__/repository.spec.ts
+++ b/src/github/__tests__/repository.spec.ts
@@ -8,7 +8,11 @@ import {
 } from '@/github/repository';
 
 describe('resolveSpokenRepositoryReference', () => {
-  const installedList = ['galfrevn/apollo', 'galfrevn/apollo-firmware', 'galfrevn/dotfiles'];
+  const installedList = [
+    'galfrevn/apollo',
+    'galfrevn/apollo-firmware',
+    'galfrevn/dotfiles',
+  ];
 
   it('matches a bare spoken name regardless of case and separators', () => {
     expect(resolveSpokenRepositoryReference('dotfiles', installedList)).toEqual({
@@ -36,6 +40,26 @@ describe('resolveSpokenRepositoryReference', () => {
     expect(
       resolveSpokenRepositoryReference('galfrevn apollo firmware', installedList),
     ).toEqual({ kind: 'match', fullName: 'galfrevn/apollo-firmware' });
+  });
+
+  it('ignores surrounding words in any language without a stopword list', () => {
+    expect(resolveSpokenRepositoryReference('el repo apollo', installedList)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/apollo',
+    });
+    expect(
+      resolveSpokenRepositoryReference('the apollo firmware repository', installedList),
+    ).toEqual({ kind: 'match', fullName: 'galfrevn/apollo-firmware' });
+    expect(
+      resolveSpokenRepositoryReference('mis dotfiles de siempre', installedList),
+    ).toEqual({ kind: 'match', fullName: 'galfrevn/dotfiles' });
+  });
+
+  it('prefers the widest window over its inner names', () => {
+    expect(resolveSpokenRepositoryReference('apollo firmware', installedList)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/apollo-firmware',
+    });
   });
 
   it('reports ambiguity instead of guessing', () => {

--- a/src/github/__tests__/repository.spec.ts
+++ b/src/github/__tests__/repository.spec.ts
@@ -4,7 +4,60 @@ import {
   formatGithubRepositoryReference,
   parseGithubRepositoryReference,
   redactSecretsFromText,
+  resolveSpokenRepositoryReference,
 } from '@/github/repository';
+
+describe('resolveSpokenRepositoryReference', () => {
+  const installedList = ['galfrevn/apollo', 'galfrevn/apollo-firmware', 'galfrevn/dotfiles'];
+
+  it('matches a bare spoken name regardless of case and separators', () => {
+    expect(resolveSpokenRepositoryReference('dotfiles', installedList)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/dotfiles',
+    });
+    expect(resolveSpokenRepositoryReference('Apollo Firmware', installedList)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/apollo-firmware',
+    });
+    expect(resolveSpokenRepositoryReference('apollo_firmware', installedList)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/apollo-firmware',
+    });
+  });
+
+  it('prefers an exact name over a partial containment', () => {
+    expect(resolveSpokenRepositoryReference('apollo', installedList)).toEqual({
+      kind: 'match',
+      fullName: 'galfrevn/apollo',
+    });
+  });
+
+  it('matches a spoken full name with the owner attached', () => {
+    expect(
+      resolveSpokenRepositoryReference('galfrevn apollo firmware', installedList),
+    ).toEqual({ kind: 'match', fullName: 'galfrevn/apollo-firmware' });
+  });
+
+  it('reports ambiguity instead of guessing', () => {
+    const resolution = resolveSpokenRepositoryReference('apol', installedList);
+    expect(resolution.kind).toBe('ambiguous');
+    if (resolution.kind === 'ambiguous') {
+      expect(resolution.candidateFullNameList).toEqual([
+        'galfrevn/apollo',
+        'galfrevn/apollo-firmware',
+      ]);
+    }
+  });
+
+  it('reports none for an unknown name or empty input', () => {
+    expect(resolveSpokenRepositoryReference('inexistente', installedList)).toEqual({
+      kind: 'none',
+    });
+    expect(resolveSpokenRepositoryReference('   ', installedList)).toEqual({
+      kind: 'none',
+    });
+  });
+});
 
 describe('parseGithubRepositoryReference', () => {
   it('accepts the shapes a user might say or paste', () => {

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -10,6 +10,8 @@ export const GITHUB_API_USER_AGENT = 'apollo-desk-agent';
 const APP_JWT_LIFETIME_SECONDS = 480;
 const APP_JWT_CLOCK_SKEW_SECONDS = 30;
 
+const GITHUB_API_PAGE_SIZE = 100;
+
 const installationResponseSchema = z.object({
   id: z.number().int().positive(),
 });
@@ -173,18 +175,25 @@ export async function listGithubAppRepositoryFullNameList(input: {
     nowMilliseconds: input.nowMilliseconds,
   });
 
-  const installationsResponse = await fetchImplementation(
-    `${GITHUB_API_BASE_URL}/app/installations?per_page=100`,
-    { headers: buildGithubRequestHeaders(`Bearer ${appJsonWebToken}`) },
-  );
-  if (!installationsResponse.ok) {
-    throw new Error(
-      `No pude listar las instalaciones del App (status ${installationsResponse.status})`,
+  const installationList: { readonly id: number }[] = [];
+  for (let pageNumber = 1; ; pageNumber += 1) {
+    const installationsResponse = await fetchImplementation(
+      `${GITHUB_API_BASE_URL}/app/installations?per_page=${GITHUB_API_PAGE_SIZE}&page=${pageNumber}`,
+      { headers: buildGithubRequestHeaders(`Bearer ${appJsonWebToken}`) },
     );
+    if (!installationsResponse.ok) {
+      throw new Error(
+        `No pude listar las instalaciones del App (status ${installationsResponse.status})`,
+      );
+    }
+    const installationPageList = installationListResponseSchema.parse(
+      await installationsResponse.json(),
+    );
+    installationList.push(...installationPageList);
+    if (installationPageList.length < GITHUB_API_PAGE_SIZE) {
+      break;
+    }
   }
-  const installationList = installationListResponseSchema.parse(
-    await installationsResponse.json(),
-  );
 
   const fullNameList: string[] = [];
   for (const installation of installationList) {
@@ -195,19 +204,26 @@ export async function listGithubAppRepositoryFullNameList(input: {
         ? { fetchImplementation: input.fetchImplementation }
         : {}),
     });
-    const repositoriesResponse = await fetchImplementation(
-      `${GITHUB_API_BASE_URL}/installation/repositories?per_page=100`,
-      { headers: buildGithubRequestHeaders(`token ${installationToken.token}`) },
-    );
-    if (!repositoriesResponse.ok) {
-      throw new Error(
-        `No pude listar los repositorios de una instalación (status ${repositoriesResponse.status})`,
+    for (let pageNumber = 1; ; pageNumber += 1) {
+      const repositoriesResponse = await fetchImplementation(
+        `${GITHUB_API_BASE_URL}/installation/repositories?per_page=${GITHUB_API_PAGE_SIZE}&page=${pageNumber}`,
+        { headers: buildGithubRequestHeaders(`token ${installationToken.token}`) },
       );
+      if (!repositoriesResponse.ok) {
+        throw new Error(
+          `No pude listar los repositorios de una instalación (status ${repositoriesResponse.status})`,
+        );
+      }
+      const payload = installationRepositoriesResponseSchema.parse(
+        await repositoriesResponse.json(),
+      );
+      fullNameList.push(
+        ...payload.repositories.map((repository) => repository.full_name),
+      );
+      if (payload.repositories.length < GITHUB_API_PAGE_SIZE) {
+        break;
+      }
     }
-    const payload = installationRepositoriesResponseSchema.parse(
-      await repositoriesResponse.json(),
-    );
-    fullNameList.push(...payload.repositories.map((repository) => repository.full_name));
   }
   return fullNameList;
 }

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -14,6 +14,12 @@ const installationResponseSchema = z.object({
   id: z.number().int().positive(),
 });
 
+const installationListResponseSchema = z.array(installationResponseSchema);
+
+const installationRepositoriesResponseSchema = z.object({
+  repositories: z.array(z.object({ full_name: z.string().min(1) })),
+});
+
 const installationTokenResponseSchema = z.object({
   token: z.string().min(1),
   expires_at: z.string().min(1),
@@ -147,6 +153,63 @@ export async function createGithubInstallationToken(input: {
 
   const payload = installationTokenResponseSchema.parse(await response.json());
   return { token: payload.token, expiresAt: payload.expires_at };
+}
+
+// The App's installation list doubles as the coding allowlist, so this is
+// also how the agent learns which repositories it may touch.
+export async function listGithubAppRepositoryFullNameList(input: {
+  readonly appId: string;
+  readonly privateKeyPem: string;
+  readonly nowMilliseconds: number;
+  readonly fetchImplementation?: typeof fetch;
+}): Promise<readonly string[]> {
+  if (input.appId.length === 0 || input.privateKeyPem.length === 0) {
+    throw new Error('Faltan GITHUB_APP_ID o GITHUB_APP_PRIVATE_KEY');
+  }
+  const fetchImplementation = input.fetchImplementation ?? globalThis.fetch;
+  const appJsonWebToken = await signGithubAppJsonWebToken({
+    appId: input.appId,
+    privateKeyPem: input.privateKeyPem,
+    nowMilliseconds: input.nowMilliseconds,
+  });
+
+  const installationsResponse = await fetchImplementation(
+    `${GITHUB_API_BASE_URL}/app/installations?per_page=100`,
+    { headers: buildGithubRequestHeaders(`Bearer ${appJsonWebToken}`) },
+  );
+  if (!installationsResponse.ok) {
+    throw new Error(
+      `No pude listar las instalaciones del App (status ${installationsResponse.status})`,
+    );
+  }
+  const installationList = installationListResponseSchema.parse(
+    await installationsResponse.json(),
+  );
+
+  const fullNameList: string[] = [];
+  for (const installation of installationList) {
+    const installationToken = await createGithubInstallationToken({
+      installationId: installation.id,
+      appJsonWebToken,
+      ...(input.fetchImplementation !== undefined
+        ? { fetchImplementation: input.fetchImplementation }
+        : {}),
+    });
+    const repositoriesResponse = await fetchImplementation(
+      `${GITHUB_API_BASE_URL}/installation/repositories?per_page=100`,
+      { headers: buildGithubRequestHeaders(`token ${installationToken.token}`) },
+    );
+    if (!repositoriesResponse.ok) {
+      throw new Error(
+        `No pude listar los repositorios de una instalación (status ${repositoriesResponse.status})`,
+      );
+    }
+    const payload = installationRepositoriesResponseSchema.parse(
+      await repositoriesResponse.json(),
+    );
+    fullNameList.push(...payload.repositories.map((repository) => repository.full_name));
+  }
+  return fullNameList;
 }
 
 export async function createGithubInstallationTokenForRepository(input: {

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -48,6 +48,58 @@ export function formatGithubRepositoryReference(
   return `${reference.owner}/${reference.repository}`;
 }
 
+export type SpokenRepositoryResolution =
+  | { readonly kind: 'match'; readonly fullName: string }
+  | { readonly kind: 'ambiguous'; readonly candidateFullNameList: readonly string[] }
+  | { readonly kind: 'none' };
+
+// A spoken repo name arrives however the transcriber heard it: "apollo
+// firmware", "Apollo-Firmware", "el repo apollo". Separators and case carry
+// no information at that point, so matching drops them entirely.
+function normalizeRepositoryNameForSpeech(text: string): string {
+  return text.toLowerCase().replaceAll(/[\s./_-]+/g, '');
+}
+
+export function resolveSpokenRepositoryReference(
+  spokenReference: string,
+  installedFullNameList: readonly string[],
+): SpokenRepositoryResolution {
+  const normalizedSpoken = normalizeRepositoryNameForSpeech(spokenReference);
+  if (normalizedSpoken.length === 0) {
+    return { kind: 'none' };
+  }
+
+  const selectMatches = (
+    isMatch: (normalizedCandidate: string) => boolean,
+  ): readonly string[] =>
+    installedFullNameList.filter((fullName) => {
+      const shortName = fullName.split('/')[1] ?? '';
+      return (
+        isMatch(normalizeRepositoryNameForSpeech(shortName)) ||
+        isMatch(normalizeRepositoryNameForSpeech(fullName))
+      );
+    });
+
+  const exactMatchList = selectMatches(
+    (normalizedCandidate) => normalizedCandidate === normalizedSpoken,
+  );
+  const matchList =
+    exactMatchList.length > 0
+      ? exactMatchList
+      : selectMatches((normalizedCandidate) =>
+          normalizedCandidate.includes(normalizedSpoken),
+        );
+
+  const [firstMatch] = matchList;
+  if (firstMatch !== undefined && matchList.length === 1) {
+    return { kind: 'match', fullName: firstMatch };
+  }
+  if (matchList.length > 1) {
+    return { kind: 'ambiguous', candidateFullNameList: matchList };
+  }
+  return { kind: 'none' };
+}
+
 // Last line of defence: a command can still echo a token it was handed, so
 // anything bound for a log, a document, an email or TTS passes through here.
 export function redactSecretsFromText(

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -66,14 +66,16 @@ function normalizeRepositoryName(name: string): string {
 
 // The repository name has to appear as consecutive words somewhere in the
 // spoken phrase, so surrounding words in any language fall away without a
-// stopword list; the widest window wins so "apollo firmware" resolves to
-// apollo-firmware instead of tying with apollo.
+// stopword list. The widest window wins so "apollo firmware" resolves to
+// apollo-firmware instead of tying with apollo, and on equal width the match
+// with more characters wins: a short name like "repo" coinciding with a
+// spoken word is far more likely incidental than a long one.
 function selectRepositoriesMatchingTokenWindow(
   spokenTokenList: readonly string[],
   candidateList: readonly { fullName: string; normalizedNameList: string[] }[],
 ): readonly string[] {
   for (let windowSize = spokenTokenList.length; windowSize >= 1; windowSize -= 1) {
-    const matchedFullNameSet = new Set<string>();
+    const matchedLengthByFullName = new Map<string, number>();
     for (
       let startIndex = 0;
       startIndex + windowSize <= spokenTokenList.length;
@@ -84,12 +86,19 @@ function selectRepositoriesMatchingTokenWindow(
         .join('');
       for (const candidate of candidateList) {
         if (candidate.normalizedNameList.includes(windowText)) {
-          matchedFullNameSet.add(candidate.fullName);
+          const knownLength = matchedLengthByFullName.get(candidate.fullName) ?? 0;
+          matchedLengthByFullName.set(
+            candidate.fullName,
+            Math.max(knownLength, windowText.length),
+          );
         }
       }
     }
-    if (matchedFullNameSet.size > 0) {
-      return [...matchedFullNameSet];
+    if (matchedLengthByFullName.size > 0) {
+      const widestMatchedLength = Math.max(...matchedLengthByFullName.values());
+      return [...matchedLengthByFullName.entries()]
+        .filter(([, matchedLength]) => matchedLength === widestMatchedLength)
+        .map(([fullName]) => fullName);
     }
   }
   return [];

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -53,42 +53,78 @@ export type SpokenRepositoryResolution =
   | { readonly kind: 'ambiguous'; readonly candidateFullNameList: readonly string[] }
   | { readonly kind: 'none' };
 
-// A spoken repo name arrives however the transcriber heard it: "apollo
-// firmware", "Apollo-Firmware", "el repo apollo". Separators and case carry
-// no information at that point, so matching drops them entirely.
-function normalizeRepositoryNameForSpeech(text: string): string {
-  return text.toLowerCase().replaceAll(/[\s./_-]+/g, '');
+function splitIntoSpokenTokenList(text: string): readonly string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s./_-]+/)
+    .filter((token) => token.length > 0);
+}
+
+function normalizeRepositoryName(name: string): string {
+  return splitIntoSpokenTokenList(name).join('');
+}
+
+// The repository name has to appear as consecutive words somewhere in the
+// spoken phrase, so surrounding words in any language fall away without a
+// stopword list; the widest window wins so "apollo firmware" resolves to
+// apollo-firmware instead of tying with apollo.
+function selectRepositoriesMatchingTokenWindow(
+  spokenTokenList: readonly string[],
+  candidateList: readonly { fullName: string; normalizedNameList: string[] }[],
+): readonly string[] {
+  for (let windowSize = spokenTokenList.length; windowSize >= 1; windowSize -= 1) {
+    const matchedFullNameSet = new Set<string>();
+    for (
+      let startIndex = 0;
+      startIndex + windowSize <= spokenTokenList.length;
+      startIndex += 1
+    ) {
+      const windowText = spokenTokenList
+        .slice(startIndex, startIndex + windowSize)
+        .join('');
+      for (const candidate of candidateList) {
+        if (candidate.normalizedNameList.includes(windowText)) {
+          matchedFullNameSet.add(candidate.fullName);
+        }
+      }
+    }
+    if (matchedFullNameSet.size > 0) {
+      return [...matchedFullNameSet];
+    }
+  }
+  return [];
 }
 
 export function resolveSpokenRepositoryReference(
   spokenReference: string,
   installedFullNameList: readonly string[],
 ): SpokenRepositoryResolution {
-  const normalizedSpoken = normalizeRepositoryNameForSpeech(spokenReference);
-  if (normalizedSpoken.length === 0) {
+  const spokenTokenList = splitIntoSpokenTokenList(spokenReference);
+  if (spokenTokenList.length === 0) {
     return { kind: 'none' };
   }
 
-  const selectMatches = (
-    isMatch: (normalizedCandidate: string) => boolean,
-  ): readonly string[] =>
-    installedFullNameList.filter((fullName) => {
-      const shortName = fullName.split('/')[1] ?? '';
-      return (
-        isMatch(normalizeRepositoryNameForSpeech(shortName)) ||
-        isMatch(normalizeRepositoryNameForSpeech(fullName))
-      );
-    });
+  const candidateList = installedFullNameList.map((fullName) => ({
+    fullName,
+    normalizedNameList: [
+      normalizeRepositoryName(fullName.split('/')[1] ?? ''),
+      normalizeRepositoryName(fullName),
+    ].filter((name) => name.length > 0),
+  }));
 
-  const exactMatchList = selectMatches(
-    (normalizedCandidate) => normalizedCandidate === normalizedSpoken,
+  const windowMatchList = selectRepositoriesMatchingTokenWindow(
+    spokenTokenList,
+    candidateList,
   );
+  const normalizedSpoken = spokenTokenList.join('');
   const matchList =
-    exactMatchList.length > 0
-      ? exactMatchList
-      : selectMatches((normalizedCandidate) =>
-          normalizedCandidate.includes(normalizedSpoken),
-        );
+    windowMatchList.length > 0
+      ? windowMatchList
+      : candidateList
+          .filter((candidate) =>
+            candidate.normalizedNameList.some((name) => name.includes(normalizedSpoken)),
+          )
+          .map((candidate) => candidate.fullName);
 
   const [firstMatch] = matchList;
   if (firstMatch !== undefined && matchList.length === 1) {

--- a/src/persona/soul.ts
+++ b/src/persona/soul.ts
@@ -19,6 +19,7 @@ const apolloOperatingBasePrompt =
   'set_timer para cuentas regresivas y start_pomodoro para pomodoros con focus. ' +
   'add_to_list, read_list y remove_from_list para listas (la del super por defecto). ' +
   'dollar_rate para cotizaciones del dólar. send_email para mandarle algo por mail al usuario. ' +
+  'start_coding_task para tareas de código en GitHub: pasale el nombre del repo tal como lo dijo el usuario, nunca pidas URLs ni owner/repo; list_coding_repositories te dice en cuáles se puede. ' +
   'Para guardar la ciudad default del clima usá set_weather_location. Si solo preguntan el clima en otra ciudad, weather_now con locationQuery (no guarda). ' +
   'Con focus activo: menos announces y más breve. No inventes hechos: preguntá o usá una tool. ' +
   'No narres el uso de tools al pedo.';

--- a/src/tools/__tests__/coding.spec.ts
+++ b/src/tools/__tests__/coding.spec.ts
@@ -1,14 +1,85 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 
 import {
+  buildTestRsaPrivateKeyPem,
   createFakeApolloEnvironment,
   createStubDeskToolEffects,
 } from '@/configuration/testing';
 import { createBuiltinToolDefinitionMap } from '@/tools/catalog';
-import { startCodingTaskTool } from '@/tools/coding';
+import { listCodingRepositoriesTool, startCodingTaskTool } from '@/tools/coding';
 import { executeToolByName } from '@/tools/router';
 
 const fakeEnvironment = createFakeApolloEnvironment();
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function stubGithubFetch(installedFullNameList: readonly string[]): void {
+  const fetchHandler = async (input: string | URL | Request): Promise<Response> => {
+    const url = String(input);
+    if (url.includes('/access_tokens')) {
+      return new Response(
+        JSON.stringify({ token: 'ghs_token', expires_at: '2026-08-10T13:00:00Z' }),
+        { status: 201 },
+      );
+    }
+    if (url.includes('/app/installations')) {
+      return new Response(JSON.stringify([{ id: 7 }]), { status: 200 });
+    }
+    if (url.includes('/installation/repositories')) {
+      return new Response(
+        JSON.stringify({
+          repositories: installedFullNameList.map((fullName) => ({
+            full_name: fullName,
+          })),
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response('{}', { status: 500 });
+  };
+  globalThis.fetch = Object.assign(fetchHandler, {
+    preconnect: () => {},
+  }) as typeof fetch;
+}
+
+async function buildConfiguredEnvironment(): Promise<Env> {
+  return createFakeApolloEnvironment({
+    GITHUB_APP_ID: '123456',
+    GITHUB_APP_PRIVATE_KEY: await buildTestRsaPrivateKeyPem(),
+  });
+}
+
+describe('listCodingRepositoriesTool', () => {
+  it('speaks the installation list', async () => {
+    stubGithubFetch(['galfrevn/apollo', 'galfrevn/dotfiles']);
+
+    const result = await listCodingRepositoriesTool.handler(
+      {},
+      {
+        environment: await buildConfiguredEnvironment(),
+        nowMilliseconds: 1_700_000_000_000,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('galfrevn/apollo');
+    expect(result.summary).toContain('galfrevn/dotfiles');
+  });
+
+  it('reports the configuration gap when the app is missing', async () => {
+    const result = await listCodingRepositoriesTool.handler(
+      {},
+      { environment: fakeEnvironment, nowMilliseconds: 0 },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.summary).toContain('GITHUB_APP_ID');
+  });
+});
 
 describe('startCodingTaskTool', () => {
   it('requires confirmation before anything is enqueued', async () => {
@@ -82,6 +153,77 @@ describe('startCodingTaskTool', () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(enqueuedList).toHaveLength(0);
+  });
+
+  it('resolves a spoken name against the installed repositories', async () => {
+    stubGithubFetch(['galfrevn/apollo', 'galfrevn/apollo-firmware']);
+    const enqueuedList: { repository: string; task: string }[] = [];
+
+    const result = await startCodingTaskTool.handler(
+      { repository: 'el repo apollo firmware', task: 'agregar un test' },
+      {
+        environment: await buildConfiguredEnvironment(),
+        nowMilliseconds: 1_700_000_000_000,
+        deviceId: 'desk-01',
+        effects: createStubDeskToolEffects({
+          enqueueCodingTask: async (input) => {
+            enqueuedList.push(input);
+          },
+        }),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(enqueuedList).toEqual([
+      { repository: 'galfrevn/apollo-firmware', task: 'agregar un test' },
+    ]);
+  });
+
+  it('asks which candidate instead of guessing an ambiguous name', async () => {
+    stubGithubFetch(['galfrevn/apollo', 'galfrevn/apollo-firmware']);
+    const enqueuedList: { repository: string; task: string }[] = [];
+
+    const result = await startCodingTaskTool.handler(
+      { repository: 'apol', task: 'hacer algo' },
+      {
+        environment: await buildConfiguredEnvironment(),
+        nowMilliseconds: 1_700_000_000_000,
+        deviceId: 'desk-01',
+        effects: createStubDeskToolEffects({
+          enqueueCodingTask: async (input) => {
+            enqueuedList.push(input);
+          },
+        }),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.summary).toContain('galfrevn/apollo');
+    expect(result.summary).toContain('galfrevn/apollo-firmware');
+    expect(enqueuedList).toHaveLength(0);
+  });
+
+  it('answers with the available repositories for an unknown name', async () => {
+    stubGithubFetch(['galfrevn/apollo']);
+    const enqueuedList: { repository: string; task: string }[] = [];
+
+    const result = await startCodingTaskTool.handler(
+      { repository: 'inexistente', task: 'hacer algo' },
+      {
+        environment: await buildConfiguredEnvironment(),
+        nowMilliseconds: 1_700_000_000_000,
+        deviceId: 'desk-01',
+        effects: createStubDeskToolEffects({
+          enqueueCodingTask: async (input) => {
+            enqueuedList.push(input);
+          },
+        }),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.summary).toContain('galfrevn/apollo');
     expect(enqueuedList).toHaveLength(0);
   });
 });

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -1,4 +1,4 @@
-import { startCodingTaskTool } from '@/tools/coding';
+import { listCodingRepositoriesTool, startCodingTaskTool } from '@/tools/coding';
 import { deviceStatusTool, setBrightnessTool, setVolumeTool } from '@/tools/device';
 import { dollarRateTool } from '@/tools/dollar';
 import { sendEmailTool } from '@/tools/email';
@@ -42,6 +42,7 @@ export function listBuiltinToolDefinitionList(): readonly ToolDefinition[] {
     sendEmailTool,
     sandboxRunCodeTool,
     sandboxExecTool,
+    listCodingRepositoriesTool,
     startCodingTaskTool,
   ];
 }

--- a/src/tools/coding.ts
+++ b/src/tools/coding.ts
@@ -93,10 +93,7 @@ export const startCodingTaskTool: ToolDefinition = {
       repositoryLabel = formatGithubRepositoryReference(
         parseGithubRepositoryReference(parsedArgs.repository),
       );
-    } catch {
-      // Not an owner/repo or URL: a spoken name, resolved against the
-      // installation list below.
-    }
+    } catch {}
 
     if (repositoryLabel === undefined) {
       let installedFullNameList: readonly string[];

--- a/src/tools/coding.ts
+++ b/src/tools/coding.ts
@@ -1,12 +1,64 @@
 import { z } from 'zod';
 
-import { parseGithubRepositoryReference } from '@/github/repository';
-import type { ToolDefinition } from '@/tools/types';
+import { listGithubAppRepositoryFullNameList } from '@/github/app';
+import {
+  formatGithubRepositoryReference,
+  parseGithubRepositoryReference,
+  resolveSpokenRepositoryReference,
+} from '@/github/repository';
+import type { ToolDefinition, ToolExecutionContext } from '@/tools/types';
 
 const startCodingTaskArgsSchema = z.object({
   repository: z.string().min(1).max(200),
   task: z.string().min(1).max(4000),
 });
+
+async function listInstalledRepositoryFullNameList(
+  context: ToolExecutionContext,
+): Promise<readonly string[]> {
+  return listGithubAppRepositoryFullNameList({
+    appId: context.environment.GITHUB_APP_ID,
+    privateKeyPem: context.environment.GITHUB_APP_PRIVATE_KEY,
+    nowMilliseconds: context.nowMilliseconds,
+  });
+}
+
+export const listCodingRepositoriesTool: ToolDefinition = {
+  name: 'list_coding_repositories',
+  safety: 'safe',
+  description:
+    'Lista los repositorios de GitHub donde Apollo puede programar (los que tienen el App instalado)',
+  parameters: {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  },
+  async handler(_args, context) {
+    let fullNameList: readonly string[];
+    try {
+      fullNameList = await listInstalledRepositoryFullNameList(context);
+    } catch (error) {
+      return {
+        ok: false,
+        summary:
+          error instanceof Error
+            ? error.message
+            : 'No pude listar los repositorios disponibles',
+      };
+    }
+    if (fullNameList.length === 0) {
+      return {
+        ok: true,
+        summary: 'El GitHub App todavía no está instalado en ningún repositorio',
+      };
+    }
+    return {
+      ok: true,
+      summary: `Puedo programar en: ${fullNameList.join(', ')}`,
+      data: { repositoryList: fullNameList },
+    };
+  },
+};
 
 // One confirmation authorizes the whole task: the agent runs many commands and
 // confirming each by voice is unusable. Blast radius is one disposable sandbox.
@@ -14,7 +66,9 @@ export const startCodingTaskTool: ToolDefinition = {
   name: 'start_coding_task',
   safety: 'unsafe',
   description:
-    'Clona un repositorio de GitHub en un sandbox, hace los cambios pedidos y abre un pull request (requiere confirmación)',
+    'Clona un repositorio de GitHub en un sandbox, hace los cambios pedidos y abre un pull request (requiere confirmación). ' +
+    'Alcanza con el nombre del repo tal como lo dice el usuario (ej: "apollo"): se resuelve contra los repos instalados. ' +
+    'Nunca le pidas al usuario una URL ni el formato owner/repo; ante la duda usá list_coding_repositories.',
   parameters: {
     type: 'object',
     properties: {
@@ -34,15 +88,49 @@ export const startCodingTaskTool: ToolDefinition = {
     }
 
     const parsedArgs = startCodingTaskArgsSchema.parse(args);
-    let repositoryLabel: string;
+    let repositoryLabel: string | undefined;
     try {
-      const repository = parseGithubRepositoryReference(parsedArgs.repository);
-      repositoryLabel = `${repository.owner}/${repository.repository}`;
-    } catch (error) {
-      return {
-        ok: false,
-        summary: error instanceof Error ? error.message : 'Repositorio inválido',
-      };
+      repositoryLabel = formatGithubRepositoryReference(
+        parseGithubRepositoryReference(parsedArgs.repository),
+      );
+    } catch {
+      // Not an owner/repo or URL: a spoken name, resolved against the
+      // installation list below.
+    }
+
+    if (repositoryLabel === undefined) {
+      let installedFullNameList: readonly string[];
+      try {
+        installedFullNameList = await listInstalledRepositoryFullNameList(context);
+      } catch (error) {
+        return {
+          ok: false,
+          summary:
+            error instanceof Error
+              ? error.message
+              : 'No pude listar los repositorios disponibles',
+        };
+      }
+      const resolution = resolveSpokenRepositoryReference(
+        parsedArgs.repository,
+        installedFullNameList,
+      );
+      if (resolution.kind === 'ambiguous') {
+        return {
+          ok: false,
+          summary: `Hay varios repos que suenan a "${parsedArgs.repository}": ${resolution.candidateFullNameList.join(', ')}. ¿Cuál de esos?`,
+        };
+      }
+      if (resolution.kind === 'none') {
+        return {
+          ok: false,
+          summary:
+            installedFullNameList.length === 0
+              ? 'El GitHub App todavía no está instalado en ningún repositorio'
+              : `No encontré un repo que suene a "${parsedArgs.repository}". Puedo programar en: ${installedFullNameList.join(', ')}`,
+        };
+      }
+      repositoryLabel = resolution.fullName;
     }
 
     await context.effects.enqueueCodingTask({


### PR DESCRIPTION
Nobody dictates `owner/repo` out loud, and the voice model kept asking the user for full URLs because it had no way to know which repositories exist. The GitHub App's installation list — already the coding allowlist — now feeds both sides of the conversation.

## What changed

- **`listGithubAppRepositoryFullNameList`** (`src/github/app.ts`): App JWT → installations → per-installation repository list. The same list that gates the coding workflow, now readable by the agent.
- **`resolveSpokenRepositoryReference`** (`src/github/repository.ts`): matches a name however the transcriber heard it ("apollo firmware", "Apollo-Firmware") — case and separators dropped, exact name beats containment, ambiguity and no-match are explicit results instead of guesses.
- **`start_coding_task`**: accepts the spoken name; `owner/repo` and URLs skip the lookup entirely (no extra API calls on the fast path). Ambiguous → spoken question with candidates; unknown → speaks the available list instead of asking for a URL.
- **New `list_coding_repositories` tool** (safe): lets the agent enumerate where it can code.
- **Soul prompt**: tells the model to never ask for URLs or owner/repo format.

Tests cover the resolver (exact, normalized, ambiguous, none, owner-attached) and the handler paths; the fake environment keeps GitHub credentials empty so nothing touches the network in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR lets coding tools resolve spoken repository names against repositories accessible to the GitHub App.
- Enumerates installations and repositories across paginated GitHub API responses.
- Resolves natural spoken references with explicit match, ambiguity, and no-match outcomes.
- Adds a safe repository-listing tool and updates the coding prompt, documentation, and tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(coding): break same-width window tie..."](https://github.com/galfrevn/apollo/commit/6828075b8da72539a5064ba079dcb039450eaaa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52044565)</sub>

<!-- /greptile_comment -->