### PR TITLE
feat(voice): closed-loop TTS pacing and the countdown arc protocol

### DIFF
--- a/documentation/reference/roadmap.md
+++ b/documentation/reference/roadmap.md
@@ -29,7 +29,7 @@ The firmware remembers which mode started the listen (`listen_started_by_hold_` 
 
 ### 6. Voice timer with ring progress — ✅ implemented 2026-08-11, ships with firmware 2.7.0
 
-"Poné 10 minutos" → `set_timer` still rides the reminder scheduler, and now also broadcasts `{"type":"timer", endsAt, durationSec}` so the ring drains in the mode's color until the end (the reminder's ding and TTS already cover completion). A timer arc outranks the focus arc while live; cancelling the timer clears it (`cancel_reminder` detects the `Timer` message prefix). The pomodoro needs no timer message: it activates focus, and the item-1 arc covers it.
+"Poné 10 minutos" → `set_timer` still rides the reminder scheduler, and now also broadcasts `{"type":"timer", endsAt, durationSeconds}` so the ring drains in the mode's color until the end (the reminder's ding and TTS already cover completion). A timer arc outranks the focus arc while live; cancelling a timer hands the arc to the soonest timer still running, or clears it (`cancel_reminder` detects the `Timer` message prefix). The pomodoro needs no timer message: it activates focus, and the item-1 arc covers it.
 
 ### 7. Live captions (cleared when the turn ends)
 
@@ -84,7 +84,7 @@ Still open: **push-style updates**. Telemetry reports `firmwareVersion`, but the
 ### 15. `tts_end` + playback acks — ✅ implemented 2026-08-11, ships with firmware 2.7.0
 
 - **`tts_end`**: `tts_start.bytes` is now optional vocabulary — a run without a total stays open until the `tts_end` terminator, so audio can be sent mid-synthesis. The server still sends `bytes` (its synthesis is per-sentence and whole-buffer today), which keeps 2.6.0 devices working; piping the ElevenLabs response body through as it arrives is the follow-up the protocol no longer blocks.
-- **Acks**: the device reports `{"type":"playback_ack", seq, playedMs}` once a second while speaking — `playedMs` counted at the codec output in source-stream time, `seq` echoed from `tts_start` so a stale run's acks are discarded. `streamAudioChunksAtPlaybackPace` uses them as a closed loop (measured backlog held at the 4 s ceiling, extrapolated between acks) and falls back to the open-loop 0.85 pace when no ack arrives. Announcements (`notify.ts`) stay open-loop on purpose: a broadcast has no single device whose acks could steer it.
+- **Acks**: the device reports `{"type":"playback_ack", sequence, playedMilliseconds}` once a second while speaking — played time counted at the codec output in source-stream time, `sequence` echoed from `tts_start` so a stale run's acks are discarded. `streamAudioChunksAtPlaybackPace` uses them as a closed loop (measured backlog held at the 4 s ceiling, extrapolated between acks) and falls back to the open-loop 0.85 pace when no ack arrives. Announcements (`notify.ts`) stay open-loop on purpose: a broadcast has no single device whose acks could steer it.
 
 ### 16. Typed on-screen cards (`ui_card`)
 

--- a/documentation/reference/roadmap.md
+++ b/documentation/reference/roadmap.md
@@ -1,114 +1,114 @@
 # Roadmap
 
-Status as of 2026-08-10. Items under **Confirmed** are already decided; the detail under each one says which side it touches — server, firmware, or both. Spoken examples stay in Rioplatense Spanish because that is what a user literally says to the device.
+Status as of 2026-08-11, verified against worker `main` (`15237ee`) and firmware 2.6.0 (`d8f09d5`); items 1, 6, and 15 landed later the same day on `feat/streaming-and-arc` (firmware 2.7.0). Items under **Confirmed** are already decided; the detail under each one says which side it touches — server, firmware, or both. Spoken examples stay in Rioplatense Spanish because that is what a user literally says to the device.
+
+Since 2026-08-10 the OTA loop is closed end to end: the worker deploys on every push to `main` (`.github/workflows/deploy.yml`), the firmware publishes to R2 on every push to its `main` (`.github/workflows/publish.yml`, with `PROJECT_VER` as the release trigger), and the device self-updates. Firmware changes no longer cost a cable flash — which reshuffles the cost side of every pending item below.
 
 ## Confirmed
 
-### 1. Focus mode visible on screen
+### 1. Focus mode visible on screen — ✅ implemented 2026-08-11, ships with firmware 2.7.0
 
-The server already tracks `focus` state and sends `focusRemainingSec` on every `ui_state`, but the device only shows the "sleepy" face (via emotion) — there is no visible countdown.
-
-- **Firmware**: render the remaining time. Candidates are a progress arc over the accent ring, or the center label of the emote engine. Parse `focusRemainingSec` in `HandleUiState` (`apollo_protocol.cc`).
-- **Server**: done — only the refresh cadence of the field needs verifying.
+`ui_state` now carries the whole window — `focusStartedAt`/`focusEndsAt` in epoch seconds — so the device counts down locally between event-driven pushes instead of chasing a stale `focusRemainingSec` (still sent for older firmware). The firmware draws it as a draining arc over the accent ring: `OverlayAccentRing` paints only the pixels whose clockwise-from-noon angle falls inside the remaining fraction, and a 1 Hz refresh timer keeps the arc moving while the emote engine is otherwise idle. The same arc serves the timer from item 6.
 
 ### 2. Complete background result: document QR
 
-- **Spoken notice**: ✅ done. `deliverDeskDeviceNotification` (`src/agents/notify.ts`) synthesizes and paces TTS for both `background_result` and `reminder`, queues them as pending messages when nobody is connected, and stays quiet during focus. What is left is cosmetic: the announcement speaks the summary directly rather than framing it ("terminé \<task\>: …").
-- **QR on screen**: when a `documentKey` is present, show a QR with the document URL. The gfx engine already has a QR widget (`emote_set_qrcode_data` in `emote_op.c`), so the firmware only needs to route a new message (say `"type": "qr"`) through to that widget, with an auto-close timeout. The reports are already emailed in parallel, so the QR is a convenience, not the only way to reach one.
+- **Spoken notice**: ✅ done. `deliverDeskDeviceNotification` (`src/agents/notify.ts`) synthesizes and paces TTS for both `background_result` and `reminder`, queues them as pending messages when nobody is connected, and stays quiet during focus. What is left is cosmetic: the notifier speaks `notification.summary` raw rather than framing it ("terminé \<task\>: …") — only the coding workflow builds its own framed summary.
+- **QR on screen**: pending on both sides. The `background_result` frame already carries `documentKey`, but the server never builds a URL or a QR message, and the protocol schema has no such type. On the device the capability sits unwired: `emote_set_qrcode_data` exists in the gfx component and the 1.85C layout even declares a 150 px `qrcode` object, but nothing routes to it. Needs a new message (say `"type": "qr"`) with an auto-close timeout.
 
 ### 3. Device → server telemetry + agent reactions — ✅ shipped 2026-08-10
 
