### PR TITLE
fix: replay approved confirmations, and guard the coding agent loop

### DIFF
--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -215,6 +215,40 @@ describe('runCodingAgent', () => {
     expect(wrapUpCall?.messageList.at(-1)?.content).toContain('Se terminaron las rondas');
   });
 
+  it('treats outputs differing only past the truncation cutoff as identical', async () => {
+    let execCallCount = 0;
+    const { sandbox } = createFakeSandbox();
+    const longPrefix = 'x'.repeat(5_000);
+    const tailChangingSandbox: CodingSandboxPort = {
+      ...sandbox,
+      exec: async () => {
+        execCallCount += 1;
+        return { stdout: `${longPrefix}${execCallCount}`, stderr: '', exitCode: 0 };
+      },
+    };
+    const callLlm: CodingLlmCaller = async ({ toolDefinitionList }) => {
+      if (toolDefinitionList.length === 0) {
+        return { text: 'No pude avanzar con eso.', toolCallList: [] };
+      }
+      return {
+        text: '',
+        toolCallList: [{ id: 'x', name: 'run_command', args: { command: 'cat log' } }],
+      };
+    };
+
+    const outcome = await runCodingAgent({
+      sandbox: tailChangingSandbox,
+      callLlm,
+      repositoryLabel: 'galfrevn/apollo',
+      taskText: 'dar vueltas para siempre',
+    });
+
+    // The tails differ, but the model only ever saw the truncated prefix:
+    // identical as far as it can tell, so the cutoff still fires.
+    expect(outcome.didReachRoundLimit).toBe(true);
+    expect(execCallCount).toBe(3);
+  });
+
   it('keeps looping when a repeated call returns different results', async () => {
     let execCallCount = 0;
     const { sandbox } = createFakeSandbox();

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -133,13 +133,26 @@ describe('runCodingAgent', () => {
     expect(outcome.summary).toContain('No pude leer eso');
   });
 
-  it('gives up at the round limit instead of looping forever', async () => {
+  it('gives up at the round limit and still wraps up with a spoken summary', async () => {
     const { sandbox } = createFakeSandbox();
     const { callLlm } = createScriptedLlm([
       {
         text: '',
-        toolCallList: [{ id: 'x', name: 'list_files', args: { path: '.' } }],
+        toolCallList: [{ id: 'a', name: 'list_files', args: { path: 'src' } }],
       },
+      {
+        text: '',
+        toolCallList: [{ id: 'b', name: 'list_files', args: { path: 'firmware' } }],
+      },
+      {
+        text: '',
+        toolCallList: [{ id: 'c', name: 'list_files', args: { path: 'documentation' } }],
+      },
+      {
+        text: '',
+        toolCallList: [{ id: 'd', name: 'list_files', args: { path: 'coverage' } }],
+      },
+      { text: 'Revisé todo y no encontré nada para tocar.', toolCallList: [] },
     ]);
 
     const outcome = await runCodingAgent({
@@ -152,7 +165,53 @@ describe('runCodingAgent', () => {
 
     expect(outcome.didReachRoundLimit).toBe(true);
     expect(outcome.roundCount).toBe(4);
-    expect(outcome.summary).toBe('');
+    expect(outcome.summary).toBe('Revisé todo y no encontré nada para tocar.');
+  });
+
+  it('warns on a repeated round and stops after three identical ones', async () => {
+    const { sandbox, callList } = createFakeSandbox();
+    const capturedCallList: {
+      readonly messageList: readonly {
+        readonly role: string;
+        readonly content?: string | null;
+      }[];
+      readonly toolDefinitionCount: number;
+    }[] = [];
+    const callLlm: CodingLlmCaller = async ({ messageList, toolDefinitionList }) => {
+      capturedCallList.push({
+        messageList: [...messageList],
+        toolDefinitionCount: toolDefinitionList.length,
+      });
+      if (toolDefinitionList.length === 0) {
+        return { text: 'Di vueltas sin llegar a nada concreto.', toolCallList: [] };
+      }
+      return {
+        text: '',
+        toolCallList: [{ id: 'x', name: 'list_files', args: { path: '.' } }],
+      };
+    };
+
+    const outcome = await runCodingAgent({
+      sandbox,
+      callLlm,
+      repositoryLabel: 'galfrevn/apollo',
+      taskText: 'dar vueltas para siempre',
+    });
+
+    expect(outcome.didReachRoundLimit).toBe(true);
+    expect(outcome.roundCount).toBe(3);
+    expect(outcome.summary).toBe('Di vueltas sin llegar a nada concreto.');
+    // The third identical round is cut before touching the sandbox.
+    expect(callList.filter((call) => call.kind === 'list')).toHaveLength(2);
+    const flattenedContentList = capturedCallList.flatMap((call) =>
+      call.messageList.map((message) => message.content ?? ''),
+    );
+    expect(flattenedContentList.some((content) => content.includes('repitiendo'))).toBe(
+      true,
+    );
+    const wrapUpCall = capturedCallList.at(-1);
+    expect(wrapUpCall?.toolDefinitionCount).toBe(0);
+    expect(wrapUpCall?.messageList.at(-1)?.content).toContain('Se terminaron las rondas');
   });
 
   it('runs commands at the repository root', async () => {

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -226,8 +226,10 @@ describe('runCodingAgent', () => {
         return { stdout: `${longPrefix}${execCallCount}`, stderr: '', exitCode: 0 };
       },
     };
+    let sawWrapUpRequest = false;
     const callLlm: CodingLlmCaller = async ({ toolDefinitionList }) => {
       if (toolDefinitionList.length === 0) {
+        sawWrapUpRequest = true;
         return { text: 'No pude avanzar con eso.', toolCallList: [] };
       }
       return {
@@ -247,6 +249,7 @@ describe('runCodingAgent', () => {
     // identical as far as it can tell, so the cutoff still fires.
     expect(outcome.didReachRoundLimit).toBe(true);
     expect(execCallCount).toBe(3);
+    expect(sawWrapUpRequest).toBe(true);
   });
 
   it('keeps looping when a repeated call returns different results', async () => {

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -201,8 +201,9 @@ describe('runCodingAgent', () => {
     expect(outcome.didReachRoundLimit).toBe(true);
     expect(outcome.roundCount).toBe(3);
     expect(outcome.summary).toBe('Di vueltas sin llegar a nada concreto.');
-    // The third identical round is cut before touching the sandbox.
-    expect(callList.filter((call) => call.kind === 'list')).toHaveLength(2);
+    // The third identical round still executes — its results are what prove
+    // the loop — but nothing runs after it.
+    expect(callList.filter((call) => call.kind === 'list')).toHaveLength(3);
     const flattenedContentList = capturedCallList.flatMap((call) =>
       call.messageList.map((message) => message.content ?? ''),
     );
@@ -212,6 +213,48 @@ describe('runCodingAgent', () => {
     const wrapUpCall = capturedCallList.at(-1);
     expect(wrapUpCall?.toolDefinitionCount).toBe(0);
     expect(wrapUpCall?.messageList.at(-1)?.content).toContain('Se terminaron las rondas');
+  });
+
+  it('keeps looping when a repeated call returns different results', async () => {
+    let execCallCount = 0;
+    const { sandbox } = createFakeSandbox();
+    const changingSandbox: CodingSandboxPort = {
+      ...sandbox,
+      exec: async () => {
+        execCallCount += 1;
+        return { stdout: `intento ${execCallCount}`, stderr: '', exitCode: 0 };
+      },
+    };
+    let llmCallCount = 0;
+    const callLlm: CodingLlmCaller = async ({ toolDefinitionList }) => {
+      llmCallCount += 1;
+      if (toolDefinitionList.length > 0 && llmCallCount <= 5) {
+        return {
+          text: '',
+          toolCallList: [
+            {
+              id: `c${llmCallCount}`,
+              name: 'run_command',
+              args: { command: 'bun test' },
+            },
+          ],
+        };
+      }
+      return { text: 'Los tests quedaron en verde.', toolCallList: [] };
+    };
+
+    const outcome = await runCodingAgent({
+      sandbox: changingSandbox,
+      callLlm,
+      repositoryLabel: 'galfrevn/apollo',
+      taskText: 'arreglá los tests',
+    });
+
+    // Same command five times, but each run returned something new: that is
+    // progress, not a loop, so the run ends on the model's own reply.
+    expect(execCallCount).toBe(5);
+    expect(outcome.didReachRoundLimit).toBe(false);
+    expect(outcome.summary).toBe('Los tests quedaron en verde.');
   });
 
   it('runs commands at the repository root', async () => {

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -306,11 +306,14 @@ export async function runCodingAgent(input: {
       } catch (error) {
         toolOutput = `Error: ${error instanceof Error ? error.message : String(error)}`;
       }
-      toolOutputList.push(toolOutput);
+      // Truncated before both uses: a difference the truncation hides is
+      // invisible to the model, so it must not count as progress either.
+      const truncatedToolOutput = truncateSandboxOutputForToolResult(toolOutput);
+      toolOutputList.push(truncatedToolOutput);
       messageList.push({
         role: 'tool',
         tool_call_id: toolCall.id,
-        content: truncateSandboxOutputForToolResult(toolOutput),
+        content: truncatedToolOutput,
       });
     }
 

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -6,9 +6,10 @@ import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
 import type { OpenRouterChatMessage, OpenRouterChatResult } from '@/voice/llm';
 
 export const DEFAULT_CODING_ROUND_LIMIT = 24;
-// Two identical rounds get the model a warning; a third ends the run. Seen in
-// production: a model re-reading the same README and re-running the same ls
-// until the round limit, with nothing to show for it.
+// Two rounds with identical calls and identical results get the model a
+// warning; a third ends the run. Seen in production: a model re-reading the
+// same README and re-running the same ls until the round limit, with nothing
+// to show for it.
 export const REPEATED_ROUND_STOP_COUNT = 3;
 const COMMAND_TIMEOUT_MILLISECONDS = 300_000;
 
@@ -199,8 +200,12 @@ async function executeCodingTool(input: {
 
 function buildRoundSignature(
   toolCallList: readonly { readonly name: string; readonly args: unknown }[],
+  toolOutputList: readonly string[],
 ): string {
-  return JSON.stringify(toolCallList.map((toolCall) => [toolCall.name, toolCall.args]));
+  return JSON.stringify([
+    toolCallList.map((toolCall) => [toolCall.name, toolCall.args]),
+    toolOutputList,
+  ]);
 }
 
 const REPEATED_ROUND_WARNING =
@@ -273,15 +278,6 @@ export async function runCodingAgent(input: {
     }
 
     completedRoundCount = roundIndex + 1;
-    const roundSignature = buildRoundSignature(llmResult.toolCallList);
-    identicalRoundCount =
-      roundSignature === previousRoundSignature ? identicalRoundCount + 1 : 1;
-    previousRoundSignature = roundSignature;
-    // Broken out before the assistant message lands: an assistant tool call
-    // without its tool results would poison the wrap-up request below.
-    if (identicalRoundCount >= REPEATED_ROUND_STOP_COUNT) {
-      break;
-    }
 
     messageList.push({
       role: 'assistant',
@@ -296,6 +292,7 @@ export async function runCodingAgent(input: {
       })),
     });
 
+    const toolOutputList: string[] = [];
     for (const toolCall of llmResult.toolCallList) {
       transcript.push(summarizeToolCallForTranscript(toolCall.name, toolCall.args));
       let toolOutput: string;
@@ -309,6 +306,7 @@ export async function runCodingAgent(input: {
       } catch (error) {
         toolOutput = `Error: ${error instanceof Error ? error.message : String(error)}`;
       }
+      toolOutputList.push(toolOutput);
       messageList.push({
         role: 'tool',
         tool_call_id: toolCall.id,
@@ -316,6 +314,15 @@ export async function runCodingAgent(input: {
       });
     }
 
+    // A repeat only counts when the results came back identical too: the same
+    // command against changed sandbox state is progress, not a loop.
+    const roundSignature = buildRoundSignature(llmResult.toolCallList, toolOutputList);
+    identicalRoundCount =
+      roundSignature === previousRoundSignature ? identicalRoundCount + 1 : 1;
+    previousRoundSignature = roundSignature;
+    if (identicalRoundCount >= REPEATED_ROUND_STOP_COUNT) {
+      break;
+    }
     if (identicalRoundCount >= 2) {
       messageList.push({ role: 'user', content: REPEATED_ROUND_WARNING });
     }

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -6,6 +6,10 @@ import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
 import type { OpenRouterChatMessage, OpenRouterChatResult } from '@/voice/llm';
 
 export const DEFAULT_CODING_ROUND_LIMIT = 24;
+// Two identical rounds get the model a warning; a third ends the run. Seen in
+// production: a model re-reading the same README and re-running the same ls
+// until the round limit, with nothing to show for it.
+export const REPEATED_ROUND_STOP_COUNT = 3;
 const COMMAND_TIMEOUT_MILLISECONDS = 300_000;
 
 export type CodingSandboxPort = {
@@ -112,6 +116,8 @@ export function buildCodingSystemPrompt(input: {
     '- Si el repo tiene tests o linter, corrélos con run_command y arreglá lo que rompas.',
     '- No toques .git, ni archivos fuera del repositorio, ni secretos.',
     '- No hagas commit ni push: de eso se encarga Apollo cuando terminás.',
+    '- Si la tarea es de solo lectura (auditoría, análisis, revisión), no inventes',
+    '  cambios: tu respuesta final es el informe.',
     '',
     'Cuando la tarea esté lista, respondé sin llamar más herramientas, con un resumen corto',
     'en español rioplatense de qué cambiaste y por qué. Ese resumen se lee en voz alta.',
@@ -191,6 +197,38 @@ async function executeCodingTool(input: {
   return `Herramienta desconocida: ${toolName}`;
 }
 
+function buildRoundSignature(
+  toolCallList: readonly { readonly name: string; readonly args: unknown }[],
+): string {
+  return JSON.stringify(toolCallList.map((toolCall) => [toolCall.name, toolCall.args]));
+}
+
+const REPEATED_ROUND_WARNING =
+  'Estás repitiendo exactamente las mismas llamadas y el resultado no va a cambiar. ' +
+  'Avanzá con la tarea, o si ya está lista respondé sin llamar herramientas.';
+
+const WRAP_UP_PROMPT =
+  'Se terminaron las rondas de herramientas. Respondé ahora, sin llamar ninguna, ' +
+  'con el resumen corto en español rioplatense de qué hiciste o encontraste.';
+
+// The run ended without a plain reply, but the conversation so far still holds
+// everything the model learned: one last call without tools turns that into a
+// spoken summary instead of throwing the whole run away.
+async function requestWrapUpSummary(
+  callLlm: CodingLlmCaller,
+  messageList: readonly OpenRouterChatMessage[],
+): Promise<string> {
+  try {
+    const wrapUpResult = await callLlm({
+      messageList: [...messageList, { role: 'user', content: WRAP_UP_PROMPT }],
+      toolDefinitionList: [],
+    });
+    return wrapUpResult.text.trim();
+  } catch {
+    return '';
+  }
+}
+
 export async function runCodingAgent(input: {
   readonly sandbox: CodingSandboxPort;
   readonly callLlm: CodingLlmCaller;
@@ -215,6 +253,10 @@ export async function runCodingAgent(input: {
     { role: 'user', content: input.taskText },
   ];
 
+  let previousRoundSignature = '';
+  let identicalRoundCount = 0;
+  let completedRoundCount = 0;
+
   for (let roundIndex = 0; roundIndex < roundLimit; roundIndex += 1) {
     const llmResult = await input.callLlm({
       messageList,
@@ -228,6 +270,17 @@ export async function runCodingAgent(input: {
         didReachRoundLimit: false,
         transcript,
       };
+    }
+
+    completedRoundCount = roundIndex + 1;
+    const roundSignature = buildRoundSignature(llmResult.toolCallList);
+    identicalRoundCount =
+      roundSignature === previousRoundSignature ? identicalRoundCount + 1 : 1;
+    previousRoundSignature = roundSignature;
+    // Broken out before the assistant message lands: an assistant tool call
+    // without its tool results would poison the wrap-up request below.
+    if (identicalRoundCount >= REPEATED_ROUND_STOP_COUNT) {
+      break;
     }
 
     messageList.push({
@@ -262,11 +315,15 @@ export async function runCodingAgent(input: {
         content: truncateSandboxOutputForToolResult(toolOutput),
       });
     }
+
+    if (identicalRoundCount >= 2) {
+      messageList.push({ role: 'user', content: REPEATED_ROUND_WARNING });
+    }
   }
 
   return {
-    summary: '',
-    roundCount: roundLimit,
+    summary: await requestWrapUpSummary(input.callLlm, messageList),
+    roundCount: completedRoundCount,
     didReachRoundLimit: true,
     transcript,
   };

--- a/src/turn/__tests__/run.spec.ts
+++ b/src/turn/__tests__/run.spec.ts
@@ -6,6 +6,7 @@ import { addMemoryRecord, type MemorySqlExecutor } from '@/memory/store';
 import { buildToolDefinitionMap } from '@/tools/router';
 import type { ToolDefinition } from '@/tools/types';
 import { runDeskTurn } from '@/turn/run';
+import type { OpenRouterChatMessage } from '@/voice/llm';
 
 function createInMemorySqlExecutor(): MemorySqlExecutor {
   const memoryRowList: Array<{
@@ -235,6 +236,64 @@ describe('runDeskTurn', () => {
 
     expect(output.pendingConfirmation).toBeTruthy();
     expect(output.uiEventList).toContain('NEED_CONFIRM');
+  });
+
+  it('replays an approved confirmation into the model conversation', async () => {
+    const unsafeTool: ToolDefinition = {
+      name: 'coding_task_test',
+      safety: 'unsafe',
+      description: 'programa',
+      parameters: { type: 'object', properties: {} },
+      buildConfirmSummary: () => 'Programar en apollo',
+      async handler() {
+        return { ok: true, summary: 'Arranco a programar en apollo.' };
+      },
+    };
+    let capturedMessageList: readonly OpenRouterChatMessage[] = [];
+
+    const output = await runDeskTurn({
+      text: 'confirmado',
+      confirmOk: true,
+      pendingConfirmation: {
+        id: 'confirm-1',
+        toolName: 'coding_task_test',
+        args: { repository: 'apollo' },
+        summary: 'Programar en apollo',
+        expiresAt: 1_000,
+      },
+      speechMode: 'default',
+      focusState: createInactiveDeskFocusState(),
+      sqlExecutor: createInMemorySqlExecutor(),
+      environment: fakeEnvironment,
+      toolDefinitionMap: buildToolDefinitionMap([unsafeTool]),
+      nowMilliseconds: 10,
+      adapters: {
+        stt: async () => '',
+        llm: async ({ messageList }) => {
+          capturedMessageList = messageList;
+          return { text: 'Listo, ya arranqué con apollo.', toolCallList: [] };
+        },
+        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+      },
+    });
+
+    const assistantToolCallMessage = capturedMessageList.find(
+      (message) => message.role === 'assistant' && message.tool_calls !== undefined,
+    );
+    expect(assistantToolCallMessage).toBeTruthy();
+    if (assistantToolCallMessage?.role === 'assistant') {
+      expect(assistantToolCallMessage.tool_calls?.[0]?.function.name).toBe(
+        'coding_task_test',
+      );
+    }
+    const toolResultMessage = capturedMessageList.find(
+      (message) => message.role === 'tool',
+    );
+    expect(toolResultMessage).toBeTruthy();
+    if (toolResultMessage?.role === 'tool') {
+      expect(toolResultMessage.content).toContain('Arranco a programar en apollo.');
+    }
+    expect(output.spokenText).toBe('Listo, ya arranqué con apollo.');
   });
 
   it('emits thinking captions before tools', async () => {

--- a/src/turn/run.ts
+++ b/src/turn/run.ts
@@ -138,6 +138,8 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
   const uiEventList: DeskUiEventName[] = ['START_THINK'];
   const toolResultList: ToolExecutionResult[] = [];
   let pendingConfirmation = input.pendingConfirmation;
+  let resolvedConfirmation: PendingToolConfirmation | undefined;
+  let resolvedConfirmationResult: ToolExecutionResult | undefined;
 
   if (pendingConfirmation !== undefined && input.confirmOk !== undefined) {
     const resolved = await resolvePendingToolConfirmation(
@@ -151,6 +153,10 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
         effects: input.effects,
       },
     );
+    if (!('cancelled' in resolved)) {
+      resolvedConfirmation = pendingConfirmation;
+      resolvedConfirmationResult = resolved;
+    }
     pendingConfirmation = undefined;
     if ('cancelled' in resolved) {
       uiEventList.push('CANCEL');
@@ -222,6 +228,21 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
     { role: 'system', content: systemPrompt },
     { role: 'user', content: userText },
   ];
+  // Each turn builds the LLM conversation from scratch, so an approved
+  // confirmation has to be replayed into it: without the tool call and its
+  // result the model only sees "confirmado" and asks what was approved.
+  if (resolvedConfirmation !== undefined && resolvedConfirmationResult !== undefined) {
+    messageList.push(
+      buildAssistantToolCallMessage('', [
+        {
+          id: resolvedConfirmation.id,
+          name: resolvedConfirmation.toolName,
+          args: resolvedConfirmation.args,
+        },
+      ]),
+      buildToolResultMessage(resolvedConfirmation.id, resolvedConfirmationResult),
+    );
+  }
 
   let spokenText = '';
 

--- a/src/workflows/coding.ts
+++ b/src/workflows/coding.ts
@@ -122,10 +122,37 @@ export class ApolloCoding extends WorkflowEntrypoint<Env, ApolloCodingParams> {
       });
 
       if (!extraction.hasChanges) {
-        const summary = agentOutcome.didReachRoundLimit
-          ? `Me quedé sin vueltas en ${repositoryLabel} y no llegué a cambiar nada.`
-          : `Revisé ${repositoryLabel} y no hizo falta cambiar nada.`;
-        await this.#notifyDevice(event.payload.deviceId, event.payload.task, summary);
+        // A read-only task (audit, review) legitimately changes nothing: the
+        // agent's reply is the deliverable, not a fallback line.
+        const summary =
+          agentOutcome.summary.length > 0
+            ? agentOutcome.summary
+            : agentOutcome.didReachRoundLimit
+              ? `Me quedé sin vueltas en ${repositoryLabel} y no llegué a cambiar nada.`
+              : `Revisé ${repositoryLabel} y no hizo falta cambiar nada.`;
+        const documentKey = buildCodingDocumentObjectKey(
+          event.payload.deviceId,
+          event.instanceId,
+        );
+        await step.do('persist-log', async () => {
+          const runLog = buildRunLog({
+            repositoryLabel,
+            taskText: event.payload.task,
+            branchName,
+            agentSummary: agentOutcome.summary,
+            transcript: agentOutcome.transcript,
+          });
+          await this.env.MEDIA.put(documentKey, redactSecretsFromText(runLog), {
+            httpMetadata: { contentType: 'text/markdown; charset=utf-8' },
+          });
+          return true;
+        });
+        await this.#notifyDevice(
+          event.payload.deviceId,
+          event.payload.task,
+          summary,
+          documentKey,
+        );
         return { summary };
       }
 
@@ -306,14 +333,16 @@ function buildRunLog(input: {
   readonly branchName: string;
   readonly agentSummary: string;
   readonly transcript: readonly string[];
-  readonly pullRequestUrl: string;
+  readonly pullRequestUrl?: string;
 }): string {
   return [
     `# Apollo — ${input.repositoryLabel}`,
     '',
     `**Tarea:** ${input.taskText}`,
     `**Branch:** ${input.branchName}`,
-    `**Pull request:** ${input.pullRequestUrl}`,
+    ...(input.pullRequestUrl !== undefined
+      ? [`**Pull request:** ${input.pullRequestUrl}`]
+      : []),
     '',
     '## Resumen',
     input.agentSummary,


### PR DESCRIPTION
### What was happening

Two problems observed on the device:

1. After approving a confirmation, the voice agent asked **what had been approved**. Each turn builds the LLM conversation from scratch, so the confirmation turn reached the model as a user saying `"confirmado"` with no context at all — the tool did execute, but the model had no idea what ran.
2. An audit task ended with *"I ran out of rounds and didn't get to change anything"*: the coding model got stuck in a loop (read the same README 4 times, ran the same `ls` 6+ times) until it burned all 24 rounds, and the workflow discarded both the agent's report and the transcript.

### What changes

- **Confirmation turn** (`src/turn/run.ts`): the resolved confirmation is replayed into the conversation as a reconstructed tool call plus its result, so the model replies knowing what was approved and what happened.
- **Coding agent loop** (`src/coding/agent.ts`): a round that repeats the previous one — same calls **and** same results — earns the model a warning; a third identical round stops the run. Re-running a command against changed sandbox state still counts as progress. When rounds run out, one final no-tools call rescues a spoken summary instead of returning empty. The system prompt now states that for read-only tasks the report is the deliverable.
- **Workflow** (`src/workflows/coding.ts`): the no-changes path speaks the agent's summary when present, and persists the run log to R2 (previously the log was only saved when a PR was opened — i.e. never when something went wrong).

### Tests

All green, with new cases for the confirmation replay, the repeated-round cutoff (including changing results not tripping it), and the wrap-up summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKEa3Q1e1boDFVmhdGstkZ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores confirmation context by replaying resolved tool calls, adds bounded coding-agent loop recovery, and persists no-change run logs.

- Reconstructs approved confirmation calls and results for the next model response.
- Stops identical coding-agent rounds and requests a final tool-free summary.
- Delivers read-only summaries and stores their redacted run logs.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["test(coding): assert the truncated-outpu..."](https://github.com/galfrevn/apollo/commit/4eb0657c5a8c510e4ef6fdc723786fc92d1c71a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52295485)</sub>

<!-- /greptile_comment -->