### PR TITLE
feat(coding): opencode as the coding engine, behind a worker LLM proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM docker.io/cloudflare/sandbox:0.12.4-python
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git ca-certificates \
+  && apt-get install -y --no-install-recommends git ca-certificates curl \
   && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://opencode.ai/install \
+  | VERSION=1.18.16 OPENCODE_INSTALL_DIR=/usr/local/bin bash \
+  && opencode --version
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,17 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates curl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://opencode.ai/install \
-  | VERSION=1.18.16 OPENCODE_INSTALL_DIR=/usr/local/bin bash \
+# Pinned by version and checksum: the release tarball is fetched over HTTPS,
+# but only a byte-for-byte match with the recorded digest reaches the image.
+ARG OPENCODE_VERSION=1.18.16
+ARG OPENCODE_SHA256=286e07355df06738c1905955be15b7fbc10a7b12d931de9394a6f7597246750b
+RUN curl -fsSL -o /tmp/opencode.tar.gz \
+  "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
+  && echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum -c - \
+  && mkdir -p /tmp/opencode-dist \
+  && tar -xzf /tmp/opencode.tar.gz -C /tmp/opencode-dist \
+  && install -m 755 "$(find /tmp/opencode-dist -type f -name opencode | head -n 1)" /usr/local/bin/opencode \
+  && rm -rf /tmp/opencode.tar.gz /tmp/opencode-dist \
   && opencode --version
 
 EXPOSE 8080

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -215,6 +215,40 @@ describe('runCodingAgent', () => {
     expect(wrapUpCall?.messageList.at(-1)?.content).toContain('Se terminaron las rondas');
   });
 