-`{"type":"telemetry", battery, charging, volume, wifiRssi, firmwareVersion, ts}` goes out on channel open, every 60 s, and immediately on a charging edge. The server keeps the snapshot in memory, stamps it into the system prompt while fresh, and announces low battery (≤15%, 30 min cooldown, hysteresis at 25%) piercing focus as `critical`. Battery sensing required wiring `AdcBatteryMonitor` into the 1.85C board — the schematic puts BAT_ADC on GPIO8 through a 200K/100K divider; there is no charge-status GPIO, so charging is the estimation library's voltage-trend guess. See `src/telemetry/logic.ts` and `Application::MaybeSendTelemetry`.
+`{"type":"telemetry", battery, charging, volume, wifiRssi, firmwareVersion, ts}` goes out on channel open, every 60 s, and immediately on a charging edge. The server keeps the snapshot in memory, stamps it into the system prompt while fresh, and announces low battery (≤15%, 30 min cooldown, hysteresis at 25%) piercing focus as `critical`. Since `5091bb1` the snapshot also survives deploys (persisted in `session_prefs`, re-read at turn start) and the persona owns it as first-person state. Battery sensing required wiring `AdcBatteryMonitor` into the 1.85C board — BAT_ADC on GPIO8 through a 200K/100K divider; there is no charge-status GPIO, so charging is the estimation library's voltage-trend guess. See `src/telemetry/logic.ts` and `Application::MaybeSendTelemetry`.
 
 ### 4. Semantic `audio_end` — ✅ shipped 2026-08-10
 
-The firmware now remembers which mode started the listen (`listen_started_by_hold_` in `apollo_protocol.cc`) and ends it with the matching event: `hold_end` for push-to-talk, `audio_end` for wake-word turns. The server dispatches them as separate cases (identical behavior today) so timeouts or continuity can diverge without a flash.
+The firmware remembers which mode started the listen (`listen_started_by_hold_` in `apollo_protocol.cc`) and ends it with the matching event: `hold_end` for push-to-talk, `audio_end` for wake-word turns. `listen_cancel` joined in 2.6.0 for turns the VAD gives up on. Known wart: a mic reopened by session flow (item 8) still reports `"wake"` on the wire — the start event doesn't distinguish continuation from a real wake.
 
-### 5. Device-side MCP: the agent with hands on the hardware — ✅ implemented 2026-08-10 (pending flash)
+### 5. Device-side MCP: the agent with hands on the hardware — ✅ shipped, live since the 2.6.0 OTA
 
-Both ends are connected: `apollo_protocol.cc` routes `"mcp"` frames into the live `application.cc` branch (and overrides `SendMcpMessage` to speak the Apollo dialect: `{"type":"mcp","payload",…,"ts"}`), and the server bridges agent tools to the embedded MCP over the websocket (`src/mcp/bridge.ts`: integer JSON-RPC ids, 5 s timeout awaited inside the tool handler). Exposed to the LLM as `set_volume`, `set_brightness`, and `device_status` (`src/tools/device.ts`); the device's user-only tools (`self.reboot`, `self.upgrade_firmware`) stay callable from server code but hidden from the model. "Apagá la pantalla" and face control need tools the 1.85C build compiles out — a later firmware addition.
+`apollo_protocol.cc` routes `"mcp"` frames into `application.cc` (speaking the Apollo dialect: `{"type":"mcp","payload",…,"ts"}`), and the server bridges agent tools to the embedded MCP over the websocket (`src/mcp/bridge.ts`: integer JSON-RPC ids, 5 s timeout awaited inside the tool handler). Exposed to the LLM as `set_volume`, `set_brightness`, and `device_status` (`src/tools/device.ts`); the device's user-only tools (`self.reboot`, `self.upgrade_firmware`, `self.get_system_info`) stay callable from server code but hidden from the model. "Apagá la pantalla" still has no tool — brightness 0 is the closest affordance; the screen/theme/snapshot tools are compiled out on the 1.85C build (`HAVE_LVGL` is undefined under the emote engine), and screen sleep exists only as the local 60 s idle timeout.
 
-### 6. Voice timer with ring progress — server half ✅ (2026-08-08)
+### 6. Voice timer with ring progress — ✅ implemented 2026-08-11, ships with firmware 2.7.0
 
-"Poné 10 minutos" → the agent creates the timer and the ring turns into a circular progress bar: it starts full in the mode's color and drains (or fills) until the end, with a sound on completion.
-
-- **Server**: ✅ `set_timer` and `start_pomodoro` are in production, mounted on the reminder scheduler; the pomodoro also activates focus. All that is missing is the message to the device carrying duration/remaining so it can draw the arc.
-- **Firmware**: the accent ring overlay is already drawn chunk by chunk in `emote_display.cc`; generalize it to a partial arc with the angle as a function of progress. The same UI serves the focus-mode countdown from item 1.
+"Poné 10 minutos" → `set_timer` still rides the reminder scheduler, and now also broadcasts `{"type":"timer", endsAt, durationSec}` so the ring drains in the mode's color until the end (the reminder's ding and TTS already cover completion). A timer arc outranks the focus arc while live; cancelling the timer clears it (`cancel_reminder` detects the `Timer` message prefix). The pomodoro needs no timer message: it activates focus, and the item-1 arc covers it.
 
 ### 7. Live captions (cleared when the turn ends)
 
 Show what the user is saying while they speak, using partial streaming STT, and clear the text as soon as the turn ends so the screen goes back to just the face.
 
-- **Server**: transcription is post-hold today (`src/voice/stt.ts`); this needs streaming STT over the chunks already arriving on the WebSocket, plus an incremental caption message.
-- **Firmware**: render partial captions (the `sentence_start` path already exists) and clear explicitly on end of turn.
+- **Server**: transcription is still post-hold — audio buffers in memory and goes to STT as one blocking request after `hold_end`/`audio_end` (`src/voice/stt.ts`). Needs streaming STT over the chunks already arriving on the WebSocket, plus an incremental caption message.
+- **Firmware**: closer than it looks — `application.cc` already has an `stt` handler that renders a user caption, but the Apollo protocol never emits that type. Wire the branch, and clear explicitly on end of turn (today captions only clear on the transition to Idle or on channel close).
 
-### 8. Conversation continuity
+### 8. Conversation continuity — ✅ shipped in 2.6.0 as "session flow"
 
-A window of roughly 10 s after a reply during which the user can follow up with no wake word and no hold: the mic reopens by itself and the ring pulses to signal it.
+After playback drains, the firmware reopens the mic by itself — no wake word, no hold — with a VAD watchdog (700 ms cue grace, 300 ms min speech, 1.2 s endpoint silence, 3 s no-speech timeout → `listen_cancel`). The server steers the loop per turn: the LLM appends `[[escucho]]` (or ends with a question) and `turn_end { expectsReply }` tells the device whether to keep listening (`src/turn/run.ts`, `src/agents/runtime.ts`); announcements never reopen. Closing phrases need no special-casing — the model simply doesn't mark a goodbye turn.
 
-- **Firmware**: after `speech_done`, re-enter listening with VAD and a short timeout; a ring "pulse" animation indicates the open mic.
-- **Server**: accept a turn that arrives with no preceding `hold_start`/`wake` inside the window; close the window on silence or on "gracias"/"listo".
+Loose ends, all minor: hold-to-talk turns intentionally fall back to Idle; the reopened mic reports `"wake"` on the wire (see item 4); and the promised ring "pulse" was never built — the open-mic signal is the `listen_anim` face plus an audible cue.
 
 ### 9. Touch reactions on the face
 
