### PR TITLE
fix(telemetry): survive deploys, and own the device state in the persona

### DIFF
--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -58,6 +58,7 @@ import {
 import { createDeskUiMachine, type DeskUiMachine } from '@/session/machine';
 import {
   evaluateLowBatteryAnnouncement,
+  parseStoredTelemetrySnapshot,
   type DeskTelemetrySnapshot,
 } from '@/telemetry/logic';
 import {
@@ -770,7 +771,6 @@ export class Apollo extends Agent<Env, ApolloState> {
     },
   ): Promise<void> {
     const deviceId = this.name ?? 'default';
-    // A new turn clears any interruption left over from the previous one.
     this.#isSpeechAborted = false;
     if (this.#lastTelemetrySnapshot === undefined) {
       const storedSnapshot = await getSessionPreference(
@@ -778,13 +778,7 @@ export class Apollo extends Agent<Env, ApolloState> {
         TELEMETRY_SNAPSHOT_PREFERENCE_KEY,
       );
       if (storedSnapshot !== undefined && storedSnapshot !== null) {
-        try {
-          this.#lastTelemetrySnapshot = JSON.parse(
-            storedSnapshot,
-          ) as DeskTelemetrySnapshot;
-        } catch {
-          // A corrupt stored snapshot is no worse than the missing one.
-        }
+        this.#lastTelemetrySnapshot = parseStoredTelemetrySnapshot(storedSnapshot);
       }
     }
     const deskToolEffects = createDeskToolEffects({

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -79,6 +79,7 @@ import {
 const MINIMUM_TURN_AUDIO_BYTE_LENGTH = 8000;
 
 const LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY = 'lowBatteryLastAnnounceAt';
+const TELEMETRY_SNAPSHOT_PREFERENCE_KEY = 'lastTelemetrySnapshot';
 
 function mapUnknownScheduleListToAgentScheduleLikeList(
   scheduleList: readonly {
@@ -598,6 +599,14 @@ export class Apollo extends Agent<Env, ApolloState> {
       receivedAtMs: Date.now(),
     };
     this.#lastTelemetrySnapshot = snapshot;
+    // A deploy or hibernation wipes the in-memory snapshot, and the next turn
+    // may run before the device's next telemetry tick — the prompt would then
+    // silently miss battery/firmware. The stored copy bridges that gap.
+    await setSessionPreference(
+      this.#sqlExecutor(),
+      TELEMETRY_SNAPSHOT_PREFERENCE_KEY,
+      JSON.stringify(snapshot),
+    );
 
     const storedAnnounceAt = await getSessionPreference(
       this.#sqlExecutor(),
@@ -763,6 +772,21 @@ export class Apollo extends Agent<Env, ApolloState> {
     const deviceId = this.name ?? 'default';
     // A new turn clears any interruption left over from the previous one.
     this.#isSpeechAborted = false;
+    if (this.#lastTelemetrySnapshot === undefined) {
+      const storedSnapshot = await getSessionPreference(
+        this.#sqlExecutor(),
+        TELEMETRY_SNAPSHOT_PREFERENCE_KEY,
+      );
+      if (storedSnapshot !== undefined && storedSnapshot !== null) {
+        try {
+          this.#lastTelemetrySnapshot = JSON.parse(
+            storedSnapshot,
+          ) as DeskTelemetrySnapshot;
+        } catch {
+          // A corrupt stored snapshot is no worse than the missing one.
+        }
+      }
+    }
     const deskToolEffects = createDeskToolEffects({
       sqlExecutor: this.#sqlExecutor(),
       environment: this.env,

--- a/src/persona/soul.ts
+++ b/src/persona/soul.ts
@@ -24,6 +24,7 @@ const apolloOperatingBasePrompt =
   'start_coding_task para tareas de código en GitHub: pasale el nombre del repo tal como lo dijo el usuario, nunca pidas URLs ni owner/repo; list_coding_repositories te dice en cuáles se puede. ' +
   'Para guardar la ciudad default del clima usá set_weather_location. Si solo preguntan el clima en otra ciudad, weather_now con locationQuery (no guarda). ' +
   'Con focus activo: menos announces y más breve. No inventes hechos: preguntá o usá una tool. ' +
+  'Los datos de "Estado del dispositivo" (batería, volumen, WiFi, versión de firmware) son tu propio estado: respondé con ellos directamente. ' +
   'No narres el uso de tools al pedo.';
 
 export function buildApolloSoulPrompt(speechModeId: string): string {

--- a/src/telemetry/__tests__/logic.spec.ts
+++ b/src/telemetry/__tests__/logic.spec.ts
@@ -4,6 +4,7 @@ import {
   buildTelemetryPromptNote,
   evaluateLowBatteryAnnouncement,
   LOW_BATTERY_ANNOUNCE_COOLDOWN_MS,
+  parseStoredTelemetrySnapshot,
   TELEMETRY_PROMPT_STALENESS_MS,
   type DeskTelemetrySnapshot,
 } from '@/telemetry/logic';
@@ -23,6 +24,35 @@ function createSnapshot(
     ...overrides,
   };
 }
+
+describe('parseStoredTelemetrySnapshot', () => {
+  it('restores a stored snapshot', () => {
+    const snapshot = createSnapshot();
+    expect(parseStoredTelemetrySnapshot(JSON.stringify(snapshot))).toEqual(snapshot);
+  });
+
+  it('rejects malformed json', () => {
+    expect(parseStoredTelemetrySnapshot('{"battery":')).toBeUndefined();
+  });
+
+  it('rejects json that is not an object', () => {
+    expect(parseStoredTelemetrySnapshot('null')).toBeUndefined();
+    expect(parseStoredTelemetrySnapshot('"87%"')).toBeUndefined();
+  });
+
+  it('rejects a snapshot without a usable timestamp', () => {
+    expect(parseStoredTelemetrySnapshot('{"battery":87}')).toBeUndefined();
+    expect(
+      parseStoredTelemetrySnapshot('{"battery":87,"receivedAtMs":"reciente"}'),
+    ).toBeUndefined();
+  });
+
+  it('rejects a snapshot whose fields have the wrong type', () => {
+    expect(
+      parseStoredTelemetrySnapshot(`{"battery":"87","receivedAtMs":${NOW_MILLISECONDS}}`),
+    ).toBeUndefined();
+  });
+});
 
 describe('buildTelemetryPromptNote', () => {
   it('describes every field of a fresh snapshot', () => {

--- a/src/telemetry/logic.ts
+++ b/src/telemetry/logic.ts
@@ -1,3 +1,14 @@
+import { z } from 'zod';
+
+const deskTelemetrySnapshotSchema = z.object({
+  battery: z.number().optional(),
+  charging: z.boolean().optional(),
+  volume: z.number().optional(),
+  wifiRssi: z.number().optional(),
+  firmwareVersion: z.string().optional(),
+  receivedAtMs: z.number().finite(),
+});
+
 export type DeskTelemetrySnapshot = {
   readonly battery?: number;
   readonly charging?: boolean;
@@ -6,6 +17,17 @@ export type DeskTelemetrySnapshot = {
   readonly firmwareVersion?: string;
   readonly receivedAtMs: number;
 };
+
+export function parseStoredTelemetrySnapshot(
+  storedSnapshot: string,
+): DeskTelemetrySnapshot | undefined {
+  try {
+    const parsed = deskTelemetrySnapshotSchema.safeParse(JSON.parse(storedSnapshot));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export const LOW_BATTERY_ANNOUNCE_THRESHOLD_PERCENT = 15;
 export const LOW_BATTERY_REARM_THRESHOLD_PERCENT = 25;


### PR DESCRIPTION
Asking Apollo "¿en qué versión de firmware estás?" drew a blank. Root cause: the telemetry snapshot (battery, volume, WiFi, firmware version) lived only in the Durable Object's memory — every deploy or hibernation wiped it, and the next turn's system prompt silently lost the "Estado del dispositivo" note until the device's next 60 s telemetry tick.

- The snapshot now also persists as a session preference and is restored on the first turn after a cold start (the 5-minute staleness gate still applies, so a long-disconnected device never shows stale numbers).
- The persona now explicitly owns that note ("son tu propio estado"), so the model answers from it instead of deflecting.

`bun test` 316 pass · typecheck + lint clean · already deployed to apollo.galfre-vn.workers.dev for live testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR persists telemetry snapshots across Durable Object restarts and restores them with runtime schema validation while preserving the existing freshness gate.
- Stores the latest telemetry snapshot as a session preference.
- Validates persisted telemetry before restoring it on a cold start.
- Clarifies that device telemetry represents Apollo’s own state.
- Adds parser coverage for malformed JSON, invalid shapes, timestamps, and field types.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported unchecked restoration issue is fixed by schema-validating parsed JSON, including the required finite timestamp, before assigning the restored snapshot; no blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(telemetry): validate the restored sn..."](https://github.com/galfrevn/apollo/commit/5d56db2153a7717a96904121e16aec2102ad47f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52234445)</sub>

<!-- /greptile_comment -->