### PR TITLE
feat(configuration): the config foundation — resolver, code-default models, neutral chat types

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -8,6 +8,15 @@ GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 MOCK_VOICE=1
 
+# Optional overrides — defaults live in src/configuration/models.ts:
+# OPENROUTER_MODEL=
+# OPENROUTER_STT_MODEL=
+# OPENROUTER_RESEARCH_MODEL=
+# OPENROUTER_CODING_MODEL=
+# OPENROUTER_EMBEDDING_MODEL=
+# ELEVENLABS_TTS_MODEL=
+# CODING_PROXY_SECRET= (sandbox-token signing; falls back to OPENROUTER_API_KEY)
+
 # Remote one-time setup (when you deploy):
 # bunx wrangler vectorize create apollo-memory --dimensions=1536 --metric=cosine
 # bunx wrangler r2 bucket create apollo-media

--- a/documentation/capabilities/coding.md
+++ b/documentation/capabilities/coding.md
@@ -53,7 +53,8 @@ Installation tokens last an hour, so one is minted immediately before the push r
 |---------|---------|
 | `GITHUB_APP_ID` | Secret — the App's numeric id |
 | `GITHUB_APP_PRIVATE_KEY` | Secret — PKCS#8 PEM. Convert a PKCS#1 key with `openssl pkcs8 -topk8 -nocrypt` |
-| `OPENROUTER_CODING_MODEL` | Var, default `moonshotai/kimi-k3` |
+| `OPENROUTER_CODING_MODEL` | Optional env override, default `moonshotai/kimi-k3` |
+| `CODING_PROXY_SECRET` | Optional secret signing sandbox proxy tokens; unset falls back to `OPENROUTER_API_KEY` |
 | `instance_type` | `standard-1` — `lite` cannot hold a clone plus an install |
 
 Create the App with **Contents: read & write**, **Pull requests: read & write**, **Metadata: read**, then install it on the repositories Apollo may touch.

--- a/documentation/capabilities/research.md
+++ b/documentation/capabilities/research.md
@@ -8,7 +8,7 @@ Apollo distinguishes quick lookups from deep multi-source research.
 
 ## Deep research
 
-`start_research` enqueues a background workflow that makes a single call to Perplexity Sonar via OpenRouter (`src/search/deepresearch.ts`, model var `OPENROUTER_RESEARCH_MODEL`, default `perplexity/sonar-deep-research`). Sonar plans and runs its own multi-source searches and returns a cited markdown report; the workflow persists it to R2, emails the full report to `APOLLO_OWNER_EMAIL` (best-effort — see [Email](email.md)), and speaks a short summary as a `background_result`. Cost is pay-per-use (~USD 0.30–0.60 per research); if runs ever time out, `perplexity/sonar-reasoning-pro` is a faster config-only fallback.
+`start_research` enqueues a background workflow that makes a single call to Perplexity Sonar via OpenRouter (`src/search/deepresearch.ts`, model default `perplexity/sonar-deep-research`, overridable via `OPENROUTER_RESEARCH_MODEL`). Sonar plans and runs its own multi-source searches and returns a cited markdown report; the workflow persists it to R2, emails the full report to `APOLLO_OWNER_EMAIL` (best-effort — see [Email](email.md)), and speaks a short summary as a `background_result`. Cost is pay-per-use (~USD 0.30–0.60 per research); if runs ever time out, `perplexity/sonar-reasoning-pro` is a faster config-only fallback.
 
 The old homemade pipeline (Cloudflare `WEBSEARCH` binding + fetch/extract/synthesize) was removed: the binding is `account_disabled` on the free plan.
 