-Touching the eyes or other zones of the face triggers an immediate reaction — a blink, surprise, annoyance if the user keeps at it. Pure firmware, no server: map touch zones (`esp_lcd_touch_cst9217`) to catalog emotes with a small cooldown and escalation on repeats.
+Touching the eyes or other zones of the face triggers an immediate reaction — a blink, surprise, annoyance if the user keeps at it. Pure firmware, no server: map touch zones to catalog emotes with a small cooldown and escalation on repeats. Today the only coordinate-aware touch code is the confirm-screen hit-test (`confirm_geometry.h`); gestures classify by shape only, and a bare tap is consumed locally as a stop.
 
 ### 10. Background moods
 
-The idle face should not always be neutral: subtle variation by time of day and last interaction (sleepier at night, more awake in the morning, "happy" for a while after a long chat).
+The idle face should not always be neutral: subtle variation by time of day and last interaction (sleepier at night, more awake in the morning, "happy" for a while after a long chat). Today idle is a fixed `"neutral"` blink every 12 s.
 
-- **Firmware**: can be resolved entirely locally (clock + last turn), or
-- **Server**: by sending the idle emotion in `ui_state` so the agent can influence it too — for example staying "curious" after an open-ended question.
+- **Firmware**: can be resolved entirely locally (SNTP clock + last turn), or
+- **Server**: the transport is already there — `emotion` rides every `ui_state` — but the mapping is a pure lookup with `idle → neutral` (`src/persona/face.ts`). Only the policy is missing, so the agent could influence idle mood with a server-only change.
 
 ## Proposed 2026-08-08: more server ↔ firmware interaction
 
-Guiding principle: the firmware only gains **vocabulary** — new protocol events and commands — while the semantics always live in the server, which deploys in seconds.
+Guiding principle: the firmware only gains **vocabulary** — new protocol events and commands — while the semantics always live in the server. Both sides now deploy automatically (worker on push, firmware over OTA), so the original "fit it in one flash" batching no longer constrains anything.
 
-Suggested first round: 12, plus the telemetry from item 3. Both fit in a single flash and each one unblocks immediate server-side features. Second round: 14 (OTA), so that becomes the last flash over cable.
+### 11. Gestures as raw events — ✅ shipped (long_press still open)
 
-### 11. Gestures as raw events — ✅ already shipped
+The pattern landed: the firmware emits `{"type":"gesture","gesture":"tap"|"double_tap"|"swipe_left"|"swipe_right","ts":…}` with no local semantics, and the server decides what each one means in `#handleGesture` (`src/agents/apollo.ts`) — tap toggles the dashboard, swipes cycle the speech mode, double_tap is a deliberate no-op server-side (the mute is local). Remapping is a worker deploy.
 
-The pattern landed: the firmware emits `{"type":"gesture","gesture":"tap"|"double_tap"|"swipe_left"|"swipe_right","ts":…}` from the touch driver with no local semantics, and the server decides what each one means in `#handleGesture` (`src/agents/apollo.ts`) — tap toggles the dashboard, swipes cycle the speech mode. Remapping is a worker deploy, not a flash.
+Touch barge-in shipped alongside it, through a dedicated `abort` message: a tap while Apollo is speaking stops the stream within a chunk and the server answers `tts_aborted`.
 
-Touch barge-in shipped alongside it, through a dedicated `abort` message rather than a gesture: a tap while Apollo is speaking stops the stream within a chunk and the server answers `tts_aborted`.
-
-Still open: `long_press` is not in the gesture enum, so "hold to start a pomodoro or a briefing" needs one enum entry on each side.
+Still open: `long_press` — and it is no longer just an enum entry, because a long press on the screen is claimed by hold-to-talk. "Hold to start a pomodoro or a briefing" needs either the physical button's long-press (already detected in `button.cc`, unused) or a rethink of the touch grammar.
 
 ### 12. Server-triggered earcons (`play_effect`) — ✅ shipped 2026-08-10
 
-`{"type":"play_effect", "name":"ding"|"chime"|"error"|"low_battery"}` plays effects already burned into flash. The names are logical — the firmware maps them to assets (`ding`→success, `chime`→popup, `error`→exclamation) so the server can re-purpose sounds without a flash. Wired at three sites: reminder/timer delivery (the ding lands while the TTS is still synthesizing), confirm requests, and turn failures, plus the low-battery announcement from item 3.
+`{"type":"play_effect", "name":"ding"|"chime"|"error"|"low_battery"}` plays effects already burned into flash. The names are logical — the firmware maps them to assets (`ding`→success, `chime`→popup, `error`→exclamation) so the server can re-purpose sounds without touching firmware. Wired at reminder/timer delivery, confirm requests, turn failures, and the low-battery announcement from item 3.
 
-### 13. `set_volume` from the server — ✅ implemented 2026-08-10 via item 5
+### 13. `set_volume` from the server — ✅ shipped 2026-08-10 via item 5
 
 Came for free through the MCP bridge, as predicted: `set_volume` is one of the three tools item 5 exposes to the agent.
 
-### 14. OTA from R2 — ✅ implemented 2026-08-10 (pending the last cable flash)
+### 14. OTA from R2 — ✅ shipped end to end; push-style updates still open
 