+  it('treats outputs differing only past the truncation cutoff as identical', async () => {
+    let execCallCount = 0;
+    const { sandbox } = createFakeSandbox();
+    const longPrefix = 'x'.repeat(5_000);
+    const tailChangingSandbox: CodingSandboxPort = {
+      ...sandbox,
+      exec: async () => {
+        execCallCount += 1;
+        return { stdout: `${longPrefix}${execCallCount}`, stderr: '', exitCode: 0 };
+      },
+    };
+    const callLlm: CodingLlmCaller = async ({ toolDefinitionList }) => {
+      if (toolDefinitionList.length === 0) {
+        return { text: 'No pude avanzar con eso.', toolCallList: [] };
+      }
+      return {
+        text: '',
+        toolCallList: [{ id: 'x', name: 'run_command', args: { command: 'cat log' } }],
+      };
+    };
+
+    const outcome = await runCodingAgent({
+      sandbox: tailChangingSandbox,
+      callLlm,
+      repositoryLabel: 'galfrevn/apollo',
+      taskText: 'dar vueltas para siempre',
+    });
+
+    // The tails differ, but the model only ever saw the truncated prefix:
+    // identical as far as it can tell, so the cutoff still fires.
+    expect(outcome.didReachRoundLimit).toBe(true);
+    expect(execCallCount).toBe(3);
+  });
+
   it('keeps looping when a repeated call returns different results', async () => {
     let execCallCount = 0;
     const { sandbox } = createFakeSandbox();

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -133,13 +133,26 @@ describe('runCodingAgent', () => {
     expect(outcome.summary).toContain('No pude leer eso');
   });
 
-  it('gives up at the round limit instead of looping forever', async () => {
+  it('gives up at the round limit and still wraps up with a spoken summary', async () => {
     const { sandbox } = createFakeSandbox();
     const { callLlm } = createScriptedLlm([
       {
         text: '',
-        toolCallList: [{ id: 'x', name: 'list_files', args: { path: '.' } }],
+        toolCallList: [{ id: 'a', name: 'list_files', args: { path: 'src' } }],
       },
+      {
+        text: '',
+        toolCallList: [{ id: 'b', name: 'list_files', args: { path: 'firmware' } }],
+      },
+      {
+        text: '',
+        toolCallList: [{ id: 'c', name: 'list_files', args: { path: 'documentation' } }],
+      },
+      {
+        text: '',
+        toolCallList: [{ id: 'd', name: 'list_files', args: { path: 'coverage' } }],
+      },
+      { text: 'Revisé todo y no encontré nada para tocar.', toolCallList: [] },
     ]);
 
     const outcome = await runCodingAgent({
@@ -152,7 +165,53 @@ describe('runCodingAgent', () => {
 
     expect(outcome.didReachRoundLimit).toBe(true);
     expect(outcome.roundCount).toBe(4);
-    expect(outcome.summary).toBe('');
+    expect(outcome.summary).toBe('Revisé todo y no encontré nada para tocar.');
+  });
+
+  it('warns on a repeated round and stops after three identical ones', async () => {
+    const { sandbox, callList } = createFakeSandbox();
+    const capturedCallList: {
+      readonly messageList: readonly {
+        readonly role: string;
+        readonly content?: string | null;
+      }[];
+      readonly toolDefinitionCount: number;
+    }[] = [];
+    const callLlm: CodingLlmCaller = async ({ messageList, toolDefinitionList }) => {
+      capturedCallList.push({
+        messageList: [...messageList],
+        toolDefinitionCount: toolDefinitionList.length,
+      });
+      if (toolDefinitionList.length === 0) {
+        return { text: 'Di vueltas sin llegar a nada concreto.', toolCallList: [] };
+      }
+      return {
+        text: '',
+        toolCallList: [{ id: 'x', name: 'list_files', args: { path: '.' } }],
+      };
+    };
+
+    const outcome = await runCodingAgent({
+      sandbox,
+      callLlm,
+      repositoryLabel: 'galfrevn/apollo',
+      taskText: 'dar vueltas para siempre',
+    });
+
+    expect(outcome.didReachRoundLimit).toBe(true);
+    expect(outcome.roundCount).toBe(3);
+    expect(outcome.summary).toBe('Di vueltas sin llegar a nada concreto.');
+    // The third identical round is cut before touching the sandbox.
+    expect(callList.filter((call) => call.kind === 'list')).toHaveLength(2);
+    const flattenedContentList = capturedCallList.flatMap((call) =>
+      call.messageList.map((message) => message.content ?? ''),
+    );
+    expect(flattenedContentList.some((content) => content.includes('repitiendo'))).toBe(
+      true,
+    );
+    const wrapUpCall = capturedCallList.at(-1);
+    expect(wrapUpCall?.toolDefinitionCount).toBe(0);
+    expect(wrapUpCall?.messageList.at(-1)?.content).toContain('Se terminaron las rondas');
   });
 
   it('runs commands at the repository root', async () => {

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -226,8 +226,10 @@ describe('runCodingAgent', () => {
         return { stdout: `${longPrefix}${execCallCount}`, stderr: '', exitCode: 0 };
       },
     };
+    let sawWrapUpRequest = false;
     const callLlm: CodingLlmCaller = async ({ toolDefinitionList }) => {
       if (toolDefinitionList.length === 0) {
+        sawWrapUpRequest = true;
         return { text: 'No pude avanzar con eso.', toolCallList: [] };
       }
       return {
@@ -247,6 +249,7 @@ describe('runCodingAgent', () => {
     // identical as far as it can tell, so the cutoff still fires.
     expect(outcome.didReachRoundLimit).toBe(true);
     expect(execCallCount).toBe(3);
+    expect(sawWrapUpRequest).toBe(true);
   });
 
   it('keeps looping when a repeated call returns different results', async () => {

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -201,8 +201,9 @@ describe('runCodingAgent', () => {
     expect(outcome.didReachRoundLimit).toBe(true);
     expect(outcome.roundCount).toBe(3);
     expect(outcome.summary).toBe('Di vueltas sin llegar a nada concreto.');
-    // The third identical round is cut before touching the sandbox.
-    expect(callList.filter((call) => call.kind === 'list')).toHaveLength(2);
+    // The third identical round still executes — its results are what prove
+    // the loop — but nothing runs after it.
+    expect(callList.filter((call) => call.kind === 'list')).toHaveLength(3);
     const flattenedContentList = capturedCallList.flatMap((call) =>
       call.messageList.map((message) => message.content ?? ''),
     );
@@ -212,6 +213,48 @@ describe('runCodingAgent', () => {
     const wrapUpCall = capturedCallList.at(-1);
     expect(wrapUpCall?.toolDefinitionCount).toBe(0);
     expect(wrapUpCall?.messageList.at(-1)?.content).toContain('Se terminaron las rondas');
+  });
+
+  it('keeps looping when a repeated call returns different results', async () => {
+    let execCallCount = 0;
+    const { sandbox } = createFakeSandbox();
+    const changingSandbox: CodingSandboxPort = {
+      ...sandbox,
+      exec: async () => {
+        execCallCount += 1;
+        return { stdout: `intento ${execCallCount}`, stderr: '', exitCode: 0 };
+      },
+    };
+    let llmCallCount = 0;
+    const callLlm: CodingLlmCaller = async ({ toolDefinitionList }) => {
+      llmCallCount += 1;
+      if (toolDefinitionList.length > 0 && llmCallCount <= 5) {
+        return {
+          text: '',
+          toolCallList: [
+            {
+              id: `c${llmCallCount}`,
+              name: 'run_command',
+              args: { command: 'bun test' },
+            },
+          ],
+        };
+      }
+      return { text: 'Los tests quedaron en verde.', toolCallList: [] };
+    };
+
+    const outcome = await runCodingAgent({
+      sandbox: changingSandbox,
+      callLlm,
+      repositoryLabel: 'galfrevn/apollo',
+      taskText: 'arreglá los tests',
+    });
+
+    // Same command five times, but each run returned something new: that is
+    // progress, not a loop, so the run ends on the model's own reply.
+    expect(execCallCount).toBe(5);
+    expect(outcome.didReachRoundLimit).toBe(false);
+    expect(outcome.summary).toBe('Los tests quedaron en verde.');
   });
 
   it('runs commands at the repository root', async () => {

--- a/src/coding/__tests__/opencode.spec.ts
+++ b/src/coding/__tests__/opencode.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildOpencodeConfig,
+  buildOpencodeRunCommand,
+  OPENCODE_CONFIG_PATH,
+  OPENCODE_SUMMARY_PATH,
+  runOpencodeAgent,
+} from '@/coding/opencode';
+import type { SandboxLike } from '@/coding/run';
+
+function createFakeSandbox(input: {
+  readonly execResult?: { stdout: string; stderr: string; exitCode: number };
+  readonly summaryContent?: string;
+}): {
+  readonly sandbox: SandboxLike;
+  readonly writtenFileByPath: Record<string, string>;
+  readonly execCallList: {
+    readonly command: string;
+    readonly options?: {
+      readonly cwd?: string;
+      readonly env?: Record<string, string>;
+      readonly timeout?: number;
+    };
+  }[];
+} {
+  const writtenFileByPath: Record<string, string> = {};
+  const execCallList: {
+    command: string;
+    options?: {
+      readonly cwd?: string;
+      readonly env?: Record<string, string>;
+      readonly timeout?: number;
+    };
+  }[] = [];
+  return {
+    writtenFileByPath,
+    execCallList,
+    sandbox: {
+      exec: async (command, options) => {
+        execCallList.push({ command, options });
+        return input.execResult ?? { stdout: 'listo', stderr: '', exitCode: 0 };
+      },
+      listFiles: async () => [],
+      readFile: async (path) => {
+        if (path === OPENCODE_SUMMARY_PATH && input.summaryContent !== undefined) {
+          return { content: input.summaryContent };
+        }
+        throw new Error('no existe');
+      },
+      writeFile: async (path, content) => {
+        writtenFileByPath[path] = content;
+      },
+    },
+  };
+}
+
+describe('buildOpencodeConfig', () => {
+  it('points the provider at the worker proxy with the token as env reference', () => {
+    const configText = buildOpencodeConfig({
+      proxyOrigin: 'https://apollo.example',
+      modelId: 'moonshotai/kimi-k3',
+    });
+    const config = JSON.parse(configText) as Record<string, unknown>;
+
+    expect(configText).toContain('https://apollo.example/coding-llm/v1');
+    expect(configText).toContain('{env:APOLLO_LLM_TOKEN}');
+    expect(configText).not.toContain('sk-or');
+    expect(config.model).toBe('apollo/moonshotai/kimi-k3');
+    expect(configText).toContain('"webfetch": "deny"');
+  });
+});
+
+describe('runOpencodeAgent', () => {
+  it('writes the config, runs opencode with the scoped env, and reads the summary', async () => {
+    const { sandbox, writtenFileByPath, execCallList } = createFakeSandbox({
+      summaryContent: 'Agregué el endpoint y los tests pasan.\n',
+    });
+
+    const outcome = await runOpencodeAgent({
+      sandbox,
+      proxyOrigin: 'https://apollo.example',
+      proxyToken: 'wf-1.999.abc',
+      modelId: 'moonshotai/kimi-k3',
+      taskText: 'agregá un endpoint de status',
+    });
+
+    expect(writtenFileByPath[OPENCODE_CONFIG_PATH]).toContain('coding-llm/v1');
+    const execCall = execCallList[0];
+    expect(execCall.command).toContain('opencode run');
+    expect(execCall.command).toContain("'apollo/moonshotai/kimi-k3'");
+    expect(execCall.command).toContain('agregá un endpoint de status');
+    expect(execCall.options?.cwd).toBe('/workspace/repo');
+    expect(execCall.options?.env?.APOLLO_LLM_TOKEN).toBe('wf-1.999.abc');
+    expect(execCall.options?.env?.OPENCODE_CONFIG).toBe(OPENCODE_CONFIG_PATH);
+    expect(outcome.summary).toBe('Agregué el endpoint y los tests pasan.');
+    expect(outcome.didReachRoundLimit).toBe(false);
+  });
+
+  it('falls back to the tail of stdout when the summary file is missing', async () => {
+    const { sandbox } = createFakeSandbox({
+      execResult: {
+        stdout: 'ruido\nAjusté la validación del formulario.',
+        stderr: '',
+        exitCode: 0,
+      },
+    });
+
+    const outcome = await runOpencodeAgent({
+      sandbox,
+      proxyOrigin: 'https://apollo.example',
+      proxyToken: 't',
+      modelId: 'moonshotai/kimi-k3',
+      taskText: 'arreglá el formulario',
+    });
+
+    expect(outcome.summary).toContain('Ajusté la validación');
+  });
+
+  it('throws when opencode exits non-zero so the step can retry', async () => {
+    const { sandbox } = createFakeSandbox({
+      execResult: { stdout: '', stderr: 'boom', exitCode: 1 },
+    });
+
+    await expect(
+      runOpencodeAgent({
+        sandbox,
+        proxyOrigin: 'https://apollo.example',
+        proxyToken: 't',
+        modelId: 'moonshotai/kimi-k3',
+        taskText: 'tarea',
+      }),
+    ).rejects.toThrow('opencode falló');
+  });
+
+  it('keeps the run command free of the token itself', () => {
+    const command = buildOpencodeRunCommand({
+      modelId: 'moonshotai/kimi-k3',
+      taskText: 'auditá el repo',
+    });
+    expect(command).not.toContain('APOLLO_LLM_TOKEN=');
+    expect(command).toContain(OPENCODE_SUMMARY_PATH);
+  });
+});

--- a/src/coding/__tests__/opencode.spec.ts
+++ b/src/coding/__tests__/opencode.spec.ts
@@ -86,6 +86,8 @@ describe('runOpencodeAgent', () => {
     });
 
     expect(writtenFileByPath[OPENCODE_CONFIG_PATH]).toContain('coding-llm/v1');
+    // A failed attempt's summary must not leak into the retry that follows it.
+    expect(writtenFileByPath[OPENCODE_SUMMARY_PATH]).toBe('');
     const execCall = execCallList[0];
     expect(execCall.command).toContain('opencode run');
     expect(execCall.command).toContain("'apollo/moonshotai/kimi-k3'");

--- a/src/coding/__tests__/proxy.spec.ts
+++ b/src/coding/__tests__/proxy.spec.ts
@@ -122,6 +122,14 @@ describe('handleCodingLlmProxyRequest', () => {
     );
     expect(unauthorizedResponse.status).toBe(401);
 
+    const missingModelRequest = await buildAuthorizedRequest({ messages: [] });
+    const missingModelResponse = await handleCodingLlmProxyRequest(
+      missingModelRequest,
+      new URL(missingModelRequest.url),
+      environment,
+    );
+    expect(missingModelResponse.status).toBe(400);
+
     const foreignModelRequest = await buildAuthorizedRequest({
       model: 'openai/gpt-5',
       messages: [],

--- a/src/coding/__tests__/proxy.spec.ts
+++ b/src/coding/__tests__/proxy.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  handleCodingLlmProxyRequest,
+  mintCodingProxyToken,
+  verifyCodingProxyToken,
+} from '@/coding/proxy';
+import { createFakeApolloEnvironment } from '@/configuration/testing';
+
+const OPENROUTER_API_KEY = 'sk-or-test-key';
+
+describe('coding proxy tokens', () => {
+  it('accepts a freshly minted token and rejects it after expiry', async () => {
+    const token = await mintCodingProxyToken({
+      instanceId: 'wf-1',
+      openRouterApiKey: OPENROUTER_API_KEY,
+      nowMilliseconds: 1_000,
+    });
+
+    expect(
+      await verifyCodingProxyToken({
+        token,
+        openRouterApiKey: OPENROUTER_API_KEY,
+        nowMilliseconds: 2_000,
+      }),
+    ).toBe(true);
+    expect(
+      await verifyCodingProxyToken({
+        token,
+        openRouterApiKey: OPENROUTER_API_KEY,
+        nowMilliseconds: 1_000 + 7 * 60 * 60 * 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects a tampered token and a token signed with another key', async () => {
+    const token = await mintCodingProxyToken({
+      instanceId: 'wf-1',
+      openRouterApiKey: OPENROUTER_API_KEY,
+      nowMilliseconds: 1_000,
+    });
+
+    expect(
+      await verifyCodingProxyToken({
+        token: token.replace('wf-1', 'wf-2'),
+        openRouterApiKey: OPENROUTER_API_KEY,
+        nowMilliseconds: 2_000,
+      }),
+    ).toBe(false);
+    expect(
+      await verifyCodingProxyToken({
+        token,
+        openRouterApiKey: 'sk-or-other-key',
+        nowMilliseconds: 2_000,
+      }),
+    ).toBe(false);
+    expect(
+      await verifyCodingProxyToken({
+        token: 'garbage',
+        openRouterApiKey: OPENROUTER_API_KEY,
+        nowMilliseconds: 2_000,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('handleCodingLlmProxyRequest', () => {
+  async function buildAuthorizedRequest(bodyObject: unknown): Promise<Request> {
+    const token = await mintCodingProxyToken({
+      instanceId: 'wf-1',
+      openRouterApiKey: OPENROUTER_API_KEY,
+      nowMilliseconds: Date.now(),
+    });
+    return new Request('https://apollo.example/coding-llm/v1/chat/completions', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify(bodyObject),
+    });
+  }
+
+  const environment = createFakeApolloEnvironment({
+    OPENROUTER_API_KEY,
+  });
+
+  it('forwards an authorized request to OpenRouter with the real key', async () => {
+    let forwardedUrl = '';
+    let forwardedAuthorization = '';
+    let forwardedBody = '';
+    const fakeFetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      forwardedUrl = String(url);
+      forwardedAuthorization = new Headers(init?.headers).get('authorization') ?? '';
+      forwardedBody = String(init?.body);
+      return new Response('{"ok":true}');
+    }) as typeof fetch;
+
+    const request = await buildAuthorizedRequest({
+      model: 'moonshotai/kimi-k3',
+      messages: [],
+    });
+    const response = await handleCodingLlmProxyRequest(
+      request,
+      new URL(request.url),
+      environment,
+      fakeFetch,
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwardedUrl).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(forwardedAuthorization).toBe(`Bearer ${OPENROUTER_API_KEY}`);
+    expect(forwardedBody).toContain('moonshotai/kimi-k3');
+  });
+
+  it('rejects a missing token, a foreign model, and a stray path', async () => {
+    const unauthorizedRequest = new Request(
+      'https://apollo.example/coding-llm/v1/chat/completions',
+      { method: 'POST', body: '{}' },
+    );
+    const unauthorizedResponse = await handleCodingLlmProxyRequest(
+      unauthorizedRequest,
+      new URL(unauthorizedRequest.url),
+      environment,
+    );
+    expect(unauthorizedResponse.status).toBe(401);
+
+    const foreignModelRequest = await buildAuthorizedRequest({
+      model: 'openai/gpt-5',
+      messages: [],
+    });
+    const foreignModelResponse = await handleCodingLlmProxyRequest(
+      foreignModelRequest,
+      new URL(foreignModelRequest.url),
+      environment,
+    );
+    expect(foreignModelResponse.status).toBe(403);
+
+    const strayPathRequest = new Request('https://apollo.example/coding-llm/v1/models', {
+      method: 'POST',
+      body: '{}',
+    });
+    const strayPathResponse = await handleCodingLlmProxyRequest(
+      strayPathRequest,
+      new URL(strayPathRequest.url),
+      environment,
+    );
+    expect(strayPathResponse.status).toBe(404);
+  });
+});

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -306,11 +306,14 @@ export async function runCodingAgent(input: {
       } catch (error) {
         toolOutput = `Error: ${error instanceof Error ? error.message : String(error)}`;
       }
-      toolOutputList.push(toolOutput);
+      // Truncated before both uses: a difference the truncation hides is
+      // invisible to the model, so it must not count as progress either.
+      const truncatedToolOutput = truncateSandboxOutputForToolResult(toolOutput);
+      toolOutputList.push(truncatedToolOutput);
       messageList.push({
         role: 'tool',
         tool_call_id: toolCall.id,
-        content: truncateSandboxOutputForToolResult(toolOutput),
+        content: truncatedToolOutput,
       });
     }
 

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -6,9 +6,10 @@ import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
 import type { OpenRouterChatMessage, OpenRouterChatResult } from '@/voice/llm';
 
 export const DEFAULT_CODING_ROUND_LIMIT = 24;
-// Two identical rounds get the model a warning; a third ends the run. Seen in
-// production: a model re-reading the same README and re-running the same ls
-// until the round limit, with nothing to show for it.
+// Two rounds with identical calls and identical results get the model a
+// warning; a third ends the run. Seen in production: a model re-reading the
+// same README and re-running the same ls until the round limit, with nothing
+// to show for it.
 export const REPEATED_ROUND_STOP_COUNT = 3;
 const COMMAND_TIMEOUT_MILLISECONDS = 300_000;
 
@@ -199,8 +200,12 @@ async function executeCodingTool(input: {
 
 function buildRoundSignature(
   toolCallList: readonly { readonly name: string; readonly args: unknown }[],
+  toolOutputList: readonly string[],
 ): string {
-  return JSON.stringify(toolCallList.map((toolCall) => [toolCall.name, toolCall.args]));
+  return JSON.stringify([
+    toolCallList.map((toolCall) => [toolCall.name, toolCall.args]),
+    toolOutputList,
+  ]);
 }
 
 const REPEATED_ROUND_WARNING =
@@ -273,15 +278,6 @@ export async function runCodingAgent(input: {
     }
 
     completedRoundCount = roundIndex + 1;
-    const roundSignature = buildRoundSignature(llmResult.toolCallList);
-    identicalRoundCount =
-      roundSignature === previousRoundSignature ? identicalRoundCount + 1 : 1;
-    previousRoundSignature = roundSignature;
-    // Broken out before the assistant message lands: an assistant tool call
-    // without its tool results would poison the wrap-up request below.
-    if (identicalRoundCount >= REPEATED_ROUND_STOP_COUNT) {
-      break;
-    }
 
     messageList.push({
       role: 'assistant',
@@ -296,6 +292,7 @@ export async function runCodingAgent(input: {
       })),
     });
 
+    const toolOutputList: string[] = [];
     for (const toolCall of llmResult.toolCallList) {
       transcript.push(summarizeToolCallForTranscript(toolCall.name, toolCall.args));
       let toolOutput: string;
@@ -309,6 +306,7 @@ export async function runCodingAgent(input: {
       } catch (error) {
         toolOutput = `Error: ${error instanceof Error ? error.message : String(error)}`;
       }
+      toolOutputList.push(toolOutput);
       messageList.push({
         role: 'tool',
         tool_call_id: toolCall.id,
@@ -316,6 +314,15 @@ export async function runCodingAgent(input: {
       });
     }
 
+    // A repeat only counts when the results came back identical too: the same
+    // command against changed sandbox state is progress, not a loop.
+    const roundSignature = buildRoundSignature(llmResult.toolCallList, toolOutputList);
+    identicalRoundCount =
+      roundSignature === previousRoundSignature ? identicalRoundCount + 1 : 1;
+    previousRoundSignature = roundSignature;
+    if (identicalRoundCount >= REPEATED_ROUND_STOP_COUNT) {
+      break;
+    }
     if (identicalRoundCount >= 2) {
       messageList.push({ role: 'user', content: REPEATED_ROUND_WARNING });
     }

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -6,6 +6,10 @@ import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
 import type { OpenRouterChatMessage, OpenRouterChatResult } from '@/voice/llm';
 
 export const DEFAULT_CODING_ROUND_LIMIT = 24;
+// Two identical rounds get the model a warning; a third ends the run. Seen in
+// production: a model re-reading the same README and re-running the same ls
+// until the round limit, with nothing to show for it.
+export const REPEATED_ROUND_STOP_COUNT = 3;
 const COMMAND_TIMEOUT_MILLISECONDS = 300_000;
 
 export type CodingSandboxPort = {
@@ -112,6 +116,8 @@ export function buildCodingSystemPrompt(input: {
     '- Si el repo tiene tests o linter, corrélos con run_command y arreglá lo que rompas.',
     '- No toques .git, ni archivos fuera del repositorio, ni secretos.',
     '- No hagas commit ni push: de eso se encarga Apollo cuando terminás.',
+    '- Si la tarea es de solo lectura (auditoría, análisis, revisión), no inventes',
+    '  cambios: tu respuesta final es el informe.',
     '',
     'Cuando la tarea esté lista, respondé sin llamar más herramientas, con un resumen corto',
     'en español rioplatense de qué cambiaste y por qué. Ese resumen se lee en voz alta.',
@@ -191,6 +197,38 @@ async function executeCodingTool(input: {
   return `Herramienta desconocida: ${toolName}`;
 }
 
+function buildRoundSignature(
+  toolCallList: readonly { readonly name: string; readonly args: unknown }[],
+): string {
+  return JSON.stringify(toolCallList.map((toolCall) => [toolCall.name, toolCall.args]));
+}
+
+const REPEATED_ROUND_WARNING =
+  'Estás repitiendo exactamente las mismas llamadas y el resultado no va a cambiar. ' +
+  'Avanzá con la tarea, o si ya está lista respondé sin llamar herramientas.';
+
+const WRAP_UP_PROMPT =
+  'Se terminaron las rondas de herramientas. Respondé ahora, sin llamar ninguna, ' +
+  'con el resumen corto en español rioplatense de qué hiciste o encontraste.';
+
+// The run ended without a plain reply, but the conversation so far still holds
+// everything the model learned: one last call without tools turns that into a
+// spoken summary instead of throwing the whole run away.
+async function requestWrapUpSummary(
+  callLlm: CodingLlmCaller,
+  messageList: readonly OpenRouterChatMessage[],
+): Promise<string> {
+  try {
+    const wrapUpResult = await callLlm({
+      messageList: [...messageList, { role: 'user', content: WRAP_UP_PROMPT }],
+      toolDefinitionList: [],
+    });
+    return wrapUpResult.text.trim();
+  } catch {
+    return '';
+  }
+}
+
 export async function runCodingAgent(input: {
   readonly sandbox: CodingSandboxPort;
   readonly callLlm: CodingLlmCaller;
@@ -215,6 +253,10 @@ export async function runCodingAgent(input: {
     { role: 'user', content: input.taskText },
   ];
 
+  let previousRoundSignature = '';
+  let identicalRoundCount = 0;
+  let completedRoundCount = 0;
+
   for (let roundIndex = 0; roundIndex < roundLimit; roundIndex += 1) {
     const llmResult = await input.callLlm({
       messageList,
@@ -228,6 +270,17 @@ export async function runCodingAgent(input: {
         didReachRoundLimit: false,
         transcript,
       };
+    }
+
+    completedRoundCount = roundIndex + 1;
+    const roundSignature = buildRoundSignature(llmResult.toolCallList);
+    identicalRoundCount =
+      roundSignature === previousRoundSignature ? identicalRoundCount + 1 : 1;
+    previousRoundSignature = roundSignature;
+    // Broken out before the assistant message lands: an assistant tool call
+    // without its tool results would poison the wrap-up request below.
+    if (identicalRoundCount >= REPEATED_ROUND_STOP_COUNT) {
+      break;
     }
 
     messageList.push({
@@ -262,11 +315,15 @@ export async function runCodingAgent(input: {
         content: truncateSandboxOutputForToolResult(toolOutput),
       });
     }
+
+    if (identicalRoundCount >= 2) {
+      messageList.push({ role: 'user', content: REPEATED_ROUND_WARNING });
+    }
   }
 
   return {
-    summary: '',
-    roundCount: roundLimit,
+    summary: await requestWrapUpSummary(input.callLlm, messageList),
+    roundCount: completedRoundCount,
     didReachRoundLimit: true,
     transcript,
   };

--- a/src/coding/opencode.ts
+++ b/src/coding/opencode.ts
@@ -89,6 +89,9 @@ export async function runOpencodeAgent(input: {
     OPENCODE_CONFIG_PATH,
     buildOpencodeConfig({ proxyOrigin: input.proxyOrigin, modelId: input.modelId }),
   );
+  // A retry runs in the same persistent sandbox: a summary left behind by a
+  // failed attempt must not pass as this run's result.
+  await input.sandbox.writeFile(OPENCODE_SUMMARY_PATH, '');
 
   const runResult = await input.sandbox.exec(
     buildOpencodeRunCommand({ modelId: input.modelId, taskText: input.taskText }),

--- a/src/coding/opencode.ts
+++ b/src/coding/opencode.ts
@@ -1,0 +1,132 @@
+import type { CodingAgentOutcome } from '@/coding/agent';
+import { CODING_WORKSPACE_PATH, quoteShellArgument } from '@/coding/git';
+import { CODING_PROXY_PATH_PREFIX } from '@/coding/proxy';
+import type { SandboxLike } from '@/coding/run';
+
+export const OPENCODE_PROVIDER_NAME = 'apollo';
+export const OPENCODE_TOKEN_ENVIRONMENT_NAME = 'APOLLO_LLM_TOKEN';
+// Outside the repo on purpose: nothing here may dirty the tree that
+// extract-changes turns into the pull request.
+export const OPENCODE_CONFIG_PATH = '/workspace/apollo-opencode.json';
+export const OPENCODE_SUMMARY_PATH = '/workspace/apollo-coding-summary.txt';
+const OPENCODE_RUN_TIMEOUT_MILLISECONDS = 2_700_000;
+const TRANSCRIPT_MAX_CHARACTER_COUNT = 100_000;
+
+export function buildOpencodeConfig(input: {
+  readonly proxyOrigin: string;
+  readonly modelId: string;
+}): string {
+  return JSON.stringify(
+    {
+      $schema: 'https://opencode.ai/config.json',
+      provider: {
+        [OPENCODE_PROVIDER_NAME]: {
+          npm: '@ai-sdk/openai-compatible',
+          name: 'Apollo LLM proxy',
+          options: {
+            baseURL: `${input.proxyOrigin}${CODING_PROXY_PATH_PREFIX}`,
+            apiKey: `{env:${OPENCODE_TOKEN_ENVIRONMENT_NAME}}`,
+          },
+          models: {
+            [input.modelId]: {
+              name: input.modelId,
+              limit: { context: 200_000, output: 32_768 },
+            },
+          },
+        },
+      },
+      model: `${OPENCODE_PROVIDER_NAME}/${input.modelId}`,
+      permission: { edit: 'allow', bash: 'allow', webfetch: 'deny' },
+      share: 'disabled',
+    },
+    null,
+    2,
+  );
+}
+
+export function buildOpencodePrompt(taskText: string): string {
+  return [
+    taskText.trim(),
+    '',
+    'Reglas de este entorno:',
+    '- No hagas commit ni push: de eso se encarga Apollo cuando terminás.',
+    '- Si la tarea es de solo lectura (auditoría, análisis, revisión), tu informe es el entregable.',
+    `- Al terminar, escribí un resumen corto en español rioplatense en ${OPENCODE_SUMMARY_PATH}.`,
+    '  Ese resumen se lee en voz alta, así que nada de markdown ni rutas largas.',
+  ].join('\n');
+}
+
+export function buildOpencodeRunCommand(input: {
+  readonly modelId: string;
+  readonly taskText: string;
+}): string {
+  return [
+    'opencode',
+    'run',
+    '--model',
+    quoteShellArgument(`${OPENCODE_PROVIDER_NAME}/${input.modelId}`),
+    quoteShellArgument(buildOpencodePrompt(input.taskText)),
+  ].join(' ');
+}
+
+function truncateTranscriptText(transcriptText: string): string {
+  if (transcriptText.length <= TRANSCRIPT_MAX_CHARACTER_COUNT) {
+    return transcriptText;
+  }
+  return `${transcriptText.slice(0, TRANSCRIPT_MAX_CHARACTER_COUNT)}\n… [salida truncada]`;
+}
+
+export async function runOpencodeAgent(input: {
+  readonly sandbox: SandboxLike;
+  readonly proxyOrigin: string;
+  readonly proxyToken: string;
+  readonly modelId: string;
+  readonly taskText: string;
+  readonly workspacePath?: string;
+}): Promise<CodingAgentOutcome> {
+  const workspacePath = input.workspacePath ?? CODING_WORKSPACE_PATH;
+  await input.sandbox.writeFile(
+    OPENCODE_CONFIG_PATH,
+    buildOpencodeConfig({ proxyOrigin: input.proxyOrigin, modelId: input.modelId }),
+  );
+
+  const runResult = await input.sandbox.exec(
+    buildOpencodeRunCommand({ modelId: input.modelId, taskText: input.taskText }),
+    {
+      cwd: workspacePath,
+      env: {
+        [OPENCODE_TOKEN_ENVIRONMENT_NAME]: input.proxyToken,
+        OPENCODE_CONFIG: OPENCODE_CONFIG_PATH,
+      },
+      timeout: OPENCODE_RUN_TIMEOUT_MILLISECONDS,
+    },
+  );
+  if (runResult.exitCode !== 0) {
+    throw new Error(
+      `opencode falló (exit ${runResult.exitCode}): ${`${runResult.stderr}\n${runResult.stdout}`
+        .trim()
+        .slice(0, 600)}`,
+    );
+  }
+
+  // The summary file is the contract with the prompt; a model that forgot it
+  // still streamed its final reply to stdout, which beats saying nothing.
+  let summary = '';
+  try {
+    summary = (await input.sandbox.readFile(OPENCODE_SUMMARY_PATH)).content.trim();
+  } catch {
+    summary = '';
+  }
+  if (summary.length === 0) {
+    summary = runResult.stdout.trim().split('\n').slice(-6).join(' ').trim();
+  }
+
+  return {
+    summary,
+    roundCount: 1,
+    didReachRoundLimit: false,
+    transcript: truncateTranscriptText(runResult.stdout.trim())
+      .split('\n')
+      .filter((line) => line.trim().length > 0),
+  };
+}

--- a/src/coding/proxy.ts
+++ b/src/coding/proxy.ts
@@ -1,0 +1,126 @@
+const OPENROUTER_CHAT_COMPLETIONS_URL = 'https://openrouter.ai/api/v1/chat/completions';
+export const CODING_PROXY_PATH_PREFIX = '/coding-llm/v1';
+export const CODING_PROXY_TOKEN_TTL_MILLISECONDS = 6 * 60 * 60 * 1000;
+
+// The token is signed with the OpenRouter key itself: the worker already holds
+// it, nothing new to provision, and rotating the key revokes every token that
+// ever reached a sandbox.
+async function computeTokenSignature(
+  openRouterApiKey: string,
+  payloadText: string,
+): Promise<string> {
+  const signingKey = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(openRouterApiKey),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signatureBytes = await crypto.subtle.sign(
+    'HMAC',
+    signingKey,
+    new TextEncoder().encode(payloadText),
+  );
+  return [...new Uint8Array(signatureBytes)]
+    .map((byteValue) => byteValue.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function mintCodingProxyToken(input: {
+  readonly instanceId: string;
+  readonly openRouterApiKey: string;
+  readonly nowMilliseconds: number;
+}): Promise<string> {
+  const expiresAtMilliseconds =
+    input.nowMilliseconds + CODING_PROXY_TOKEN_TTL_MILLISECONDS;
+  const payloadText = `${input.instanceId}.${expiresAtMilliseconds}`;
+  const signature = await computeTokenSignature(input.openRouterApiKey, payloadText);
+  return `${payloadText}.${signature}`;
+}
+
+export async function verifyCodingProxyToken(input: {
+  readonly token: string;
+  readonly openRouterApiKey: string;
+  readonly nowMilliseconds: number;
+}): Promise<boolean> {
+  const lastSeparatorIndex = input.token.lastIndexOf('.');
+  if (lastSeparatorIndex <= 0) {
+    return false;
+  }
+  const payloadText = input.token.slice(0, lastSeparatorIndex);
+  const presentedSignature = input.token.slice(lastSeparatorIndex + 1);
+  const expiresAtMilliseconds = Number(
+    payloadText.slice(payloadText.lastIndexOf('.') + 1),
+  );
+  if (!Number.isFinite(expiresAtMilliseconds)) {
+    return false;
+  }
+  if (input.nowMilliseconds > expiresAtMilliseconds) {
+    return false;
+  }
+  const expectedSignature = await computeTokenSignature(
+    input.openRouterApiKey,
+    payloadText,
+  );
+  if (presentedSignature.length !== expectedSignature.length) {
+    return false;
+  }
+  let differenceBits = 0;
+  for (
+    let characterIndex = 0;
+    characterIndex < expectedSignature.length;
+    characterIndex += 1
+  ) {
+    differenceBits |=
+      presentedSignature.charCodeAt(characterIndex) ^
+      expectedSignature.charCodeAt(characterIndex);
+  }
+  return differenceBits === 0;
+}
+
+// OpenAI-compatible passthrough for the opencode process inside the sandbox:
+// the real OpenRouter key never leaves the worker, and the sandbox only ever
+// sees a short-lived token this route can refuse.
+export async function handleCodingLlmProxyRequest(
+  request: Request,
+  requestUrl: URL,
+  environment: Env,
+  fetchImplementation: typeof fetch = globalThis.fetch,
+): Promise<Response> {
+  if (
+    request.method !== 'POST' ||
+    requestUrl.pathname !== `${CODING_PROXY_PATH_PREFIX}/chat/completions`
+  ) {
+    return new Response('Not found', { status: 404 });
+  }
+  const authorizationHeader = request.headers.get('authorization') ?? '';
+  const presentedToken = authorizationHeader.replace(/^Bearer\s+/i, '');
+  const isTokenValid = await verifyCodingProxyToken({
+    token: presentedToken,
+    openRouterApiKey: environment.OPENROUTER_API_KEY,
+    nowMilliseconds: Date.now(),
+  });
+  if (!isTokenValid) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const requestBodyText = await request.text();
+  let requestedModel: unknown;
+  try {
+    requestedModel = (JSON.parse(requestBodyText) as { model?: unknown }).model;
+  } catch {
+    return new Response('Bad request', { status: 400 });
+  }
+  if (requestedModel !== environment.OPENROUTER_CODING_MODEL) {
+    return new Response('Model not allowed', { status: 403 });
+  }
+
+  return fetchImplementation(OPENROUTER_CHAT_COMPLETIONS_URL, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${environment.OPENROUTER_API_KEY}`,
+      'content-type': 'application/json',
+    },
+    body: requestBodyText,
+  });
+}

--- a/src/coding/proxy.ts
+++ b/src/coding/proxy.ts
@@ -1,4 +1,8 @@
+import { z } from 'zod';
+
 const OPENROUTER_CHAT_COMPLETIONS_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+const proxyRequestBodySchema = z.object({ model: z.string() }).passthrough();
 export const CODING_PROXY_PATH_PREFIX = '/coding-llm/v1';
 export const CODING_PROXY_TOKEN_TTL_MILLISECONDS = 6 * 60 * 60 * 1000;
 
@@ -105,13 +109,17 @@ export async function handleCodingLlmProxyRequest(
   }
 
   const requestBodyText = await request.text();
-  let requestedModel: unknown;
+  let parsedBodyJson: unknown;
   try {
-    requestedModel = (JSON.parse(requestBodyText) as { model?: unknown }).model;
+    parsedBodyJson = JSON.parse(requestBodyText);
   } catch {
     return new Response('Bad request', { status: 400 });
   }
-  if (requestedModel !== environment.OPENROUTER_CODING_MODEL) {
+  const parsedBody = proxyRequestBodySchema.safeParse(parsedBodyJson);
+  if (!parsedBody.success) {
+    return new Response('Bad request', { status: 400 });
+  }
+  if (parsedBody.data.model !== environment.OPENROUTER_CODING_MODEL) {
     return new Response('Model not allowed', { status: 403 });
   }
 

--- a/src/configuration/environment.d.ts
+++ b/src/configuration/environment.d.ts
@@ -7,6 +7,8 @@ interface Env {
   GITHUB_APP_ID: string;
   GITHUB_APP_PRIVATE_KEY: string;
   MOCK_VOICE?: string;
+  CODING_PROXY_ORIGIN?: string;
+  CODING_ENGINE?: string;
 }
 
 declare namespace Cloudflare {
@@ -19,5 +21,7 @@ declare namespace Cloudflare {
     GITHUB_APP_ID: string;
     GITHUB_APP_PRIVATE_KEY: string;
     MOCK_VOICE?: string;
+    CODING_PROXY_ORIGIN?: string;
+    CODING_ENGINE?: string;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { routeAgentRequest } from 'agents';
 import { Sandbox } from '@cloudflare/sandbox';
 
 import { authorizeApolloConnection, Apollo } from '@/agents/apollo';
+import { CODING_PROXY_PATH_PREFIX, handleCodingLlmProxyRequest } from '@/coding/proxy';
 import { handleOtaRequest } from '@/ota/routes';
 import { consumeApolloQueueBatch } from '@/queues/consume';
 import { ApolloBackground } from '@/workflows/background';
@@ -23,6 +24,10 @@ export default {
 
     if (requestUrl.pathname.startsWith('/ota/')) {
       return handleOtaRequest(request, requestUrl, environment);
+    }
+
+    if (requestUrl.pathname.startsWith(`${CODING_PROXY_PATH_PREFIX}/`)) {
+      return handleCodingLlmProxyRequest(request, requestUrl, environment);
     }
 
     const agentResponse = await routeAgentRequest(request, environment, {

--- a/src/turn/__tests__/run.spec.ts
+++ b/src/turn/__tests__/run.spec.ts
@@ -6,6 +6,7 @@ import { addMemoryRecord, type MemorySqlExecutor } from '@/memory/store';
 import { buildToolDefinitionMap } from '@/tools/router';
 import type { ToolDefinition } from '@/tools/types';
 import { runDeskTurn } from '@/turn/run';
+import type { OpenRouterChatMessage } from '@/voice/llm';
 
 function createInMemorySqlExecutor(): MemorySqlExecutor {
   const memoryRowList: Array<{
@@ -235,6 +236,64 @@ describe('runDeskTurn', () => {
 
     expect(output.pendingConfirmation).toBeTruthy();
     expect(output.uiEventList).toContain('NEED_CONFIRM');
+  });
+
+  it('replays an approved confirmation into the model conversation', async () => {
+    const unsafeTool: ToolDefinition = {
+      name: 'coding_task_test',
+      safety: 'unsafe',
+      description: 'programa',
+      parameters: { type: 'object', properties: {} },
+      buildConfirmSummary: () => 'Programar en apollo',
+      async handler() {
+        return { ok: true, summary: 'Arranco a programar en apollo.' };
+      },
+    };
+    let capturedMessageList: readonly OpenRouterChatMessage[] = [];
+
+    const output = await runDeskTurn({
+      text: 'confirmado',
+      confirmOk: true,
+      pendingConfirmation: {
+        id: 'confirm-1',
+        toolName: 'coding_task_test',
+        args: { repository: 'apollo' },
+        summary: 'Programar en apollo',
+        expiresAt: 1_000,
+      },
+      speechMode: 'default',
+      focusState: createInactiveDeskFocusState(),
+      sqlExecutor: createInMemorySqlExecutor(),
+      environment: fakeEnvironment,
+      toolDefinitionMap: buildToolDefinitionMap([unsafeTool]),
+      nowMilliseconds: 10,
+      adapters: {
+        stt: async () => '',
+        llm: async ({ messageList }) => {
+          capturedMessageList = messageList;
+          return { text: 'Listo, ya arranqué con apollo.', toolCallList: [] };
+        },
+        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+      },
+    });
+
+    const assistantToolCallMessage = capturedMessageList.find(
+      (message) => message.role === 'assistant' && message.tool_calls !== undefined,
+    );
+    expect(assistantToolCallMessage).toBeTruthy();
+    if (assistantToolCallMessage?.role === 'assistant') {
+      expect(assistantToolCallMessage.tool_calls?.[0]?.function.name).toBe(
+        'coding_task_test',
+      );
+    }
+    const toolResultMessage = capturedMessageList.find(
+      (message) => message.role === 'tool',
+    );
+    expect(toolResultMessage).toBeTruthy();
+    if (toolResultMessage?.role === 'tool') {
+      expect(toolResultMessage.content).toContain('Arranco a programar en apollo.');
+    }
+    expect(output.spokenText).toBe('Listo, ya arranqué con apollo.');
   });
 
   it('emits thinking captions before tools', async () => {

--- a/src/turn/run.ts
+++ b/src/turn/run.ts
@@ -138,6 +138,8 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
   const uiEventList: DeskUiEventName[] = ['START_THINK'];
   const toolResultList: ToolExecutionResult[] = [];
   let pendingConfirmation = input.pendingConfirmation;
+  let resolvedConfirmation: PendingToolConfirmation | undefined;
+  let resolvedConfirmationResult: ToolExecutionResult | undefined;
 
   if (pendingConfirmation !== undefined && input.confirmOk !== undefined) {
     const resolved = await resolvePendingToolConfirmation(
@@ -151,6 +153,10 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
         effects: input.effects,
       },
     );
+    if (!('cancelled' in resolved)) {
+      resolvedConfirmation = pendingConfirmation;
+      resolvedConfirmationResult = resolved;
+    }
     pendingConfirmation = undefined;
     if ('cancelled' in resolved) {
       uiEventList.push('CANCEL');
@@ -222,6 +228,21 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
     { role: 'system', content: systemPrompt },
     { role: 'user', content: userText },
   ];
+  // Each turn builds the LLM conversation from scratch, so an approved
+  // confirmation has to be replayed into it: without the tool call and its
+  // result the model only sees "confirmado" and asks what was approved.
+  if (resolvedConfirmation !== undefined && resolvedConfirmationResult !== undefined) {
+    messageList.push(
+      buildAssistantToolCallMessage('', [
+        {
+          id: resolvedConfirmation.id,
+          name: resolvedConfirmation.toolName,
+          args: resolvedConfirmation.args,
+        },
+      ]),
+      buildToolResultMessage(resolvedConfirmation.id, resolvedConfirmationResult),
+    );
+  }
 
   let spokenText = '';
 

--- a/src/workflows/coding.ts
+++ b/src/workflows/coding.ts
@@ -122,10 +122,37 @@ export class ApolloCoding extends WorkflowEntrypoint<Env, ApolloCodingParams> {
       });
 
       if (!extraction.hasChanges) {
-        const summary = agentOutcome.didReachRoundLimit
-          ? `Me quedé sin vueltas en ${repositoryLabel} y no llegué a cambiar nada.`
-          : `Revisé ${repositoryLabel} y no hizo falta cambiar nada.`;
-        await this.#notifyDevice(event.payload.deviceId, event.payload.task, summary);
+        // A read-only task (audit, review) legitimately changes nothing: the
+        // agent's reply is the deliverable, not a fallback line.
+        const summary =
+          agentOutcome.summary.length > 0
+            ? agentOutcome.summary
+            : agentOutcome.didReachRoundLimit
+              ? `Me quedé sin vueltas en ${repositoryLabel} y no llegué a cambiar nada.`
+              : `Revisé ${repositoryLabel} y no hizo falta cambiar nada.`;
+        const documentKey = buildCodingDocumentObjectKey(
+          event.payload.deviceId,
+          event.instanceId,
+        );
+        await step.do('persist-log', async () => {
+          const runLog = buildRunLog({
+            repositoryLabel,
+            taskText: event.payload.task,
+            branchName,
+            agentSummary: agentOutcome.summary,
+            transcript: agentOutcome.transcript,
+          });
+          await this.env.MEDIA.put(documentKey, redactSecretsFromText(runLog), {
+            httpMetadata: { contentType: 'text/markdown; charset=utf-8' },
+          });
+          return true;
+        });
+        await this.#notifyDevice(
+          event.payload.deviceId,
+          event.payload.task,
+          summary,
+          documentKey,
+        );
         return { summary };
       }
 
@@ -306,14 +333,16 @@ function buildRunLog(input: {
   readonly branchName: string;
   readonly agentSummary: string;
   readonly transcript: readonly string[];
-  readonly pullRequestUrl: string;
+  readonly pullRequestUrl?: string;
 }): string {
   return [
     `# Apollo — ${input.repositoryLabel}`,
     '',
     `**Tarea:** ${input.taskText}`,
     `**Branch:** ${input.branchName}`,
-    `**Pull request:** ${input.pullRequestUrl}`,
+    ...(input.pullRequestUrl !== undefined
+      ? [`**Pull request:** ${input.pullRequestUrl}`]
+      : []),
     '',
     '## Resumen',
     input.agentSummary,

--- a/src/workflows/coding.ts
+++ b/src/workflows/coding.ts
@@ -7,6 +7,8 @@ import { getAgentByName } from 'agents';
 
 import { runCodingAgent } from '@/coding/agent';
 import { buildCodingBranchName } from '@/coding/git';
+import { runOpencodeAgent } from '@/coding/opencode';
+import { mintCodingProxyToken } from '@/coding/proxy';
 import {
   buildCodingDocumentObjectKey,
   buildCodingPublishSandboxId,
@@ -101,6 +103,23 @@ export class ApolloCoding extends WorkflowEntrypoint<Env, ApolloCodingParams> {
         { retries: { limit: 1, delay: '10 seconds', backoff: 'constant' } },
         async () => {
           const sandbox = await this.#getSandbox(agentSandboxId);
+          // opencode manages its own loop and context; the hand-rolled agent
+          // stays as the fallback while the proxy origin is unset, and as an
+          // escape hatch behind CODING_ENGINE=legacy.
+          const proxyOrigin = this.env.CODING_PROXY_ORIGIN;
+          if (this.env.CODING_ENGINE !== 'legacy' && proxyOrigin !== undefined) {
+            return runOpencodeAgent({
+              sandbox,
+              proxyOrigin,
+              proxyToken: await mintCodingProxyToken({
+                instanceId: event.instanceId,
+                openRouterApiKey: this.env.OPENROUTER_API_KEY,
+                nowMilliseconds: Date.now(),
+              }),
+              modelId: this.env.OPENROUTER_CODING_MODEL,
+              taskText: event.payload.task,
+            });
+          }
           return runCodingAgent({
             sandbox: buildAgentSandboxPort(sandbox),
             callLlm: async ({ messageList, toolDefinitionList }) =>


### PR DESCRIPTION
> Stacked on #20 — merge that one first.

### Why

The hand-rolled coding loop papers over what is really a context-management problem with a fixed round limit: big tasks exhaust it and small ones don't need it. Instead of building our own compaction + checkpoints, the sandbox now runs [opencode](https://opencode.ai) (pinned to v1.18.16), which brings its own loop, automatic compaction, and patch-style edits — and speaks OpenRouter natively, so it uses the models we already have.

### How

- **`src/coding/opencode.ts`** — writes the opencode config outside the cloned repo (keeps the diff clean), runs `opencode run` with a 45-minute timeout, and reads the spoken summary from a file agreed upon in the prompt (falling back to the tail of stdout).
- **`src/coding/proxy.ts` + route in `src/index.ts`** — OpenAI-compatible passthrough to OpenRouter. The real key never enters the sandbox: opencode authenticates with a short-lived (6 h) HMAC token signed with the OpenRouter key itself, so there is no new secret to provision and rotating the key revokes every outstanding token. Only the configured coding model is accepted.
- **`src/workflows/coding.ts`** — engine selection: opencode when `CODING_PROXY_ORIGIN` is set and `CODING_ENGINE` is not `legacy`; otherwise the existing loop. The rest of the pipeline (token-free clone, extract-changes, publish from a fresh sandbox, PR) is untouched.
- **`Dockerfile`** — installs opencode pinned to v1.18.16.

### Security

The invariant that no durable secret lives where the model has a shell is preserved. The only thing entering the container is the ephemeral proxy token; a prompt-injected repo can read it, but it only buys 6 hours of access to the coding model through our proxy — not the key.

### To activate

```
bunx wrangler secret put CODING_PROXY_ORIGIN   # e.g. https://apollo.<subdomain>.workers.dev
```

Without that secret everything keeps running on the legacy engine. `CODING_ENGINE=legacy` forces the fallback without redeploying the image.

### Tests

All green: token mint/verify (expiry, tampering, foreign key), proxy forwarding (401/403/404), opencode config and command, summary fallback, and failure propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKEa3Q1e1boDFVmhdGstkZ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the optional hand-rolled coding loop with OpenCode behind a short-lived-token LLM proxy while retaining the legacy fallback.
- Installs a version- and checksum-pinned OpenCode binary in the sandbox image.
- Adds OpenCode configuration, execution, transcript, and spoken-summary handling.
- Adds an authenticated, model-restricted OpenRouter proxy and workflow engine selection.
- Adds coverage for token verification, proxy validation, command construction, retry summary clearing, and failure handling.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the previously reported issues are fixed and no blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["merge: sync stacked base"](https://github.com/galfrevn/apollo/commit/527ba004a1d3ed4626441e122721b5ca960dace1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52298931)</sub>

<!-- /greptile_comment -->