--- a/documentation/operations/deploy.md
+++ b/documentation/operations/deploy.md
@@ -29,19 +29,23 @@ None of these live in `wrangler.jsonc`; set each with `bunx wrangler secret put 
 | `APOLLO_OWNER_EMAIL` | Pinned recipient for `send_email` and research reports ([Email](../capabilities/email.md)) |
 | `GITHUB_APP_ID` | GitHub App used by coding tasks ([Coding](../capabilities/coding.md)) |
 | `GITHUB_APP_PRIVATE_KEY` | Same App — PKCS#8 PEM ([Coding](../capabilities/coding.md)) |
+| `CODING_PROXY_SECRET` | Optional — signs sandbox proxy tokens; unset falls back to `OPENROUTER_API_KEY` |
 
-## Vars
+## Models
 
-Plain vars in `wrangler.jsonc`: `OPENROUTER_MODEL`, `OPENROUTER_STT_MODEL`,
-`OPENROUTER_RESEARCH_MODEL`, `OPENROUTER_CODING_MODEL`, `OPENROUTER_EMBEDDING_MODEL`,
-and `ELEVENLABS_TTS_MODEL`.
+Model ids are code defaults in `src/configuration/models.ts`, resolved through
+`resolveApolloConfiguration` (`src/configuration/resolve.ts`). Each one can be overridden
+per deployment with a plain environment value — `OPENROUTER_MODEL`,
+`OPENROUTER_STT_MODEL`, `OPENROUTER_RESEARCH_MODEL`, `OPENROUTER_CODING_MODEL`,
+`OPENROUTER_EMBEDDING_MODEL`, `ELEVENLABS_TTS_MODEL` — set as a secret or in `.dev.vars`;
+an unset or empty override falls back to the default.
 
-Changing a var means editing `wrangler.jsonc` and redeploying. `wrangler types` turns each
-var into a *literal* type, so `createFakeApolloEnvironment`
-(`src/configuration/testing.ts`) has to repeat the exact same string — a var change that
-skips it fails typecheck, not tests.
+There are deliberately no `vars` in `wrangler.jsonc`: `wrangler types` freezes each var
+into a *literal* type whose exact value must be repeated in
+`createFakeApolloEnvironment` (`src/configuration/testing.ts`) and committed to the
+public repo.
 
-See `wrangler.jsonc` for the authoritative list and the migration tags.
+See `wrangler.jsonc` for the authoritative binding list and the migration tags.
 
 ## Deploy command
 

--- a/documentation/runtime/voice.md
+++ b/documentation/runtime/voice.md
@@ -18,9 +18,9 @@ Two more latency/cost layers sit on that path:
 Configuration knobs:
 
 - `ELEVENLABS_API_KEY` — secret (`.dev.vars` locally, `bunx wrangler secret put ELEVENLABS_API_KEY` in prod)
-- `ELEVENLABS_TTS_MODEL` — `wrangler.jsonc` var, default `eleven_multilingual_v2` (best accent fidelity; `eleven_flash_v2_5` is half the credits if quota bites)
+- `ELEVENLABS_TTS_MODEL` — optional env override, default `eleven_multilingual_v2` in `src/configuration/models.ts` (best accent fidelity; `eleven_flash_v2_5` is half the credits if quota bites)
 - `APOLLO_TTS_VOICE` — voice id constant in `src/persona/soul.ts`. The model takes no `language_code`, so the Rioplatense accent lives in the voice: pick one from the ElevenLabs Voice Library (Spanish / Argentina), add it to My Voices, paste the id
-- STT/LLM stay on OpenRouter: `OPENROUTER_STT_MODEL`, `OPENROUTER_MODEL`
+- STT/LLM stay on OpenRouter: `OPENROUTER_STT_MODEL`, `OPENROUTER_MODEL` (same pattern — code defaults, optional env overrides)
 
 Quota math (Starter ≈ 30k credits/mo): `eleven_multilingual_v2` burns ~1 credit per character, `eleven_flash_v2_5` ~0.5. A typical spoken reply (~200 chars) is ~200 credits.
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -2,6 +2,7 @@ import type { Connection } from 'agents';
 import type { Session } from 'agents/experimental/memory/session';
 
 import type { ApolloState } from '@/agents/apollo';
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import { createInactiveDeskFocusState, tickDeskFocus } from '@/focus/logic';
 import { buildSessionSystemPrompt } from '@/memory/session';
 import type { MemorySqlExecutor } from '@/memory/store';
@@ -62,6 +63,7 @@ export async function executeApolloTurn(
   );
 
   const isMockVoice = dependencies.environment.MOCK_VOICE === '1';
+  const { models } = resolveApolloConfiguration(dependencies.environment);
   const sessionSystemPrompt = await buildSessionSystemPrompt(dependencies.session);
   const recallSemanticMemoryContentList = async (
     queryText: string,
@@ -69,7 +71,7 @@ export async function executeApolloTurn(
     recallSemanticMemoryContent({
       vectorizeIndex: dependencies.environment.VECTORIZE,
       openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
-      embeddingModelId: dependencies.environment.OPENROUTER_EMBEDDING_MODEL,
+      embeddingModelId: models.embedding,
       queryText,
       deviceId: dependencies.deviceId,
     });
@@ -100,12 +102,12 @@ export async function executeApolloTurn(
           transcribeAudioWithOpenRouter({
             audioBuffer: wrapPcmAsWavBuffer({ pcmBuffer: audioBuffer }),
             openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
-            modelId: dependencies.environment.OPENROUTER_STT_MODEL,
+            modelId: models.transcription,
           }),
         llm: async ({ messageList, toolDefinitionList, onTextDelta }) =>
           chatWithOpenRouter({
             openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
-            modelId: dependencies.environment.OPENROUTER_MODEL,
+            modelId: models.conversation,
             messageList,
             toolDefinitionList,
             ...(onTextDelta !== undefined ? { onTextDelta } : {}),

--- a/src/coding/__tests__/agent.spec.ts
+++ b/src/coding/__tests__/agent.spec.ts
@@ -5,7 +5,7 @@ import {
   type CodingSandboxPort,
   type CodingLlmCaller,
 } from '@/coding/agent';
-import type { OpenRouterChatResult } from '@/voice/llm';
+import type { ChatResult } from '@/voice/chat';
 
 type RecordedSandboxCall = {
   readonly kind: 'list' | 'read' | 'write' | 'exec';
@@ -44,7 +44,7 @@ function createFakeSandbox(fileContentByPath: Record<string, string> = {}): {
   };
 }
 
-function createScriptedLlm(resultList: readonly OpenRouterChatResult[]): {
+function createScriptedLlm(resultList: readonly ChatResult[]): {
   readonly callLlm: CodingLlmCaller;
   readonly roundCount: () => number;
 } {

--- a/src/coding/__tests__/proxy.spec.ts
+++ b/src/coding/__tests__/proxy.spec.ts
@@ -13,21 +13,21 @@ describe('coding proxy tokens', () => {
   it('accepts a freshly minted token and rejects it after expiry', async () => {
     const token = await mintCodingProxyToken({
       instanceId: 'wf-1',
-      openRouterApiKey: OPENROUTER_API_KEY,
+      signingSecret: OPENROUTER_API_KEY,
       nowMilliseconds: 1_000,
     });
 
     expect(
       await verifyCodingProxyToken({
         token,
-        openRouterApiKey: OPENROUTER_API_KEY,
+        signingSecret: OPENROUTER_API_KEY,
         nowMilliseconds: 2_000,
       }),
     ).toBe(true);
     expect(
       await verifyCodingProxyToken({
         token,
-        openRouterApiKey: OPENROUTER_API_KEY,
+        signingSecret: OPENROUTER_API_KEY,
         nowMilliseconds: 1_000 + 7 * 60 * 60 * 1000,
       }),
     ).toBe(false);
@@ -36,28 +36,28 @@ describe('coding proxy tokens', () => {
   it('rejects a tampered token and a token signed with another key', async () => {
     const token = await mintCodingProxyToken({
       instanceId: 'wf-1',
-      openRouterApiKey: OPENROUTER_API_KEY,
+      signingSecret: OPENROUTER_API_KEY,
       nowMilliseconds: 1_000,
     });
 
     expect(
       await verifyCodingProxyToken({
         token: token.replace('wf-1', 'wf-2'),
-        openRouterApiKey: OPENROUTER_API_KEY,
+        signingSecret: OPENROUTER_API_KEY,
         nowMilliseconds: 2_000,
       }),
     ).toBe(false);
     expect(
       await verifyCodingProxyToken({
         token,
-        openRouterApiKey: 'sk-or-other-key',
+        signingSecret: 'sk-or-other-key',
         nowMilliseconds: 2_000,
       }),
     ).toBe(false);
     expect(
       await verifyCodingProxyToken({
         token: 'garbage',
-        openRouterApiKey: OPENROUTER_API_KEY,
+        signingSecret: OPENROUTER_API_KEY,
         nowMilliseconds: 2_000,
       }),
     ).toBe(false);
@@ -68,7 +68,7 @@ describe('handleCodingLlmProxyRequest', () => {
   async function buildAuthorizedRequest(bodyObject: unknown): Promise<Request> {
     const token = await mintCodingProxyToken({
       instanceId: 'wf-1',
-      openRouterApiKey: OPENROUTER_API_KEY,
+      signingSecret: OPENROUTER_API_KEY,
       nowMilliseconds: Date.now(),
     });
     return new Request('https://apollo.example/coding-llm/v1/chat/completions', {

--- a/src/coding/agent.ts
+++ b/src/coding/agent.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { CODING_WORKSPACE_PATH } from '@/coding/git';
 import { resolveWorkspaceFilePath } from '@/coding/workspace';
 import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
-import type { OpenRouterChatMessage, OpenRouterChatResult } from '@/voice/llm';
+import type { ChatMessage, ChatResult, ChatToolDefinition } from '@/voice/chat';
 
 export const DEFAULT_CODING_ROUND_LIMIT = 24;
 // Two rounds with identical calls and identical results get the model a
@@ -30,13 +30,9 @@ export type CodingSandboxPort = {
 };
 
 export type CodingLlmCaller = (input: {
-  readonly messageList: readonly OpenRouterChatMessage[];
-  readonly toolDefinitionList: readonly {
-    readonly name: string;
-    readonly description: string;
-    readonly parameters: Record<string, unknown>;
-  }[];
-}) => Promise<OpenRouterChatResult>;
+  readonly messageList: readonly ChatMessage[];
+  readonly toolDefinitionList: readonly ChatToolDefinition[];
+}) => Promise<ChatResult>;
 
 export type CodingAgentOutcome = {
   readonly summary: string;
@@ -221,7 +217,7 @@ const WRAP_UP_PROMPT =
 // spoken summary instead of throwing the whole run away.
 async function requestWrapUpSummary(
   callLlm: CodingLlmCaller,
-  messageList: readonly OpenRouterChatMessage[],
+  messageList: readonly ChatMessage[],
 ): Promise<string> {
   try {
     const wrapUpResult = await callLlm({
@@ -246,7 +242,7 @@ export async function runCodingAgent(input: {
   const roundLimit = input.roundLimit ?? DEFAULT_CODING_ROUND_LIMIT;
   const transcript: string[] = [];
 
-  const messageList: OpenRouterChatMessage[] = [
+  const messageList: ChatMessage[] = [
     {
       role: 'system',
       content: buildCodingSystemPrompt({

--- a/src/coding/proxy.ts
+++ b/src/coding/proxy.ts
@@ -1,21 +1,30 @@
 import { z } from 'zod';
 
+import { resolveApolloConfiguration } from '@/configuration/resolve';
+
 const OPENROUTER_CHAT_COMPLETIONS_URL = 'https://openrouter.ai/api/v1/chat/completions';
 
 const proxyRequestBodySchema = z.object({ model: z.string() }).passthrough();
 export const CODING_PROXY_PATH_PREFIX = '/coding-llm/v1';
 export const CODING_PROXY_TOKEN_TTL_MILLISECONDS = 6 * 60 * 60 * 1000;
 
-// The token is signed with the OpenRouter key itself: the worker already holds
-// it, nothing new to provision, and rotating the key revokes every token that
-// ever reached a sandbox.
+// A dedicated signing secret keeps sandbox-token auth independent of the LLM
+// provider: rotating the provider key no longer revokes every token in flight.
+// The provider-key fallback keeps deployments working until the secret is set.
+export function resolveCodingProxySigningSecret(environment: Env): string {
+  const dedicatedSecret = environment.CODING_PROXY_SECRET;
+  return dedicatedSecret !== undefined && dedicatedSecret.length > 0
+    ? dedicatedSecret
+    : environment.OPENROUTER_API_KEY;
+}
+
 async function computeTokenSignature(
-  openRouterApiKey: string,
+  signingSecret: string,
   payloadText: string,
 ): Promise<string> {
   const signingKey = await crypto.subtle.importKey(
     'raw',
-    new TextEncoder().encode(openRouterApiKey),
+    new TextEncoder().encode(signingSecret),
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['sign'],
@@ -32,19 +41,19 @@ async function computeTokenSignature(
 
 export async function mintCodingProxyToken(input: {
   readonly instanceId: string;
-  readonly openRouterApiKey: string;
+  readonly signingSecret: string;
   readonly nowMilliseconds: number;
 }): Promise<string> {
   const expiresAtMilliseconds =
     input.nowMilliseconds + CODING_PROXY_TOKEN_TTL_MILLISECONDS;
   const payloadText = `${input.instanceId}.${expiresAtMilliseconds}`;
-  const signature = await computeTokenSignature(input.openRouterApiKey, payloadText);
+  const signature = await computeTokenSignature(input.signingSecret, payloadText);
   return `${payloadText}.${signature}`;
 }
 
 export async function verifyCodingProxyToken(input: {
   readonly token: string;
-  readonly openRouterApiKey: string;
+  readonly signingSecret: string;
   readonly nowMilliseconds: number;
 }): Promise<boolean> {
   const lastSeparatorIndex = input.token.lastIndexOf('.');
@@ -62,10 +71,7 @@ export async function verifyCodingProxyToken(input: {
   if (input.nowMilliseconds > expiresAtMilliseconds) {
     return false;
   }
-  const expectedSignature = await computeTokenSignature(
-    input.openRouterApiKey,
-    payloadText,
-  );
+  const expectedSignature = await computeTokenSignature(input.signingSecret, payloadText);
   if (presentedSignature.length !== expectedSignature.length) {
     return false;
   }
@@ -101,7 +107,7 @@ export async function handleCodingLlmProxyRequest(
   const presentedToken = authorizationHeader.replace(/^Bearer\s+/i, '');
   const isTokenValid = await verifyCodingProxyToken({
     token: presentedToken,
-    openRouterApiKey: environment.OPENROUTER_API_KEY,
+    signingSecret: resolveCodingProxySigningSecret(environment),
     nowMilliseconds: Date.now(),
   });
   if (!isTokenValid) {
@@ -119,7 +125,7 @@ export async function handleCodingLlmProxyRequest(
   if (!parsedBody.success) {
     return new Response('Bad request', { status: 400 });
   }
-  if (parsedBody.data.model !== environment.OPENROUTER_CODING_MODEL) {
+  if (parsedBody.data.model !== resolveApolloConfiguration(environment).models.coding) {
     return new Response('Model not allowed', { status: 403 });
   }
 

--- a/src/configuration/__tests__/resolve.spec.ts
+++ b/src/configuration/__tests__/resolve.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+
+import { defaultModelCatalog } from '@/configuration/models';
+import { resolveApolloConfiguration } from '@/configuration/resolve';
+import { createFakeApolloEnvironment } from '@/configuration/testing';
+
+describe('resolveApolloConfiguration', () => {
+  it('falls back to the default model catalog when nothing is set', () => {
+    const configuration = resolveApolloConfiguration(createFakeApolloEnvironment());
+    expect(configuration.models).toEqual(defaultModelCatalog);
+  });
+
+  it('prefers environment overrides over defaults', () => {
+    const configuration = resolveApolloConfiguration(
+      createFakeApolloEnvironment({
+        OPENROUTER_MODEL: 'openai/gpt-5o',
+        ELEVENLABS_TTS_MODEL: 'eleven_flash_v2_5',
+      }),
+    );
+    expect(configuration.models.conversation).toBe('openai/gpt-5o');
+    expect(configuration.models.speech).toBe('eleven_flash_v2_5');
+    expect(configuration.models.embedding).toBe(defaultModelCatalog.embedding);
+  });
+
+  it('treats an empty override as unset', () => {
+    const configuration = resolveApolloConfiguration(
+      createFakeApolloEnvironment({ OPENROUTER_MODEL: '' }),
+    );
+    expect(configuration.models.conversation).toBe(defaultModelCatalog.conversation);
+  });
+});

--- a/src/configuration/environment.d.ts
+++ b/src/configuration/environment.d.ts
@@ -10,6 +10,13 @@ interface Env {
   MOCK_VOICE?: string;
   CODING_PROXY_ORIGIN?: string;
   CODING_ENGINE?: string;
+  CODING_PROXY_SECRET?: string;
+  OPENROUTER_MODEL?: string;
+  OPENROUTER_STT_MODEL?: string;
+  OPENROUTER_RESEARCH_MODEL?: string;
+  OPENROUTER_CODING_MODEL?: string;
+  OPENROUTER_EMBEDDING_MODEL?: string;
+  ELEVENLABS_TTS_MODEL?: string;
 }
 
 declare namespace Cloudflare {
@@ -25,5 +32,12 @@ declare namespace Cloudflare {
     MOCK_VOICE?: string;
     CODING_PROXY_ORIGIN?: string;
     CODING_ENGINE?: string;
+    CODING_PROXY_SECRET?: string;
+    OPENROUTER_MODEL?: string;
+    OPENROUTER_STT_MODEL?: string;
+    OPENROUTER_RESEARCH_MODEL?: string;
+    OPENROUTER_CODING_MODEL?: string;
+    OPENROUTER_EMBEDDING_MODEL?: string;
+    ELEVENLABS_TTS_MODEL?: string;
   }
 }

--- a/src/configuration/models.ts
+++ b/src/configuration/models.ts
@@ -1,0 +1,11 @@
+// Default model ids live in code instead of wrangler vars: vars freeze into
+// literal types whose values must be committed to the public repo, while these
+// defaults can be overridden per deployment through plain environment values.
+export const defaultModelCatalog = {
+  conversation: 'deepseek/deepseek-v4-flash-0731',
+  transcription: 'openai/whisper-large-v3',
+  research: 'perplexity/sonar-deep-research',
+  coding: 'moonshotai/kimi-k3',
+  embedding: 'openai/text-embedding-3-small',
+  speech: 'eleven_multilingual_v2',
+} as const;

--- a/src/configuration/resolve.ts
+++ b/src/configuration/resolve.ts
@@ -1,0 +1,57 @@
+import { defaultModelCatalog } from '@/configuration/models';
+
+export type ApolloModelConfiguration = {
+  readonly conversation: string;
+  readonly transcription: string;
+  readonly research: string;
+  readonly coding: string;
+  readonly embedding: string;
+  readonly speech: string;
+};
+
+export type ApolloConfiguration = {
+  readonly models: ApolloModelConfiguration;
+};
+
+function resolveOverridableValue(
+  overrideValue: string | undefined,
+  defaultValue: string,
+): string {
+  return overrideValue !== undefined && overrideValue.length > 0
+    ? overrideValue
+    : defaultValue;
+}
+
+// The single place deployment configuration is assembled. Today it reads
+// environment overrides over code defaults; the runtime (wizard-managed)
+// override layer lands on top of this same seam.
+export function resolveApolloConfiguration(environment: Env): ApolloConfiguration {
+  return {
+    models: {
+      conversation: resolveOverridableValue(
+        environment.OPENROUTER_MODEL,
+        defaultModelCatalog.conversation,
+      ),
+      transcription: resolveOverridableValue(
+        environment.OPENROUTER_STT_MODEL,
+        defaultModelCatalog.transcription,
+      ),
+      research: resolveOverridableValue(
+        environment.OPENROUTER_RESEARCH_MODEL,
+        defaultModelCatalog.research,
+      ),
+      coding: resolveOverridableValue(
+        environment.OPENROUTER_CODING_MODEL,
+        defaultModelCatalog.coding,
+      ),
+      embedding: resolveOverridableValue(
+        environment.OPENROUTER_EMBEDDING_MODEL,
+        defaultModelCatalog.embedding,
+      ),
+      speech: resolveOverridableValue(
+        environment.ELEVENLABS_TTS_MODEL,
+        defaultModelCatalog.speech,
+      ),
+    },
+  };
+}

--- a/src/configuration/testing.ts
+++ b/src/configuration/testing.ts
@@ -107,12 +107,6 @@ export async function buildTestRsaPrivateKeyPem(): Promise<string> {
 
 export function createFakeApolloEnvironment(overrides: Partial<Env> = {}): Env {
   return {
-    OPENROUTER_MODEL: 'deepseek/deepseek-v4-flash-0731',
-    OPENROUTER_STT_MODEL: 'openai/whisper-large-v3',
-    OPENROUTER_RESEARCH_MODEL: 'perplexity/sonar-deep-research',
-    OPENROUTER_CODING_MODEL: 'moonshotai/kimi-k3',
-    ELEVENLABS_TTS_MODEL: 'eleven_multilingual_v2',
-    OPENROUTER_EMBEDDING_MODEL: 'openai/text-embedding-3-small',
     DEVICE_SHARED_SECRET: 'secret',
     OPENROUTER_API_KEY: '',
     ELEVENLABS_API_KEY: '',

--- a/src/queues/consume.ts
+++ b/src/queues/consume.ts
@@ -1,3 +1,4 @@
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import { embedTextWithOpenRouter, upsertMemoryVector } from '@/memory/vector';
 import { parseApolloQueueJob } from '@/queues/jobs';
 
@@ -5,6 +6,7 @@ export async function consumeApolloQueueBatch(
   batch: MessageBatch<unknown>,
   environment: Env,
 ): Promise<void> {
+  const { models } = resolveApolloConfiguration(environment);
   for (const message of batch.messages) {
     try {
       const job = parseApolloQueueJob(message.body);
@@ -12,7 +14,7 @@ export async function consumeApolloQueueBatch(
       if (job.type === 'index_memory') {
         const values = await embedTextWithOpenRouter({
           openRouterApiKey: environment.OPENROUTER_API_KEY,
-          modelId: environment.OPENROUTER_EMBEDDING_MODEL,
+          modelId: models.embedding,
           text: job.content,
         });
         await upsertMemoryVector({

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import type { ToolDefinition } from '@/tools/types';
 
 const rememberFactArgsSchema = z.object({
@@ -59,7 +60,7 @@ export const recallMemoryTool: ToolDefinition = {
         await import('@/memory/vector');
       const values = await embedTextWithOpenRouter({
         openRouterApiKey: context.environment.OPENROUTER_API_KEY,
-        modelId: context.environment.OPENROUTER_EMBEDDING_MODEL,
+        modelId: resolveApolloConfiguration(context.environment).models.embedding,
         text: parsedArgs.query,
       });
       const matchList = await queryMemoryVectors({

--- a/src/tools/translate.ts
+++ b/src/tools/translate.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import type { ToolDefinition } from '@/tools/types';
 import { chatWithOpenRouter } from '@/voice/llm';
 
@@ -33,7 +34,7 @@ export const translateTool: ToolDefinition = {
     try {
       const chatResult = await chatWithOpenRouter({
         openRouterApiKey: context.environment.OPENROUTER_API_KEY,
-        modelId: context.environment.OPENROUTER_MODEL,
+        modelId: resolveApolloConfiguration(context.environment).models.conversation,
         messageList: [
           {
             role: 'system',

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import { formatCurrentDateTimeForPrompt } from '@/persona/clock';
 import { synthesizeQuickWebAnswer } from '@/search/synthesize';
 import { searchWebSourcesWithTavily } from '@/search/tavily';
@@ -36,7 +37,7 @@ export const webSearchTool: ToolDefinition = {
       }
       const answerText = await synthesizeQuickWebAnswer({
         openRouterApiKey: context.environment.OPENROUTER_API_KEY,
-        modelId: context.environment.OPENROUTER_MODEL,
+        modelId: resolveApolloConfiguration(context.environment).models.conversation,
         query: parsedArgs.query,
         currentDateText: formatCurrentDateTimeForPrompt(context.nowMilliseconds),
         sourceList,

--- a/src/turn/__tests__/run.spec.ts
+++ b/src/turn/__tests__/run.spec.ts
@@ -6,7 +6,7 @@ import { addMemoryRecord, type MemorySqlExecutor } from '@/memory/store';
 import { buildToolDefinitionMap } from '@/tools/router';
 import type { ToolDefinition } from '@/tools/types';
 import { runDeskTurn } from '@/turn/run';
-import type { OpenRouterChatMessage } from '@/voice/llm';
+import type { ChatMessage } from '@/voice/chat';
 
 function createInMemorySqlExecutor(): MemorySqlExecutor {
   const memoryRowList: Array<{
@@ -249,7 +249,7 @@ describe('runDeskTurn', () => {
         return { ok: true, summary: 'Arranco a programar en apollo.' };
       },
     };
-    let capturedMessageList: readonly OpenRouterChatMessage[] = [];
+    let capturedMessageList: readonly ChatMessage[] = [];
 
     const output = await runDeskTurn({
       text: 'confirmado',

--- a/src/turn/run.ts
+++ b/src/turn/run.ts
@@ -11,11 +11,8 @@ import type {
   ToolExecutionResult,
 } from '@/tools/types';
 import { mapToolNameToThinkingCaption } from '@/turn/caption';
-import {
-  buildOpenRouterSystemPrompt,
-  buildSemanticMemoryPromptNote,
-  type OpenRouterChatMessage,
-} from '@/voice/llm';
+import type { ChatMessage, ChatToolDefinition } from '@/voice/chat';
+import { buildApolloSystemPrompt, buildSemanticMemoryPromptNote } from '@/voice/llm';
 import { sanitizeTextForSpeech } from '@/voice/sanitize';
 import {
   SPEECH_SEGMENT_MAX_CHARACTER_COUNT,
@@ -27,12 +24,8 @@ const DEFAULT_MAX_TOOL_ROUND_COUNT = 3;
 export type VoiceAdapters = {
   readonly stt: (audioBuffer: ArrayBuffer) => Promise<string>;
   readonly llm: (input: {
-    readonly messageList: readonly OpenRouterChatMessage[];
-    readonly toolDefinitionList: readonly {
-      readonly name: string;
-      readonly description: string;
-      readonly parameters: Record<string, unknown>;
-    }[];
+    readonly messageList: readonly ChatMessage[];
+    readonly toolDefinitionList: readonly ChatToolDefinition[];
     // Optional streaming hook: adapters that support it push content deltas
     // as they arrive so the turn can start synthesizing speech early.
     readonly onTextDelta?: (deltaText: string) => void;
@@ -108,7 +101,7 @@ function buildAssistantToolCallMessage(
     readonly name: string;
     readonly args: unknown;
   }[],
-): OpenRouterChatMessage {
+): ChatMessage {
   return {
     role: 'assistant',
     content: llmText.trim().length > 0 ? llmText : null,
@@ -126,7 +119,7 @@ function buildAssistantToolCallMessage(
 function buildToolResultMessage(
   toolCallId: string,
   toolResult: ToolExecutionResult,
-): OpenRouterChatMessage {
+): ChatMessage {
   return {
     role: 'tool',
     tool_call_id: toolCallId,
@@ -205,7 +198,7 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
   ];
   const systemPromptBase =
     input.systemPromptOverride === undefined
-      ? buildOpenRouterSystemPrompt({
+      ? buildApolloSystemPrompt({
           soulSystemPrompt: buildApolloSoulPrompt(input.speechMode),
           memoryContentList,
           isFocusActive: input.focusState.active,
@@ -224,7 +217,7 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
   };
   const maxToolRoundCount = input.maxToolRoundCount ?? DEFAULT_MAX_TOOL_ROUND_COUNT;
 
-  const messageList: OpenRouterChatMessage[] = [
+  const messageList: ChatMessage[] = [
     { role: 'system', content: systemPrompt },
     { role: 'user', content: userText },
   ];

--- a/src/voice/__tests__/llm.spec.ts
+++ b/src/voice/__tests__/llm.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildOpenRouterSystemPrompt, chatWithOpenRouter } from '@/voice/llm';
+import { buildApolloSystemPrompt, chatWithOpenRouter } from '@/voice/llm';
 
 type CapturedFetchCall = {
   readonly url: string;
@@ -30,9 +30,9 @@ function createCapturingFetchMock(
   };
 }
 
-describe('buildOpenRouterSystemPrompt', () => {
+describe('buildApolloSystemPrompt', () => {
   it('lists memories when present', () => {
-    const prompt = buildOpenRouterSystemPrompt({
+    const prompt = buildApolloSystemPrompt({
       soulSystemPrompt: 'Sos Apollo.',
       memoryContentList: ['toma mate', 'vive en Buenos Aires'],
       isFocusActive: false,
@@ -43,7 +43,7 @@ describe('buildOpenRouterSystemPrompt', () => {
   });
 
   it('notes the absence of memories and an active focus', () => {
-    const prompt = buildOpenRouterSystemPrompt({
+    const prompt = buildApolloSystemPrompt({
       soulSystemPrompt: 'Sos Apollo.',
       memoryContentList: [],
       isFocusActive: true,

--- a/src/voice/chat.ts
+++ b/src/voice/chat.ts
@@ -1,0 +1,40 @@
+// The OpenAI chat-completions wire shape is the lingua franca between the turn
+// loop and every provider transport: keeping messages in that shape end to end
+// lets tool calls round-trip without translation.
+export type ChatMessage =
+  | { readonly role: 'system'; readonly content: string }
+  | { readonly role: 'user'; readonly content: string }
+  | {
+      readonly role: 'assistant';
+      readonly content: string | null;
+      readonly tool_calls?: readonly {
+        readonly id: string;
+        readonly type: 'function';
+        readonly function: {
+          readonly name: string;
+          readonly arguments: string;
+        };
+      }[];
+    }
+  | {
+      readonly role: 'tool';
+      readonly tool_call_id: string;
+      readonly content: string;
+    };
+
+export type ChatToolCall = {
+  readonly id: string;
+  readonly name: string;
+  readonly args: unknown;
+};
+
+export type ChatToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+export type ChatResult = {
+  readonly text: string;
+  readonly toolCallList: readonly ChatToolCall[];
+};

--- a/src/voice/llm.ts
+++ b/src/voice/llm.ts
@@ -1,36 +1,6 @@
 import { z } from 'zod';
 
-export type OpenRouterToolCall = {
-  readonly id: string;
-  readonly name: string;
-  readonly args: unknown;
-};
-
-export type OpenRouterChatMessage =
-  | { readonly role: 'system'; readonly content: string }
-  | { readonly role: 'user'; readonly content: string }
-  | {
-      readonly role: 'assistant';
-      readonly content: string | null;
-      readonly tool_calls?: readonly {
-        readonly id: string;
-        readonly type: 'function';
-        readonly function: {
-          readonly name: string;
-          readonly arguments: string;
-        };
-      }[];
-    }
-  | {
-      readonly role: 'tool';
-      readonly tool_call_id: string;
-      readonly content: string;
-    };
-
-export type OpenRouterChatResult = {
-  readonly text: string;
-  readonly toolCallList: readonly OpenRouterToolCall[];
-};
+import type { ChatMessage, ChatResult, ChatToolDefinition } from '@/voice/chat';
 
 const openRouterChatResponseSchema = z.object({
   choices: z
@@ -55,7 +25,7 @@ const openRouterChatResponseSchema = z.object({
     .min(1),
 });
 
-export function buildOpenRouterSystemPrompt(input: {
+export function buildApolloSystemPrompt(input: {
   readonly soulSystemPrompt: string;
   readonly memoryContentList: readonly string[];
   readonly isFocusActive: boolean;
@@ -121,7 +91,7 @@ const openRouterStreamChunkSchema = z.object({
 async function consumeOpenRouterStream(
   response: Response,
   onTextDelta: (deltaText: string) => void,
-): Promise<OpenRouterChatResult> {
+): Promise<ChatResult> {
   const bodyReader = response.body?.getReader();
   if (bodyReader === undefined) {
     throw new Error('LLM en streaming sin body');
@@ -199,18 +169,14 @@ async function consumeOpenRouterStream(
 export async function chatWithOpenRouter(input: {
   readonly openRouterApiKey: string;
   readonly modelId: string;
-  readonly messageList: readonly OpenRouterChatMessage[];
-  readonly toolDefinitionList?: readonly {
-    readonly name: string;
-    readonly description: string;
-    readonly parameters: Record<string, unknown>;
-  }[];
+  readonly messageList: readonly ChatMessage[];
+  readonly toolDefinitionList?: readonly ChatToolDefinition[];
   // When given, the request streams over SSE and every content delta lands here
   // as it arrives, so the caller can start speaking the first sentence while
   // the model is still writing the rest.
   readonly onTextDelta?: (deltaText: string) => void;
   readonly fetchImplementation?: typeof fetch;
-}): Promise<OpenRouterChatResult> {
+}): Promise<ChatResult> {
   const toolDefinitionPayloadList =
     input.toolDefinitionList !== undefined && input.toolDefinitionList.length > 0
       ? input.toolDefinitionList.map((toolDefinition) => ({

--- a/src/voice/synthesize.ts
+++ b/src/voice/synthesize.ts
@@ -1,3 +1,4 @@
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import { synthesizeSpeechWithElevenLabs } from '@/voice/elevenlabs';
 import { synthesizeSpeechThroughCache } from '@/voice/ttscache';
 
@@ -8,17 +9,18 @@ export async function synthesizeApolloSpeech(input: {
   readonly text: string;
   readonly voiceId: string;
 }): Promise<ArrayBuffer> {
+  const { models } = resolveApolloConfiguration(input.environment);
   return synthesizeSpeechThroughCache({
     mediaBucket: input.environment.MEDIA,
     text: input.text,
     voiceId: input.voiceId,
-    modelId: input.environment.ELEVENLABS_TTS_MODEL,
+    modelId: models.speech,
     synthesize: () =>
       synthesizeSpeechWithElevenLabs({
         text: input.text,
         voiceId: input.voiceId,
         elevenLabsApiKey: input.environment.ELEVENLABS_API_KEY,
-        modelId: input.environment.ELEVENLABS_TTS_MODEL,
+        modelId: models.speech,
       }),
   });
 }

--- a/src/workflows/background.ts
+++ b/src/workflows/background.ts
@@ -5,6 +5,7 @@ import {
 } from 'cloudflare:workers';
 import { getAgentByName } from 'agents';
 
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import { sendEmailWithResend } from '@/notifications/email';
 import { runDeepResearchWithPerplexity } from '@/search/deepresearch';
 import { buildResearchDocumentObjectKey } from '@/search/keys';
@@ -29,7 +30,7 @@ export class ApolloBackground extends WorkflowEntrypoint<Env, ApolloBackgroundPa
       async () =>
         runDeepResearchWithPerplexity({
           openRouterApiKey: this.env.OPENROUTER_API_KEY,
-          modelId: this.env.OPENROUTER_RESEARCH_MODEL,
+          modelId: resolveApolloConfiguration(this.env).models.research,
           prompt: event.payload.prompt,
           nowMilliseconds: Date.now(),
         }),
@@ -94,7 +95,7 @@ export class ApolloBackground extends WorkflowEntrypoint<Env, ApolloBackgroundPa
       async () =>
         synthesizeResearchSpokenSummary({
           openRouterApiKey: this.env.OPENROUTER_API_KEY,
-          modelId: this.env.OPENROUTER_MODEL,
+          modelId: resolveApolloConfiguration(this.env).models.conversation,
           prompt: event.payload.prompt,
           reportMarkdown,
         }),

--- a/src/workflows/coding.ts
+++ b/src/workflows/coding.ts
@@ -8,7 +8,8 @@ import { getAgentByName } from 'agents';
 import { runCodingAgent } from '@/coding/agent';
 import { buildCodingBranchName } from '@/coding/git';
 import { runOpencodeAgent } from '@/coding/opencode';
-import { mintCodingProxyToken } from '@/coding/proxy';
+import { mintCodingProxyToken, resolveCodingProxySigningSecret } from '@/coding/proxy';
+import { resolveApolloConfiguration } from '@/configuration/resolve';
 import {
   buildCodingDocumentObjectKey,
   buildCodingPublishSandboxId,
@@ -107,16 +108,17 @@ export class ApolloCoding extends WorkflowEntrypoint<Env, ApolloCodingParams> {
           // stays as the fallback while the proxy origin is unset, and as an
           // escape hatch behind CODING_ENGINE=legacy.
           const proxyOrigin = this.env.CODING_PROXY_ORIGIN;
+          const codingModelId = resolveApolloConfiguration(this.env).models.coding;
           if (this.env.CODING_ENGINE !== 'legacy' && proxyOrigin !== undefined) {
             return runOpencodeAgent({
               sandbox,
               proxyOrigin,
               proxyToken: await mintCodingProxyToken({
                 instanceId: event.instanceId,
-                openRouterApiKey: this.env.OPENROUTER_API_KEY,
+                signingSecret: resolveCodingProxySigningSecret(this.env),
                 nowMilliseconds: Date.now(),
               }),
-              modelId: this.env.OPENROUTER_CODING_MODEL,
+              modelId: codingModelId,
               taskText: event.payload.task,
             });
           }
@@ -125,7 +127,7 @@ export class ApolloCoding extends WorkflowEntrypoint<Env, ApolloCodingParams> {
             callLlm: async ({ messageList, toolDefinitionList }) =>
               chatWithOpenRouter({
                 openRouterApiKey: this.env.OPENROUTER_API_KEY,
-                modelId: this.env.OPENROUTER_CODING_MODEL,
+                modelId: codingModelId,
                 messageList,
                 toolDefinitionList,
               }),

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,14 +8,6 @@
     "enabled": true,
     "head_sampling_rate": 1,
   },
-  "vars": {
-    "OPENROUTER_MODEL": "deepseek/deepseek-v4-flash-0731",
-    "OPENROUTER_STT_MODEL": "openai/whisper-large-v3",
-    "OPENROUTER_RESEARCH_MODEL": "perplexity/sonar-deep-research",
-    "OPENROUTER_CODING_MODEL": "moonshotai/kimi-k3",
-    "ELEVENLABS_TTS_MODEL": "eleven_multilingual_v2",
-    "OPENROUTER_EMBEDDING_MODEL": "openai/text-embedding-3-small",
-  },
   "containers": [
     {
       "class_name": "Sandbox",


### PR DESCRIPTION
Phase 1 of the platform plan, stacked on #24. Three moves that everything later (provider abstraction, setup wizard) sits on:

**Central configuration resolver.** `resolveApolloConfiguration(env)` (`src/configuration/resolve.ts`) is now the single seam deployment config flows through: model ids default in code (`src/configuration/models.ts`), plain env values override per deployment, empty/unset falls back. All twelve scattered model-id reads across ten files route through it. The wizard-managed runtime override layer lands on this same seam in a later phase.

**No more wrangler vars.** The literal-type trap — every var frozen into a literal type whose exact value must be committed in the test fixture — is gone because the `vars` block is gone. CI already regenerates worker types before typechecking, so this is CI-safe.

**Provider-neutral chat types.** `ChatMessage`/`ChatResult`/`ChatToolCall`/`ChatToolDefinition` move to `src/voice/chat.ts`; the OpenAI wire shape stays the lingua franca, but no longer named after one vendor. `chatWithOpenRouter` keeps its name — it *is* the OpenRouter transport; the neutral facade arrives with the provider abstraction in phase 2.

**Bonus hardening:** sandbox proxy tokens can be signed by a dedicated `CODING_PROXY_SECRET` instead of the OpenRouter key itself, so rotating the provider key no longer revokes every sandbox token in flight. Unset, it falls back to the provider key — nothing breaks.

No behavior changes for a deployment that sets nothing: every default equals the old var value.

Verified: `tsc`, `oxlint`, `oxfmt`, 342/342 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hu5LZnYJ5CoRhdmMJxP9NU

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes model configuration behind code defaults with optional environment overrides, extracts provider-neutral chat types, and introduces an optional dedicated coding-proxy signing secret.
- Routes model selection through `resolveApolloConfiguration`.
- Removes model defaults from Wrangler vars while preserving existing defaults in code.
- Moves shared chat wire types into `src/voice/chat.ts`.
- Allows sandbox proxy tokens to use `CODING_PROXY_SECRET`.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking import-order issue in src/turn/run.ts.

The configuration migration and chat-type extraction preserve existing runtime behavior, and the only accepted issue is a repository import-order convention violation.

**Files Needing Attention:** src/turn/run.ts
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fturn%2Frun.ts%3A14-15%0A**Order%20local%20imports%20consistently**%0A%0AThe%20type-only%20%60%40%2Fvoice%2Fchat%60%20import%20precedes%20the%20value%20import%20from%20%60%40%2Fvoice%2Fllm%60%2C%20contrary%20to%20the%20repository's%20stable%20import%20ordering%20convention%20and%20creating%20avoidable%20formatting%20and%20review%20churn.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20buildApolloSystemPrompt%2C%20buildSemanticMemoryPromptNote%20%7D%20from%20'%40%2Fvoice%2Fllm'%3B%0Aimport%20type%20%7B%20ChatMessage%2C%20ChatToolDefinition%20%7D%20from%20'%40%2Fvoice%2Fchat'%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=galfrevn%2Fapollo&pr=25&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(configuration): resolve models from..."](https://github.com/galfrevn/apollo/commit/13bcf4e52c5953cc2751620801b5e3a43b7ee9e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52342944)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Import grouping and sorting for TypeScript modules... ([source](https://github.com/galfrevn/apollo/blob/main/.cursor/rules/imports.mdc))

<!-- /greptile_comment -->