-The worker serves `/ota/check` and `/ota/firmware.bin` from the `MEDIA` bucket (`src/ota/`, token-authenticated, versions strictly `digits.and.dots` because the device's parser aborts on anything else). The device (2.5.0) checks once at boot right after time sync — single attempt, a failed check never blocks boot — and self-updates through the existing `esp_ota` path; `MarkCurrentVersionValid` now runs under Apollo so rollback no longer reverts OTA'd images. Publishing steps live in [Deploy](../operations/deploy.md#publishing-firmware-ota). Remaining: deploy the worker, upload 2.5.0 + manifest, one last cable flash; from then on firmware "deploys" too. Push-style updates (server calls `self.upgrade_firmware` over the item-5 bridge when telemetry shows a stale version) are the documented follow-up for devices that never reboot.
+The full loop is live: the worker serves `/ota/check` and `/ota/firmware.bin` from the `MEDIA` bucket (`src/ota/`, token-authenticated, versions strictly `digits.and.dots`), every push to the firmware `main` builds and publishes to R2 (`publish.yml`, `PROJECT_VER` bump as the trigger), and the device checks off the boot path and self-updates through `esp_ota` with rollback protection. The 2.6.0 fleet arrived this way — cable flashing is over. Publishing steps live in [Deploy](../operations/deploy.md#publishing-firmware-ota).
 
-### 15. `tts_end` + playback acks (real streaming)
+Still open: **push-style updates**. Telemetry reports `firmwareVersion`, but the server never compares it against the R2 manifest nor calls `self.upgrade_firmware` over the item-5 bridge — a device that never reboots never updates.
 
-The two pieces currently blocking end-to-end streaming:
+### 15. `tts_end` + playback acks — ✅ implemented 2026-08-11, ships with firmware 2.7.0
 
-- **`tts_end`**: removes the requirement to know total `bytes` up front in `tts_start`, so the server could start sending ElevenLabs audio while it is still being synthesized. Sentence segmentation already delivers about 80% of the benefit; this captures the rest.
-- **Acks**: a periodic "I have played X ms" message, so the server's pacing (`src/voice/stream.ts`) stops estimating the backlog with an open-loop model and uses the device queue's real state instead. Robust on any WiFi, and it replaces the fixed 4 s cap.
+- **`tts_end`**: `tts_start.bytes` is now optional vocabulary — a run without a total stays open until the `tts_end` terminator, so audio can be sent mid-synthesis. The server still sends `bytes` (its synthesis is per-sentence and whole-buffer today), which keeps 2.6.0 devices working; piping the ElevenLabs response body through as it arrives is the follow-up the protocol no longer blocks.
+- **Acks**: the device reports `{"type":"playback_ack", seq, playedMs}` once a second while speaking — `playedMs` counted at the codec output in source-stream time, `seq` echoed from `tts_start` so a stale run's acks are discarded. `streamAudioChunksAtPlaybackPace` uses them as a closed loop (measured backlog held at the 4 s ceiling, extrapolated between acks) and falls back to the open-loop 0.85 pace when no ack arrives. Announcements (`notify.ts`) stay open-loop on purpose: a broadcast has no single device whose acks could steer it.
 
 ### 16. Typed on-screen cards (`ui_card`)
 
-Beyond face + caption: a circular timer countdown (which merges with item 6), weather with an icon, the dollar rate, the grocery list while it is being read out. Typed and bounded — timer, weather, list, rate, QR (the QR is already in item 2) — with no arbitrary layouts. The discarded dashboard ("dashboard has no UI yet") would come back in through here.
+Beyond face + caption: a circular timer countdown (which merges with item 6), weather with an icon, the dollar rate, the grocery list while it is being read out. Typed and bounded — timer, weather, list, rate, QR (the QR is already in item 2) — with no arbitrary layouts. The firmware still discards the dashboard state on purpose ("dashboard has no UI yet", `apollo_protocol.cc`), while the server keeps pushing clock + weather on tap and refreshing it every 30 minutes; that dashboard would come back in through here.
 
 ## Under consideration (ideas, no commitment)
 
-- **Clock + weather dashboard on tap**: the server half is done — a tap while idle enters `dashboard` state and pushes the payload, then refreshes it every 30 minutes for as long as that state holds. The firmware still discards it ("dashboard has no UI yet"), so tapping shows nothing. If item 16 lands, this becomes just another card.
-- **Voice barge-in**: interrupting the assistant by *talking* over it. Untested; the raw mic path has no AEC (see the wake word notes). Touch barge-in already works (item 11), so this is only about the hands-free case.
+- **Voice barge-in**: interrupting the assistant by *talking* over it. Untested; the raw mic path has no AEC (see the wake word notes). Touch barge-in already works (item 11), so this is only about the hands-free case. The 2.6.0 VAD watchdog gives session flow an endpointer, but nothing listens during playback.
 - **Morning briefing**: weather plus the day's reminders by voice at a fixed hour, orchestrated on top of the existing reminder cron.
 - **Night mode**: minimum brightness, quieter effects, and silenced notifications within an hour range — a natural fit on top of MCP + telemetry.
 - **Web session console**: a page served by the worker with transcripts, tool calls, and errors, for debugging without serial.
 - **Multi-device**: the protocol already routes by `device_id`; formalize a second Apollo with shared memory and reminders.
 
+## Shipped since the last revision (2026-08-10 → 2026-08-11)
+
+Beyond the items above, landed and not previously tracked here:
+
+- **microWakeWord "Hey, Apólo"**: TFLite streaming model on the AFE output replaced WakeNet (`main/audio/wake_words/micro_wake_word.cc`), model swappable via `-DMICRO_WAKE_WORD_MODEL`. Part of the 2.6.0 perf pass (`-O2`, bigger data cache, OTA check off the boot path), plus a 10 s idle channel pre-warm so press-and-hold finds an open socket.
+- **Full-screen Sí/No confirmations**: dedicated confirm screen with touch hit-testing (`confirm_geometry.h`), single-winner arbitration between button, local expiry (clamped 3–45 s), and the new `confirm_close` message the server broadcasts on resolve/expire/orphan. Approved confirmations are also replayed into the next LLM turn so the model knows what it asked for (`9e9b345`).
+- **Coding engine on opencode**: coding tasks run opencode behind a worker-hosted LLM proxy (`src/coding/opencode.ts`, `src/coding/proxy.ts`; HMAC-tokened `/coding-llm/v1`, 45 min cap), env-gated with the legacy loop as fallback. Repos are resolved from *spoken* names against the GitHub App installations (`list_coding_repositories`, `resolveSpokenRepositoryReference`) — the agent never asks for a URL.
+
 ## Context notes
 
-The per-mode accent color ring, the pitch variants for effects, and the PCM/Opus decode fix all landed on 2026-08-08 — see the firmware and server git logs for that day. Timers, lists, dollar rates, email, and the streaming/speculative TTS path landed on 2026-08-10 (`444f324`); each now has its own chapter in Part III.
+The per-mode accent color ring, the pitch variants for effects, and the PCM/Opus decode fix all landed on 2026-08-08. Timers, lists, dollar rates, email, and the streaming/speculative TTS path landed on 2026-08-10 (`444f324`); each has its own chapter in Part III. Telemetry, earcons, semantic `audio_end`, MCP bridge, and OTA landed 2026-08-10; microWakeWord, session flow, full-screen confirmations, and the publish pipeline landed with firmware 2.6.0 on 2026-08-11.
 
 ## Navigation
 

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -146,7 +146,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #deviceMcpRequestRegistry = createDeviceMcpRequestRegistry();
   #ttsSequence = 0;
   #lastPlaybackAck: {
-    readonly seq: number;
+    readonly sequence: number;
     readonly playedMilliseconds: number;
     readonly receivedAtMilliseconds: number;
   } | null = null;
@@ -342,8 +342,8 @@ export class Apollo extends Agent<Env, ApolloState> {
       }
       case 'playback_ack': {
         this.#lastPlaybackAck = {
-          seq: deviceMessage.seq,
-          playedMilliseconds: deviceMessage.playedMs,
+          sequence: deviceMessage.sequence,
+          playedMilliseconds: deviceMessage.playedMilliseconds,
           receivedAtMilliseconds: Date.now(),
         };
         break;
@@ -732,19 +732,45 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
   }
 
-  #broadcastTimerArc(durationSeconds: number | undefined): void {
+  #broadcastTimerArc(
+    arc:
+      | { readonly endsAtEpochSeconds: number; readonly durationSeconds: number }
+      | undefined,
+  ): void {
     const encodedMessage = encodeServerToDeviceMessage(
-      durationSeconds === undefined
+      arc === undefined
         ? { type: 'timer' }
         : {
             type: 'timer',
-            endsAt: Math.floor(Date.now() / 1000) + durationSeconds,
-            durationSec: durationSeconds,
+            endsAt: arc.endsAtEpochSeconds,
+            durationSeconds: arc.durationSeconds,
           },
     );
     for (const connection of this.getConnections()) {
       connection.send(encodedMessage);
     }
+  }
+
+  async #broadcastSoonestRemainingTimerArc(): Promise<void> {
+    const remainingReminderList = mapAgentScheduleListToReminderList(
+      mapUnknownScheduleListToAgentScheduleLikeList(await this.listSchedules()),
+    );
+    const remainingTimerList = remainingReminderList
+      .filter(
+        (reminder) =>
+          reminder.message.startsWith('Timer') &&
+          typeof reminder.delayInSeconds === 'number',
+      )
+      .toSorted((left, right) => left.firesAtIso.localeCompare(right.firesAtIso));
+    const soonestTimer = remainingTimerList[0];
+    if (soonestTimer === undefined || soonestTimer.delayInSeconds === undefined) {
+      this.#broadcastTimerArc(undefined);
+      return;
+    }
+    this.#broadcastTimerArc({
+      endsAtEpochSeconds: Math.floor(Date.parse(soonestTimer.firesAtIso) / 1000),
+      durationSeconds: soonestTimer.delayInSeconds,
+    });
   }
 
   async #runTurnFromText(connection: Connection, text: string): Promise<void> {
@@ -846,7 +872,10 @@ export class Apollo extends Agent<Env, ApolloState> {
         await this.schedule(delaySeconds, 'deliverReminder', { message });
       },
       broadcastTimerProgress: async ({ durationSeconds }) => {
-        this.#broadcastTimerArc(durationSeconds);
+        this.#broadcastTimerArc({
+          endsAtEpochSeconds: Math.floor(Date.now() / 1000) + durationSeconds,
+          durationSeconds,
+        });
       },
       listReminders: async () => {
         const scheduleList = await this.listSchedules();
@@ -870,9 +899,10 @@ export class Apollo extends Agent<Env, ApolloState> {
           }
         }
         // Timers are reminders whose message starts with "Timer" (see
-        // @/tools/timer); cancelling one has to take its arc off the screen.
+        // @/tools/timer); cancelling one has to take its arc off the screen —
+        // unless another timer is still running, whose arc takes over.
         if (cancelledMessageList.some((cancelled) => cancelled.startsWith('Timer'))) {
-          this.#broadcastTimerArc(undefined);
+          await this.#broadcastSoonestRemainingTimerArc();
         }
         return {
           cancelledCount: cancelledMessageList.length,
@@ -919,7 +949,7 @@ export class Apollo extends Agent<Env, ApolloState> {
             return this.#ttsSequence;
           },
           getPlaybackAckForSequence: (sequence) =>
-            this.#lastPlaybackAck !== null && this.#lastPlaybackAck.seq === sequence
+            this.#lastPlaybackAck !== null && this.#lastPlaybackAck.sequence === sequence
               ? {
                   playedMilliseconds: this.#lastPlaybackAck.playedMilliseconds,
                   receivedAtMilliseconds: this.#lastPlaybackAck.receivedAtMilliseconds,

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -117,6 +117,7 @@ export type ApolloState = {
   readonly uiState: DeskUiState;
   readonly speechMode: string;
   readonly focusEndsAt: number | null;
+  readonly focusStartedAt: number | null;
   readonly caption: string | null;
   readonly pendingConfirmId: string | null;
   readonly pendingConfirmSummary: string | null;
@@ -127,6 +128,7 @@ export class Apollo extends Agent<Env, ApolloState> {
     uiState: 'idle',
     speechMode: 'default',
     focusEndsAt: null,
+    focusStartedAt: null,
     caption: null,
     pendingConfirmId: null,
     pendingConfirmSummary: null,
@@ -142,6 +144,12 @@ export class Apollo extends Agent<Env, ApolloState> {
   #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
   #isAnnouncingLowBattery = false;
   #deviceMcpRequestRegistry = createDeviceMcpRequestRegistry();
+  #ttsSequence = 0;
+  #lastPlaybackAck: {
+    readonly seq: number;
+    readonly playedMilliseconds: number;
+    readonly receivedAtMilliseconds: number;
+  } | null = null;
 
   get session(): Session {
     if (this.#session === undefined) {
@@ -332,6 +340,14 @@ export class Apollo extends Agent<Env, ApolloState> {
         this.#deviceMcpRequestRegistry.resolvePendingRequest(deviceMessage.payload);
         break;
       }
+      case 'playback_ack': {
+        this.#lastPlaybackAck = {
+          seq: deviceMessage.seq,
+          playedMilliseconds: deviceMessage.playedMs,
+          receivedAtMilliseconds: Date.now(),
+        };
+        break;
+      }
     }
   }
 
@@ -509,6 +525,15 @@ export class Apollo extends Agent<Env, ApolloState> {
         speechMode: this.state.speechMode,
         caption: this.state.caption ?? undefined,
         focusRemainingSec,
+        ...(this.state.focusEndsAt !== null
+          ? {
+              focusEndsAt: Math.floor(this.state.focusEndsAt / 1000),
+              ...(this.state.focusStartedAt !== null &&
+              this.state.focusStartedAt !== undefined
+                ? { focusStartedAt: Math.floor(this.state.focusStartedAt / 1000) }
+                : {}),
+            }
+          : {}),
         emotion: resolveDeskFaceEmotion(this.state.uiState),
         accentColor: resolveDeskSpeechMode(this.state.speechMode).accentColor,
       }),
@@ -707,6 +732,21 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
   }
 
+  #broadcastTimerArc(durationSeconds: number | undefined): void {
+    const encodedMessage = encodeServerToDeviceMessage(
+      durationSeconds === undefined
+        ? { type: 'timer' }
+        : {
+            type: 'timer',
+            endsAt: Math.floor(Date.now() / 1000) + durationSeconds,
+            durationSec: durationSeconds,
+          },
+    );
+    for (const connection of this.getConnections()) {
+      connection.send(encodedMessage);
+    }
+  }
+
   async #runTurnFromText(connection: Connection, text: string): Promise<void> {
     this.#applyUiEvent('START_LISTEN');
     await this.#executeTurn(connection, { text });
@@ -787,14 +827,26 @@ export class Apollo extends Agent<Env, ApolloState> {
       deviceId,
       session: this.session,
       applyFocusMinutes: async (minutes) => {
-        const nextFocus = startDeskFocus(Date.now(), minutes * 60);
-        this.setState({ ...this.state, focusEndsAt: nextFocus.endsAt });
+        const startedAt = Date.now();
+        const nextFocus = startDeskFocus(startedAt, minutes * 60);
+        this.setState({
+          ...this.state,
+          focusEndsAt: nextFocus.endsAt,
+          focusStartedAt: startedAt,
+        });
       },
       clearFocus: async () => {
-        this.setState({ ...this.state, focusEndsAt: clearDeskFocus().endsAt });
+        this.setState({
+          ...this.state,
+          focusEndsAt: clearDeskFocus().endsAt,
+          focusStartedAt: null,
+        });
       },
       scheduleReminder: async ({ delaySeconds, message }) => {
         await this.schedule(delaySeconds, 'deliverReminder', { message });
+      },
+      broadcastTimerProgress: async ({ durationSeconds }) => {
+        this.#broadcastTimerArc(durationSeconds);
       },
       listReminders: async () => {
         const scheduleList = await this.listSchedules();
@@ -816,6 +868,11 @@ export class Apollo extends Agent<Env, ApolloState> {
           if (didCancel) {
             cancelledMessageList.push(reminder.message);
           }
+        }
+        // Timers are reminders whose message starts with "Timer" (see
+        // @/tools/timer); cancelling one has to take its arc off the screen.
+        if (cancelledMessageList.some((cancelled) => cancelled.startsWith('Timer'))) {
+          this.#broadcastTimerArc(undefined);
         }
         return {
           cancelledCount: cancelledMessageList.length,
@@ -857,6 +914,17 @@ export class Apollo extends Agent<Env, ApolloState> {
           deviceId,
           effects: deskToolEffects,
           isSpeechAborted: () => this.#isSpeechAborted,
+          allocateTtsSequence: () => {
+            this.#ttsSequence += 1;
+            return this.#ttsSequence;
+          },
+          getPlaybackAckForSequence: (sequence) =>
+            this.#lastPlaybackAck !== null && this.#lastPlaybackAck.seq === sequence
+              ? {
+                  playedMilliseconds: this.#lastPlaybackAck.playedMilliseconds,
+                  receivedAtMilliseconds: this.#lastPlaybackAck.receivedAtMilliseconds,
+                }
+              : null,
           ...(this.#lastTelemetrySnapshot !== undefined
             ? { telemetrySnapshot: this.#lastTelemetrySnapshot }
             : {}),

--- a/src/agents/effects.ts
+++ b/src/agents/effects.ts
@@ -25,6 +25,7 @@ export function createDeskToolEffects(input: {
     delaySeconds: number;
     message: string;
   }) => Promise<void>;
+  readonly broadcastTimerProgress: DeskToolEffects['broadcastTimerProgress'];
   readonly listReminders: DeskToolEffects['listReminders'];
   readonly cancelReminders: DeskToolEffects['cancelReminders'];
   readonly resolveWeatherLocation: DeskToolEffects['resolveWeatherLocation'];
@@ -58,6 +59,7 @@ export function createDeskToolEffects(input: {
       });
     },
     scheduleReminder: input.scheduleReminder,
+    broadcastTimerProgress: input.broadcastTimerProgress,
     listReminders: input.listReminders,
     cancelReminders: input.cancelReminders,
     resolveWeatherLocation: input.resolveWeatherLocation,

--- a/src/agents/notify.ts
+++ b/src/agents/notify.ts
@@ -133,7 +133,8 @@ async function announceNotificationWithTts(input: {
   }
 
   // Paced once for every listener rather than per connection: the devices play
-  // the same announcement at the same time.
+  // the same announcement at the same time. Open-loop on purpose — a broadcast
+  // has no single device whose acks could steer it.
   await streamAudioChunksAtPlaybackPace({
     audioBuffer: ttsAudio,
     sampleRateHz: TTS_PCM_SAMPLE_RATE_HZ,
@@ -144,6 +145,11 @@ async function announceNotificationWithTts(input: {
       }
     },
   });
+
+  const ttsEndMessage = encodeServerToDeviceMessage({ type: 'tts_end' });
+  for (const connection of input.connectionList) {
+    connection.send(ttsEndMessage);
+  }
 
   // Announcements are one-way: without this the device would reopen the mic
   // after speaking, as if the reminder had asked a question.

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -18,7 +18,10 @@ import { runDeskTurn, type VoiceAdapters } from '@/turn/run';
 import { TTS_PCM_CHANNEL_COUNT, TTS_PCM_SAMPLE_RATE_HZ } from '@/voice/elevenlabs';
 import { chatWithOpenRouter } from '@/voice/llm';
 import { transcribeAudioWithOpenRouter } from '@/voice/stt';
-import { streamAudioChunksAtPlaybackPace } from '@/voice/stream';
+import {
+  streamAudioChunksAtPlaybackPace,
+  type PlaybackAckSnapshot,
+} from '@/voice/stream';
 import { synthesizeApolloSpeech } from '@/voice/synthesize';
 import { wrapPcmAsWavBuffer } from '@/voice/wav';
 
@@ -38,6 +41,8 @@ export type ApolloTurnRuntimeDependencies = {
   readonly effects: DeskToolEffects;
   readonly isSpeechAborted?: () => boolean;
   readonly telemetrySnapshot?: DeskTelemetrySnapshot;
+  readonly allocateTtsSequence?: () => number;
+  readonly getPlaybackAckForSequence?: (sequence: number) => PlaybackAckSnapshot | null;
 };
 
 export async function executeApolloTurn(
@@ -154,6 +159,10 @@ export async function executeApolloTurn(
                   0,
                   Math.ceil((liveState.focusEndsAt - Date.now()) / 1000),
                 ),
+                focusEndsAt: Math.floor(liveState.focusEndsAt / 1000),
+                ...(liveState.focusStartedAt !== null
+                  ? { focusStartedAt: Math.floor(liveState.focusStartedAt / 1000) }
+                  : {}),
               }
             : {}),
         }),
@@ -202,6 +211,7 @@ export async function executeApolloTurn(
     pendingConfirmId: turnOutput.pendingConfirmation?.id ?? null,
     pendingConfirmSummary: turnOutput.pendingConfirmation?.summary ?? null,
     focusEndsAt: finalFocusEndsAt,
+    focusStartedAt: finalFocusEndsAt === null ? null : liveState.focusStartedAt,
   });
 
   if (turnOutput.pendingConfirmation !== undefined) {
@@ -244,16 +254,19 @@ export async function executeApolloTurn(
           : undefined;
       const isFirstSegment = followUpIndex === 0;
       followUpIndex += 1;
+      const ttsSequence = dependencies.allocateTtsSequence?.();
 
       connection.send(
         encodeServerToDeviceMessage({
           type: 'tts_start',
           format: 'pcm',
           bytes: currentAudioBuffer.byteLength,
+          ...(ttsSequence !== undefined ? { seq: ttsSequence } : {}),
           sampleRate: TTS_PCM_SAMPLE_RATE_HZ,
           channels: TTS_PCM_CHANNEL_COUNT,
         }),
       );
+      const getPlaybackAckForSequence = dependencies.getPlaybackAckForSequence;
       await streamAudioChunksAtPlaybackPace({
         audioBuffer: currentAudioBuffer,
         sampleRateHz: TTS_PCM_SAMPLE_RATE_HZ,
@@ -269,12 +282,16 @@ export async function executeApolloTurn(
         ...(dependencies.isSpeechAborted !== undefined
           ? { shouldStop: dependencies.isSpeechAborted }
           : {}),
+        ...(ttsSequence !== undefined && getPlaybackAckForSequence !== undefined
+          ? { getPlaybackAck: () => getPlaybackAckForSequence(ttsSequence) }
+          : {}),
       });
 
       if (dependencies.isSpeechAborted?.() === true) {
         wasAborted = true;
         break;
       }
+      connection.send(encodeServerToDeviceMessage({ type: 'tts_end' }));
       currentAudioBuffer = await nextAudioBufferPromise;
     }
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -261,7 +261,7 @@ export async function executeApolloTurn(
           type: 'tts_start',
           format: 'pcm',
           bytes: currentAudioBuffer.byteLength,
-          ...(ttsSequence !== undefined ? { seq: ttsSequence } : {}),
+          ...(ttsSequence !== undefined ? { sequence: ttsSequence } : {}),
           sampleRate: TTS_PCM_SAMPLE_RATE_HZ,
           channels: TTS_PCM_CHANNEL_COUNT,
         }),

--- a/src/configuration/testing.ts
+++ b/src/configuration/testing.ts
@@ -144,6 +144,7 @@ export function createStubDeskToolEffects(
     enqueueResearch: async () => {},
     enqueueCodingTask: async () => {},
     scheduleReminder: async () => {},
+    broadcastTimerProgress: async () => {},
     listReminders: async () => [],
     cancelReminders: async () => ({ cancelledCount: 0, cancelledMessageList: [] }),
     resolveWeatherLocation: async () => ({

--- a/src/protocol/schema.ts
+++ b/src/protocol/schema.ts
@@ -109,8 +109,8 @@ export const deviceToServerMessageSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('playback_ack'),
-    seq: z.number().int().nonnegative(),
-    playedMs: z.number().int().nonnegative(),
+    sequence: z.number().int().nonnegative(),
+    playedMilliseconds: z.number().int().nonnegative(),
     ts: z.number().int().nonnegative(),
   }),
 ]);
@@ -148,7 +148,7 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
     // Optional since tts_end closes runs; firmware before 2.7.0 treats a
     // missing total as an empty run, so keep sending it whenever it is known.
     bytes: z.number().int().nonnegative().optional(),
-    seq: z.number().int().nonnegative().optional(),
+    sequence: z.number().int().nonnegative().optional(),
     sampleRate: z.number().int().positive().optional(),
     channels: z.number().int().positive().optional(),
   }),
@@ -162,7 +162,7 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
     type: z.literal('timer'),
     // Epoch seconds; both absent means clear whatever arc is showing.
     endsAt: z.number().int().nonnegative().optional(),
-    durationSec: z.number().int().positive().optional(),
+    durationSeconds: z.number().int().positive().optional(),
   }),
   z.object({
     type: z.literal('turn_end'),

--- a/src/protocol/schema.ts
+++ b/src/protocol/schema.ts
@@ -107,6 +107,12 @@ export const deviceToServerMessageSchema = z.discriminatedUnion('type', [
     }),
     ts: z.number().int().nonnegative(),
   }),
+  z.object({
+    type: z.literal('playback_ack'),
+    seq: z.number().int().nonnegative(),
+    playedMs: z.number().int().nonnegative(),
+    ts: z.number().int().nonnegative(),
+  }),
 ]);
 
 export type DeviceToServerMessage = z.infer<typeof deviceToServerMessageSchema>;
@@ -118,6 +124,10 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
     speechMode: z.string().min(1),
     caption: z.string().optional(),
     focusRemainingSec: z.number().int().nonnegative().optional(),
+    // Epoch seconds: ui_state pushes are event-driven, so the device needs the
+    // whole window to count down locally between pushes.
+    focusStartedAt: z.number().int().nonnegative().optional(),
+    focusEndsAt: z.number().int().nonnegative().optional(),
     emotion: deskFaceEmotionSchema.optional(),
     accentColor: z.string().optional(),
   }),
@@ -135,12 +145,24 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('tts_start'),
     format: z.enum(['mp3', 'wav', 'pcm']),
-    bytes: z.number().int().nonnegative(),
+    // Optional since tts_end closes runs; firmware before 2.7.0 treats a
+    // missing total as an empty run, so keep sending it whenever it is known.
+    bytes: z.number().int().nonnegative().optional(),
+    seq: z.number().int().nonnegative().optional(),
     sampleRate: z.number().int().positive().optional(),
     channels: z.number().int().positive().optional(),
   }),
   z.object({
+    type: z.literal('tts_end'),
+  }),
+  z.object({
     type: z.literal('tts_aborted'),
+  }),
+  z.object({
+    type: z.literal('timer'),
+    // Epoch seconds; both absent means clear whatever arc is showing.
+    endsAt: z.number().int().nonnegative().optional(),
+    durationSec: z.number().int().positive().optional(),
   }),
   z.object({
     type: z.literal('turn_end'),

--- a/src/tools/__tests__/intent.spec.ts
+++ b/src/tools/__tests__/intent.spec.ts
@@ -77,6 +77,9 @@ function createRecordingEffects(): DeskToolEffects & {
     scheduleReminder: async ({ delaySeconds, message }) => {
       calls.push(`remind:${delaySeconds}:${message}`);
     },
+    broadcastTimerProgress: async ({ durationSeconds }) => {
+      calls.push(`timerArc:${durationSeconds}`);
+    },
     listReminders: async () => {
       calls.push('listReminders');
       return [

--- a/src/tools/timer.ts
+++ b/src/tools/timer.ts
@@ -57,6 +57,9 @@ export const setTimerTool: ToolDefinition = {
           ? `Timer de ${durationText} terminado.`
           : `Timer terminado: ${parsedArgs.label}.`,
     });
+    await context.effects.broadcastTimerProgress({
+      durationSeconds: parsedArgs.durationSeconds,
+    });
     return {
       ok: true,
       summary: `Timer de ${durationText} puesto.`,

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -32,6 +32,9 @@ export type DeskToolEffects = {
     readonly delaySeconds: number;
     readonly message: string;
   }) => Promise<void>;
+  readonly broadcastTimerProgress: (input: {
+    readonly durationSeconds: number;
+  }) => Promise<void>;
   readonly listReminders: () => Promise<readonly ScheduledReminderRow[]>;
   readonly cancelReminders: (input: {
     readonly message?: string;

--- a/src/voice/__tests__/stream.spec.ts
+++ b/src/voice/__tests__/stream.spec.ts
@@ -230,4 +230,91 @@ describe('streamAudioChunksAtPlaybackPace', () => {
       TTS_STREAM_PREBUFFER_MILLISECONDS - 500,
     );
   });
+
+  it('holds the measured backlog at the ceiling when the device acks playback', async () => {
+    const sink = createRecordingSink();
+    const sampleRateHz = 24000;
+    let virtualNowMilliseconds = 0;
+    let playedMilliseconds = 0;
+    const wait = async (milliseconds: number): Promise<void> => {
+      sink.waitMillisecondsList.push(milliseconds);
+      virtualNowMilliseconds += milliseconds;
+      playedMilliseconds += milliseconds;
+    };
+
+    await streamAudioChunksAtPlaybackPace({
+      audioBuffer: buildAudioBuffer(8192 * 700),
+      sampleRateHz,
+      channelCount: 1,
+      send: sink.send,
+      wait,
+      now: () => virtualNowMilliseconds,
+      getPlaybackAck: () => ({
+        playedMilliseconds,
+        receivedAtMilliseconds: virtualNowMilliseconds,
+      }),
+    });
+
+    const chunkMilliseconds = computeChunkPlaybackMilliseconds({
+      chunkByteLength: 8192,
+      sampleRateHz,
+      channelCount: 1,
+    });
+    let deliveredMilliseconds = 0;
+    let drainedMilliseconds = 0;
+    let peakBacklogMilliseconds = 0;
+    for (let index = 0; index < sink.sentByteLengthList.length; index += 1) {
+      drainedMilliseconds += sink.waitMillisecondsList[index - 1] ?? 0;
+      deliveredMilliseconds += chunkMilliseconds;
+      peakBacklogMilliseconds = Math.max(
+        peakBacklogMilliseconds,
+        deliveredMilliseconds - drainedMilliseconds,
+      );
+    }
+
+    expect(sink.sentByteLengthList).toHaveLength(700);
+    expect(peakBacklogMilliseconds).toBeLessThanOrEqual(
+      TTS_STREAM_MAX_BACKLOG_MILLISECONDS + 1,
+    );
+  });
+
+  it('trusts the reported backlog over the open-loop pace when acks say the device is behind', async () => {
+    const sink = createRecordingSink();
+    const sampleRateHz = 24000;
+    let virtualNowMilliseconds = 0;
+    const wait = async (milliseconds: number): Promise<void> => {
+      sink.waitMillisecondsList.push(milliseconds);
+      virtualNowMilliseconds += milliseconds;
+    };
+
+    // The device never advances: every wait must come from the measured
+    // backlog alone, so delivery keeps pace with the extrapolated estimate
+    // instead of racing ahead at link speed.
+    await streamAudioChunksAtPlaybackPace({
+      audioBuffer: buildAudioBuffer(8192 * 100),
+      sampleRateHz,
+      channelCount: 1,
+      send: sink.send,
+      wait,
+      now: () => virtualNowMilliseconds,
+      getPlaybackAck: () => ({
+        playedMilliseconds: 0,
+        receivedAtMilliseconds: 0,
+      }),
+    });
+
+    const totalWaitMilliseconds = sink.waitMillisecondsList.reduce(
+      (sum, milliseconds) => sum + milliseconds,
+      0,
+    );
+    const totalAudioMilliseconds = computeChunkPlaybackMilliseconds({
+      chunkByteLength: 8192 * 100,
+      sampleRateHz,
+      channelCount: 1,
+    });
+    expect(sink.sentByteLengthList).toHaveLength(100);
+    expect(totalWaitMilliseconds).toBeGreaterThan(
+      totalAudioMilliseconds - TTS_STREAM_MAX_BACKLOG_MILLISECONDS - 1000,
+    );
+  });
 });

--- a/src/voice/stream.ts
+++ b/src/voice/stream.ts
@@ -38,6 +38,24 @@ async function waitWithTimeout(milliseconds: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+export type PlaybackAckSnapshot = {
+  readonly playedMilliseconds: number;
+  readonly receivedAtMilliseconds: number;
+};
+
+// Acks arrive about once a second; between them the estimate assumes playback
+// kept running, capped at what was delivered so a stale ack can never claim
+// more was played than was sent.
+function estimatePlayedMilliseconds(
+  ack: PlaybackAckSnapshot,
+  deliveredMilliseconds: number,
+  nowMilliseconds: number,
+): number {
+  const extrapolated =
+    ack.playedMilliseconds + Math.max(0, nowMilliseconds - ack.receivedAtMilliseconds);
+  return Math.min(deliveredMilliseconds, extrapolated);
+}
+
 export async function streamAudioChunksAtPlaybackPace(input: {
   readonly audioBuffer: ArrayBuffer;
   readonly sampleRateHz: number;
@@ -49,11 +67,16 @@ export async function streamAudioChunksAtPlaybackPace(input: {
   // Checked between chunks: pacing means the run is still in flight long after
   // it started, so an interruption has to be able to cut it short.
   readonly shouldStop?: () => boolean;
+  // With acks the backlog is measured instead of modeled; without them the
+  // open-loop pace factor stays in charge (firmware before 2.7.0 sends none).
+  readonly getPlaybackAck?: () => PlaybackAckSnapshot | null;
+  readonly now?: () => number;
 }): Promise<number> {
   const chunkByteLength = input.chunkByteLength ?? TTS_STREAM_CHUNK_BYTE_LENGTH;
   const prebufferMilliseconds =
     input.prebufferMilliseconds ?? TTS_STREAM_PREBUFFER_MILLISECONDS;
   const wait = input.wait ?? waitWithTimeout;
+  const now = input.now ?? Date.now;
 
   const chunkList = sliceAudioBufferIntoChunkList(input.audioBuffer, chunkByteLength);
   let unbufferedMilliseconds = prebufferMilliseconds;
@@ -77,14 +100,27 @@ export async function streamAudioChunksAtPlaybackPace(input: {
     if (unbufferedMilliseconds > 0) {
       unbufferedMilliseconds -= chunkMilliseconds;
     } else {
-      const backlogAfterSendMilliseconds =
-        deliveredMilliseconds + chunkMilliseconds - waitedMilliseconds;
-      const waitMilliseconds = Math.max(
-        chunkMilliseconds * TTS_STREAM_PACE_FACTOR,
-        backlogAfterSendMilliseconds - TTS_STREAM_MAX_BACKLOG_MILLISECONDS,
-      );
-      await wait(waitMilliseconds);
-      waitedMilliseconds += waitMilliseconds;
+      const playbackAck = input.getPlaybackAck?.() ?? null;
+      if (playbackAck !== null) {
+        const backlogAfterSendMilliseconds =
+          deliveredMilliseconds +
+          chunkMilliseconds -
+          estimatePlayedMilliseconds(playbackAck, deliveredMilliseconds, now());
+        const waitMilliseconds =
+          backlogAfterSendMilliseconds - TTS_STREAM_MAX_BACKLOG_MILLISECONDS;
+        if (waitMilliseconds > 0) {
+          await wait(waitMilliseconds);
+        }
+      } else {
+        const backlogAfterSendMilliseconds =
+          deliveredMilliseconds + chunkMilliseconds - waitedMilliseconds;
+        const waitMilliseconds = Math.max(
+          chunkMilliseconds * TTS_STREAM_PACE_FACTOR,
+          backlogAfterSendMilliseconds - TTS_STREAM_MAX_BACKLOG_MILLISECONDS,
+        );
+        await wait(waitMilliseconds);
+        waitedMilliseconds += waitMilliseconds;
+      }
     }
 
     // Re-checked after the wait: an interruption most often lands while paused.


### PR DESCRIPTION
## Qué cambia

Roadmap 15 y 1+6 juntos, porque comparten flash (contraparte firmware: galfrevn/apollo-firmware#7, versión 2.7.0).

**Streaming real (15)**
- `playback_ack` nuevo en el protocolo device→server; el agente guarda el último ack y `streamAudioChunksAtPlaybackPace` lo usa como lazo cerrado: backlog **medido** sostenido en el techo de 4 s, extrapolado entre acks y con tope en lo entregado, así un ack viejo nunca infla lo reproducido. Sin acks (firmware ≤2.6.0) cae al open-loop de siempre — cero cambio de comportamiento hasta que llegue el OTA.
- `tts_start.bytes` pasa a opcional y cada segmento cierra con `tts_end`; `seq` por run filtra acks cruzados. El server sigue mandando `bytes` (síntesis por oración, buffer completo), así que cualquier orden de deploy es seguro; el streaming mid-synthesis desde ElevenLabs queda como follow-up ya desbloqueado.
- Los announcements (`notify.ts`) quedan open-loop a propósito: son broadcast y no hay un device único cuyos acks puedan gobernar el pacing.

**Arco de cuenta regresiva (1+6)**
- `ui_state` lleva `focusStartedAt`/`focusEndsAt` en epoch segundos (además de `focusRemainingSec` por compatibilidad): el device cuenta solo entre pushes, que son por evento.
- `set_timer` difunde `{"type":"timer", endsAt, durationSec}`; cancelar el timer limpia el arco (detección por el prefijo `Timer` del mensaje, la convención existente del scheduler). El pomodoro usa el arco de focus.
- `ApolloState` gana `focusStartedAt`, seteado/limpiado junto a `focusEndsAt`.

**Tests**: 336 pasan; 2 nuevos cubren el lazo cerrado (backlog en el techo con acks reales, y acks congelados que degradan a la extrapolación sin frenar el envío).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnWeHoHnkxsNc2X5NX3tGo

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds playback-acknowledged TTS pacing and event-driven countdown arcs while preserving compatibility with older firmware.
- Adds sequence-scoped playback acknowledgements and explicit TTS termination.
- Propagates focus timing windows and timer countdown messages to devices.
- Updates selective timer cancellation to restore the soonest remaining timer’s arc.
- Replaces newly introduced abbreviated protocol fields with descriptive names.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(firmware): point the submodule at ..."](https://github.com/galfrevn/apollo/commit/d9e8c2f2ef3dc7cbd168ed58f1b269de93c45ca4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52331438)</sub>

<!-- /greptile_comment -->