### PR TITLE
feat: initiative engine, push OTA with spoken changelog, owner memory consolidation

### DIFF
--- a/documentation/capabilities/memory.md
+++ b/documentation/capabilities/memory.md
@@ -28,6 +28,27 @@ embedding calls; keyword recall from the SQL store still works.
 `memories`, `session_prefs`, `pending_device_messages`, and `list_items` (see
 [Lists](lists.md)) are created in `onStart` (`src/agents/apollo.ts`).
 
+## Consolidación nocturna (owner memory)
+
+A cron on the DO scheduler (`'0 6 * * *'` UTC = 03:00 Buenos Aires, registered in
+`onStart`) runs `consolidateOwnerMemory`: it reads a byte-budgeted tail of the
+transcript (`session.getRecentHistory`, 48 KB), asks the conversation model to
+extract, reinforce, and retire facts about the owner (`src/memory/consolidate.ts`,
+strict-JSON with one corrective retry), merges them (dedupe by content, 60-day decay
+for unconfirmed facts, capped at 50 evicting the weakest first), and **rewrites** the
+`memory` context block — which until this feature only ever grew by appends from
+`remember_fact`.
+
+Ownership split: the consolidated block governs what occupies prompt budget; the
+`memories` table + Vectorize stay append-only as the provenance log `recall_memory`
+searches — decayed facts are not deleted from them. Genuinely new facts flow into
+both. State (fact list, last run, last processed leaf) lives in `session_prefs`
+under `ownerMemoryState`; an idle day (unchanged leaf) skips the LLM call, and
+`MOCK_VOICE=1` skips the run entirely.
+
+"¿Qué aprendiste de mí?" needs no tool: the block sits in the system prompt and the
+persona instructs Apollo to answer from it in first person (`src/persona/soul.ts`).
+
 ## Preferences
 
 Small durable preferences (default weather location, speech mode) go through the store, not the vector index.

--- a/documentation/operations/deploy.md
+++ b/documentation/operations/deploy.md
@@ -53,7 +53,8 @@ The `Sandbox` container image is built by the Docker CLI as part of every deploy
 
 The device self-updates from the `MEDIA` bucket (see [Protocol](../runtime/protocol.md#ota-endpoints)). Layout:
 
-- `firmware/latest.json` — `{ "version": "2.5.0", "key": "firmware/apollo-2.5.0.bin" }`
+- `firmware/latest.json` — `{ "version": "2.5.0", "key": "firmware/apollo-2.5.0.bin" }`, plus an
+  optional `"changelog"` field (≤500 chars)
 - `firmware/apollo-<version>.bin` — the app image
 
 Rules that keep devices alive:
@@ -74,8 +75,18 @@ bunx wrangler r2 object put apollo-media/firmware/latest.json \
   --file latest.json --content-type application/json --remote
 ```
 
-The device checks at boot only, so a running device picks the update up on its next
-power cycle. Smoke-test after publishing:
+The device checks at boot, and the worker also **pushes** updates: when telemetry reports
+a version older than the manifest and the device is idle and powered (charging or ≥50%
+battery), the server calls `self.upgrade_firmware` over the MCP bridge (`src/ota/push.ts`,
+capped at 3 attempts per version, 6 h apart — a device that rolls back stops being
+retried until the next release). After the reboot, Apollo announces the update out loud.
+
+**Changelog authoring**: when bumping `PROJECT_VER`, also write `changelog/<version>.md`
+in the firmware repo — one short Spanish sentence, spoken verbatim by Apollo after the
+update ("ahora la cuenta regresiva se ve en el aro"). `publish.yml` embeds it into
+`latest.json`; without the file, Apollo falls back to a generic announcement.
+
+Smoke-test after publishing:
 `curl -s "https://<worker>/ota/check?token=$TOKEN"` should answer with the new version,
 and `curl -sI "https://<worker>/ota/firmware.bin?token=$TOKEN"` with a 200 and the
 binary's exact `Content-Length`.

--- a/documentation/reference/roadmap.md
+++ b/documentation/reference/roadmap.md
@@ -79,7 +79,7 @@ Came for free through the MCP bridge, as predicted: `set_volume` is one of the t
 
 The full loop is live: the worker serves `/ota/check` and `/ota/firmware.bin` from the `MEDIA` bucket (`src/ota/`, token-authenticated, versions strictly `digits.and.dots`), every push to the firmware `main` builds and publishes to R2 (`publish.yml`, `PROJECT_VER` bump as the trigger), and the device checks off the boot path and self-updates through `esp_ota` with rollback protection. The 2.6.0 fleet arrived this way — cable flashing is over. Publishing steps live in [Deploy](../operations/deploy.md#publishing-firmware-ota).
 
-Still open: **push-style updates**. Telemetry reports `firmwareVersion`, but the server never compares it against the R2 manifest nor calls `self.upgrade_firmware` over the item-5 bridge — a device that never reboots never updates.
+Push-style updates closed 2026-08-11 through item 23: the server now compares telemetry's `firmwareVersion` against the R2 manifest and calls `self.upgrade_firmware` over the item-5 bridge when the device is idle and powered.
 
 ### 15. `tts_end` + playback acks — ✅ implemented 2026-08-11, ships with firmware 2.7.0
 
@@ -94,13 +94,13 @@ Beyond face + caption: a circular timer countdown (which merges with item 6), we
 
 Guiding principle: Apollo grows with its owner — it originates actions instead of only reacting, and it accumulates a model of the person it lives with. Every item in this section is **server-only**: the firmware already has all the vocabulary these need (notifications, telemetry, MCP, confirmations, session flow), so each one deploys on a push to `main`.
 
-### 17. Initiative engine
+### 17. Initiative engine — ✅ implemented 2026-08-11
 
-The substrate for everything below: a server-side policy that lets Apollo decide to speak unprompted. The delivery half already exists — `deliverDeskDeviceNotification` (`src/agents/notify.ts`) paces TTS, queues pending messages when nobody is connected, and stays quiet during focus. What is missing is origination: nothing in the worker ever *decides* Apollo has something worth saying. Needs a policy layer with hard bounds so it never becomes annoying — quiet hours, focus awareness (already respected downstream), and a daily budget of self-initiated utterances. Items 20–23 all deliver through this.
+The substrate for everything below: a server-side policy that lets Apollo decide to speak unprompted. `evaluateInitiativeCandidate` (`src/initiative/logic.ts`) decides deliver/defer/suppress per candidate: quiet hours (22:00–09:00 Buenos Aires) defer to morning via the DO scheduler, active focus defers past the window, a daily budget of 6 and a per-source hourly cooldown suppress, `critical` bypasses everything, and an offline device suppresses outright (a queued card is never spoken). Budget and cooldowns live in `session_prefs` (`initiativeState`), recorded only after delivery succeeds. Every source funnels through `#deliverInitiativeUtterance` (`src/agents/apollo.ts`); low battery was the first adopter (behavior unchanged), the item-23 changelog the second. Items 20–22 plug into the same seam.
 
-### 18. Long-term owner memory
+### 18. Long-term owner memory — ✅ implemented 2026-08-11
 
-A persistent store of facts and preferences about the owner, consolidated by a nightly job on the existing reminder cron and stamped into the system prompt while relevant — the same pattern telemetry established (snapshot in `session_prefs`, re-read at turn start, owned first-person by the persona). Extraction runs over recent transcripts; consolidation merges, decays, and drops stale facts. "¿Qué aprendiste de mí?" should get a real answer.
+Rather than a parallel store, the nightly job took ownership of the session's `memory` context block, which until now only grew by appends. `consolidateOwnerMemory` (cron `0 6 * * *` UTC = 03:00 local) reads a 48 KB tail of the transcript, extracts/reinforces/retires facts with a strict-JSON LLM call (`src/memory/consolidate.ts`, one corrective retry), merges with 60-day decay and a 50-fact cap, and rewrites the block grouped by category. The `memories` table + Vectorize stay as the append-only provenance log for `recall_memory`; genuinely new facts land in both. Idle days skip the LLM call. "¿Qué aprendiste de mí?" is answered from the block in first person — no new tool. See [Memory](../capabilities/memory.md#consolidación-nocturna-owner-memory).
 
 ### 19. Owner routine model
 
@@ -118,9 +118,9 @@ The reminder scheduler is user-only today — every entry comes from an explicit
 
 The coding engine already resolves the owner's repositories from the GitHub App installations (`list_coding_repositories`, `src/coding/`). Watch them: poll on a cron (or take webhooks into the worker), and when CI goes red or a review is requested, announce it through the initiative engine and offer to act — "se rompió el build de apollo, ¿lo miro?". Acceptance flows through the full-screen Sí/No confirmation, which already replays the approval into the next LLM turn, and launches the opencode engine (item under "Shipped": coding on opencode). Turns the coding stack from on-demand into a standing watch.
 
-### 23. Self-maintaining device
+### 23. Self-maintaining device — ✅ implemented 2026-08-11
 
-Close the open half of item 14 and give it personality. The server compares telemetry's `firmwareVersion` against the R2 manifest and, when the device is idle and preferably charging, calls `self.upgrade_firmware` over the item-5 MCP bridge — no more devices stranded on old firmware because they never reboot. Then the payoff: `publish.yml` stores a short changelog next to the manifest at build time, and when the post-reboot telemetry reports the new version, Apollo tells the owner what changed — "me actualicé anoche: ahora la cuenta regresiva se ve en el aro". Self-maintenance becomes a visible part of the relationship instead of silent plumbing.
+Closed the open half of item 14 and gave it personality. Every telemetry tick (manifest read throttled to 15 min, bypassed on a charging edge) compares the reported version against the R2 manifest with the device's own compare rules (`src/ota/push.ts`) and, in the safe window — idle or dashboard, no confirm pending, no announcement in flight, focus off, charging or ≥50% battery — calls `self.upgrade_firmware` with a URL built from the origin captured at connect time. Attempts are capped at 3 per manifest version, 6 h apart, recorded before the call, so a rolled-back device is never hammered. The post-reboot version edge queues the spoken changelog (`changelog/<version>.md` in the firmware repo, embedded into `latest.json` by `publish.yml`), delivered through item 17 — a 3 AM upgrade announces itself after 9. `FIRMWARE_PUSH_DISABLED=1` is the kill switch; publishing steps in [Deploy](../operations/deploy.md#publishing-firmware-ota).
 
 ## Under consideration (ideas, no commitment)
 

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -35,7 +35,9 @@ import {
   type DeskFocusState,
 } from '@/focus/logic';
 import {
+  buildInitiativeDeliveryMarkerKey,
   evaluateInitiativeCandidate,
+  hasScheduledInitiativeRetryForSource,
   INITIATIVE_MAX_RETRY_ATTEMPTS,
   INITIATIVE_SUPPRESSED_RETRY_DELAY_SECONDS,
   parseStoredInitiativeState,
@@ -547,6 +549,7 @@ export class Apollo extends Agent<Env, ApolloState> {
         priority: input.priority,
         message: input.message,
         ...(input.earconName !== undefined ? { earconName: input.earconName } : {}),
+        ...(input.utteranceKey !== undefined ? { utteranceKey: input.utteranceKey } : {}),
         deferCount,
       });
       return 'deferred';
@@ -584,6 +587,13 @@ export class Apollo extends Agent<Env, ApolloState> {
           ),
         ),
       );
+      if (input.utteranceKey !== undefined) {
+        await setSessionPreference(
+          this.#sqlExecutor(),
+          buildInitiativeDeliveryMarkerKey(input.utteranceKey),
+          String(nowMilliseconds),
+        );
+      }
     } finally {
       this.#isDeliveringInitiative = false;
     }
@@ -599,6 +609,9 @@ export class Apollo extends Agent<Env, ApolloState> {
       message: parsedPayload.message,
       ...(parsedPayload.earconName !== undefined
         ? { earconName: parsedPayload.earconName }
+        : {}),
+      ...(parsedPayload.utteranceKey !== undefined
+        ? { utteranceKey: parsedPayload.utteranceKey }
         : {}),
     };
     const deliveryOutcome = await this.#deliverInitiativeUtterance({
@@ -855,6 +868,8 @@ export class Apollo extends Agent<Env, ApolloState> {
           nowMilliseconds: Date.now(),
           deliverInitiativeUtterance: (utterance) =>
             this.#deliverInitiativeUtterance(utterance),
+          hasScheduledInitiativeRetry: async (source) =>
+            hasScheduledInitiativeRetryForSource(await this.listSchedules(), source),
           callDeviceTool: (deviceToolName, argumentRecord) =>
             this.#callDeviceTool(deviceToolName, argumentRecord),
         },

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -1,4 +1,10 @@
-import { Agent, callable, type Connection, type WSMessage } from 'agents';
+import {
+  Agent,
+  callable,
+  type Connection,
+  type ConnectionContext,
+  type WSMessage,
+} from 'agents';
 import type { Session } from 'agents/experimental/memory/session';
 
 import {
@@ -42,6 +48,17 @@ import {
   summarizeDeviceToolResult,
 } from '@/mcp/bridge';
 import { deletePendingDeviceMessage, listPendingDeviceMessages } from '@/memory/pending';
+import { readFirmwareManifest } from '@/ota/manifest';
+import {
+  buildFirmwareChangelogMessage,
+  detectFirmwareVersionChange,
+  evaluateFirmwarePush,
+  parseStoredFirmwareChangelogState,
+  parseStoredFirmwarePushState,
+  recordFirmwareManifestCheck,
+  recordFirmwarePushAttempt,
+  shouldCheckFirmwareManifest,
+} from '@/ota/push';
 import { createApolloSession } from '@/memory/session';
 import {
   getSessionPreference,
@@ -90,6 +107,9 @@ const MINIMUM_TURN_AUDIO_BYTE_LENGTH = 8000;
 const LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY = 'lowBatteryLastAnnounceAt';
 const TELEMETRY_SNAPSHOT_PREFERENCE_KEY = 'lastTelemetrySnapshot';
 const INITIATIVE_STATE_PREFERENCE_KEY = 'initiativeState';
+const FIRMWARE_PUSH_STATE_PREFERENCE_KEY = 'firmwarePushState';
+const FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY = 'firmwareChangelogState';
+const PUBLIC_ORIGIN_PREFERENCE_KEY = 'publicOrigin';
 
 function mapUnknownScheduleListToAgentScheduleLikeList(
   scheduleList: readonly {
@@ -255,8 +275,26 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
   }
 
-  async onConnect(connection: Connection): Promise<void> {
+  async onConnect(
+    connection: Connection,
+    connectionContext: ConnectionContext,
+  ): Promise<void> {
     await this.#ensurePreferencesLoaded();
+    // The DO has no ambient request origin, and the OTA push must hand the
+    // device a URL it can reach — the connection that just arrived proves this
+    // origin works, so it is captured here instead of configured.
+    const publicOrigin = new URL(connectionContext.request.url).origin;
+    const storedPublicOrigin = await getSessionPreference(
+      this.#sqlExecutor(),
+      PUBLIC_ORIGIN_PREFERENCE_KEY,
+    );
+    if (storedPublicOrigin !== publicOrigin) {
+      await setSessionPreference(
+        this.#sqlExecutor(),
+        PUBLIC_ORIGIN_PREFERENCE_KEY,
+        publicOrigin,
+      );
+    }
     // A caption describes the turn that produced it, not the session. Left in
     // durable state, a failure message greets the user on every reconnect long
     // after the turn that failed.
@@ -738,6 +776,24 @@ export class Apollo extends Agent<Env, ApolloState> {
         : {}),
       receivedAtMs: Date.now(),
     };
+    // The previous snapshot is read before the overwrite because the firmware
+    // lifecycle diffs versions across it — and after a deploy or hibernation
+    // the in-memory copy is gone, which is exactly the post-OTA-reboot case,
+    // so the stored copy is the fallback.
+    let previousSnapshot = this.#lastTelemetrySnapshot;
+    if (previousSnapshot === undefined) {
+      const storedSnapshot = await getSessionPreference(
+        this.#sqlExecutor(),
+        TELEMETRY_SNAPSHOT_PREFERENCE_KEY,
+      );
+      if (storedSnapshot !== null) {
+        previousSnapshot = parseStoredTelemetrySnapshot(storedSnapshot);
+      }
+    }
+    const didChargingEdgeOccur =
+      previousSnapshot?.charging !== undefined &&
+      snapshot.charging !== undefined &&
+      previousSnapshot.charging !== snapshot.charging;
     this.#lastTelemetrySnapshot = snapshot;
     // A deploy or hibernation wipes the in-memory snapshot, and the next turn
     // may run before the device's next telemetry tick — the prompt would then
@@ -748,6 +804,26 @@ export class Apollo extends Agent<Env, ApolloState> {
       JSON.stringify(snapshot),
     );
 
+    await this.#handleLowBatteryAnnouncement(snapshot);
+    try {
+      await this.#handleFirmwareLifecycle({
+        previousFirmwareVersion: previousSnapshot?.firmwareVersion,
+        snapshot,
+        didChargingEdgeOccur,
+      });
+    } catch (error) {
+      // OTA plumbing must never take telemetry handling down with it.
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: 'firmware_lifecycle_failed',
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+  }
+
+  async #handleLowBatteryAnnouncement(snapshot: DeskTelemetrySnapshot): Promise<void> {
     const storedAnnounceAt = await getSessionPreference(
       this.#sqlExecutor(),
       LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
@@ -797,6 +873,180 @@ export class Apollo extends Agent<Env, ApolloState> {
     } finally {
       this.#isAnnouncingLowBattery = false;
     }
+  }
+
+  // Roadmap item 23: after a reboot the first telemetry reports the new
+  // version (the changelog edge), and every telemetry tick is a chance to
+  // push a pending update when the device is idle and powered.
+  async #handleFirmwareLifecycle(input: {
+    readonly previousFirmwareVersion: string | undefined;
+    readonly snapshot: DeskTelemetrySnapshot;
+    readonly didChargingEdgeOccur: boolean;
+  }): Promise<void> {
+    const nowMilliseconds = Date.now();
+    const sqlExecutor = this.#sqlExecutor();
+
+    const storedChangelogState = await getSessionPreference(
+      sqlExecutor,
+      FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+    );
+    let changelogState =
+      storedChangelogState === null
+        ? undefined
+        : parseStoredFirmwareChangelogState(storedChangelogState);
+
+    const versionChange = detectFirmwareVersionChange({
+      previousFirmwareVersion: input.previousFirmwareVersion,
+      nextFirmwareVersion: input.snapshot.firmwareVersion,
+    });
+    if (versionChange !== undefined) {
+      changelogState = { ...changelogState, pendingVersion: versionChange.toVersion };
+      await setSessionPreference(
+        sqlExecutor,
+        FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+        JSON.stringify(changelogState),
+      );
+      // The device came back on the new version: the attempt marker did its
+      // job and must not throttle the next release.
+      await setSessionPreference(
+        sqlExecutor,
+        FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+        JSON.stringify(recordFirmwareManifestCheck(undefined, nowMilliseconds)),
+      );
+      console.log(
+        JSON.stringify({
+          level: 'info',
+          message: 'firmware_changelog_pending',
+          fromVersion: versionChange.fromVersion,
+          toVersion: versionChange.toVersion,
+        }),
+      );
+    }
+
+    if (
+      changelogState?.pendingVersion !== undefined &&
+      changelogState.pendingVersion !== changelogState.announcedVersion
+    ) {
+      const manifest = await readFirmwareManifest(this.env.MEDIA);
+      const changelogText =
+        manifest !== undefined && manifest.version === changelogState.pendingVersion
+          ? manifest.changelog
+          : undefined;
+      const deliveryOutcome = await this.#deliverInitiativeUtterance({
+        source: 'firmware_changelog',
+        priority: 'normal',
+        message: buildFirmwareChangelogMessage({
+          toVersion: changelogState.pendingVersion,
+          ...(changelogText !== undefined ? { changelogText } : {}),
+        }),
+        earconName: 'chime',
+      });
+      // A deferred utterance carries its message in the schedule payload, so
+      // it counts as announced here — otherwise the next telemetry tick would
+      // schedule a duplicate. Only a suppression leaves it pending for retry.
+      if (deliveryOutcome !== 'suppressed') {
+        changelogState = { announcedVersion: changelogState.pendingVersion };
+        await setSessionPreference(
+          sqlExecutor,
+          FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+          JSON.stringify(changelogState),
+        );
+      }
+    }
+
+    if (this.env.FIRMWARE_PUSH_DISABLED === '1') {
+      return;
+    }
+    const storedPushState = await getSessionPreference(
+      sqlExecutor,
+      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+    );
+    const pushState =
+      storedPushState === null
+        ? undefined
+        : parseStoredFirmwarePushState(storedPushState);
+    if (
+      !shouldCheckFirmwareManifest({
+        pushState,
+        didChargingEdgeOccur: input.didChargingEdgeOccur,
+        nowMilliseconds,
+      })
+    ) {
+      return;
+    }
+    const manifest = await readFirmwareManifest(this.env.MEDIA);
+    const checkedPushState = recordFirmwareManifestCheck(pushState, nowMilliseconds);
+    await setSessionPreference(
+      sqlExecutor,
+      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+      JSON.stringify(checkedPushState),
+    );
+    if (manifest === undefined) {
+      return;
+    }
+    const evaluation = evaluateFirmwarePush({
+      snapshot: input.snapshot,
+      manifestVersion: manifest.version,
+      uiState: this.state.uiState,
+      isFocusActive: this.#currentFocusState().active,
+      hasPendingConfirmation: this.state.pendingConfirmId !== null,
+      isAnnouncementInFlight:
+        this.#isAnnouncingLowBattery || this.#isDeliveringInitiative,
+      pushState: checkedPushState,
+      nowMilliseconds,
+    });
+    if (!evaluation.shouldPush) {
+      if (evaluation.reason !== 'already_current') {
+        console.log(
+          JSON.stringify({
+            level: 'info',
+            message: 'firmware_push_skipped',
+            reason: evaluation.reason,
+          }),
+        );
+      }
+      return;
+    }
+    const publicOrigin = await getSessionPreference(
+      sqlExecutor,
+      PUBLIC_ORIGIN_PREFERENCE_KEY,
+    );
+    if (publicOrigin === null) {
+      console.error(
+        JSON.stringify({ level: 'error', message: 'firmware_push_missing_origin' }),
+      );
+      return;
+    }
+    const firmwareBinaryUrl = new URL('/ota/firmware.bin', publicOrigin);
+    firmwareBinaryUrl.searchParams.set('token', this.env.DEVICE_SHARED_SECRET);
+    // Recorded before the call: a crash mid-push must read as an attempt, or
+    // the device could be flashed in a loop.
+    await setSessionPreference(
+      sqlExecutor,
+      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+      JSON.stringify(
+        recordFirmwarePushAttempt(checkedPushState, manifest.version, nowMilliseconds),
+      ),
+    );
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        message: 'firmware_push_attempted',
+        manifestVersion: manifest.version,
+        deviceVersion: input.snapshot.firmwareVersion,
+      }),
+    );
+    const pushResult = await this.#callDeviceTool('self.upgrade_firmware', {
+      url: firmwareBinaryUrl.toString(),
+    });
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        message: 'firmware_push_result',
+        ok: pushResult.ok,
+        summary: pushResult.summary,
+      }),
+    );
   }
 
   async #callDeviceTool(

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -17,6 +17,7 @@ import {
   deliverReminderPayloadSchema,
   expireConfirmPayloadSchema,
   notifyBackgroundResultInputSchema,
+  retryInitiativeUtterancePayloadSchema,
 } from '@/agents/rpc';
 import { concatenateArrayBufferList, executeApolloTurn } from '@/agents/runtime';
 import { isDeviceSharedSecretValid, readDeviceTokenFromRequestUrl } from '@/auth/token';
@@ -27,6 +28,13 @@ import {
   tickDeskFocus,
   type DeskFocusState,
 } from '@/focus/logic';
+import {
+  evaluateInitiativeCandidate,
+  parseStoredInitiativeState,
+  recordInitiativeDelivery,
+  type InitiativePriority,
+  type InitiativeSource,
+} from '@/initiative/logic';
 import {
   buildDeviceToolCallPayload,
   createDeviceMcpRequestRegistry,
@@ -81,6 +89,7 @@ const MINIMUM_TURN_AUDIO_BYTE_LENGTH = 8000;
 
 const LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY = 'lowBatteryLastAnnounceAt';
 const TELEMETRY_SNAPSHOT_PREFERENCE_KEY = 'lastTelemetrySnapshot';
+const INITIATIVE_STATE_PREFERENCE_KEY = 'initiativeState';
 
 function mapUnknownScheduleListToAgentScheduleLikeList(
   scheduleList: readonly {
@@ -143,6 +152,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #lastKnownWeatherSnapshot: DeskWeatherSnapshot | undefined;
   #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
   #isAnnouncingLowBattery = false;
+  #isDeliveringInitiative = false;
   #deviceMcpRequestRegistry = createDeviceMcpRequestRegistry();
   #ttsSequence = 0;
   #lastPlaybackAck: {
@@ -462,6 +472,110 @@ export class Apollo extends Agent<Env, ApolloState> {
     });
   }
 
+  // The single chokepoint for self-initiated speech (roadmap item 17): every
+  // source of proactive utterances goes through the initiative policy so quiet
+  // hours, focus, and the daily budget are enforced in exactly one place.
+  async #deliverInitiativeUtterance(input: {
+    readonly source: InitiativeSource;
+    readonly priority: InitiativePriority;
+    readonly message: string;
+    readonly earconName?: DeskSoundEffectName;
+    readonly deferCount?: number;
+  }): Promise<'delivered' | 'suppressed' | 'deferred'> {
+    const nowMilliseconds = Date.now();
+    const storedInitiativeState = await getSessionPreference(
+      this.#sqlExecutor(),
+      INITIATIVE_STATE_PREFERENCE_KEY,
+    );
+    const initiativeState =
+      storedInitiativeState === null
+        ? undefined
+        : parseStoredInitiativeState(storedInitiativeState);
+    const deferCount = input.deferCount ?? 0;
+    const decision = evaluateInitiativeCandidate({
+      source: input.source,
+      priority: input.priority,
+      state: initiativeState,
+      nowMilliseconds,
+      focusEndsAtMilliseconds: this.state.focusEndsAt,
+      connectionCount: [...this.getConnections()].length,
+      deferCount,
+    });
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        message: 'initiative_decision',
+        source: input.source,
+        action: decision.action,
+        ...(decision.action !== 'deliver' ? { reason: decision.reason } : {}),
+      }),
+    );
+    if (decision.action === 'defer') {
+      const retryDelaySeconds = Math.max(
+        60,
+        Math.ceil((decision.retryAtMilliseconds - nowMilliseconds) / 1000),
+      );
+      await this.schedule(retryDelaySeconds, 'retryInitiativeUtterance', {
+        source: input.source,
+        priority: input.priority,
+        message: input.message,
+        ...(input.earconName !== undefined ? { earconName: input.earconName } : {}),
+        deferCount,
+      });
+      return 'deferred';
+    }
+    if (decision.action === 'suppress' || this.#isDeliveringInitiative) {
+      return 'suppressed';
+    }
+    this.#isDeliveringInitiative = true;
+    try {
+      if (input.earconName !== undefined) {
+        this.#broadcastPlayEffect(input.earconName);
+      }
+      await deliverDeskDeviceNotification({
+        notification: { type: 'reminder', message: input.message },
+        connectionList: [...this.getConnections()],
+        sqlExecutor: this.#sqlExecutor(),
+        focusState: this.#currentFocusState(),
+        environment: this.env,
+        deviceId: this.name ?? 'default',
+        ttsVoiceId: APOLLO_TTS_VOICE,
+        isMockVoice: this.env.MOCK_VOICE === '1',
+        ...(input.priority === 'critical' ? { announceKind: 'critical' as const } : {}),
+      });
+      // Recorded only after delivery succeeds, so a failed delivery neither
+      // consumes budget nor starts the source cooldown.
+      await setSessionPreference(
+        this.#sqlExecutor(),
+        INITIATIVE_STATE_PREFERENCE_KEY,
+        JSON.stringify(
+          recordInitiativeDelivery(
+            initiativeState,
+            input.source,
+            input.priority,
+            nowMilliseconds,
+          ),
+        ),
+      );
+    } finally {
+      this.#isDeliveringInitiative = false;
+    }
+    return 'delivered';
+  }
+
+  async retryInitiativeUtterance(payload: unknown): Promise<void> {
+    const parsedPayload = retryInitiativeUtterancePayloadSchema.parse(payload);
+    await this.#deliverInitiativeUtterance({
+      source: parsedPayload.source,
+      priority: parsedPayload.priority,
+      message: parsedPayload.message,
+      ...(parsedPayload.earconName !== undefined
+        ? { earconName: parsedPayload.earconName }
+        : {}),
+      deferCount: parsedPayload.deferCount + 1,
+    });
+  }
+
   #currentFocusState(): DeskFocusState {
     if (this.state.focusEndsAt === null) {
       return createInactiveDeskFocusState();
@@ -667,23 +781,19 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
     this.#isAnnouncingLowBattery = true;
     try {
-      this.#broadcastPlayEffect('low_battery');
-      await deliverDeskDeviceNotification({
-        notification: { type: 'reminder', message: evaluation.message },
-        connectionList: [...this.getConnections()],
-        sqlExecutor: this.#sqlExecutor(),
-        focusState: this.#currentFocusState(),
-        environment: this.env,
-        deviceId: this.name ?? 'default',
-        ttsVoiceId: APOLLO_TTS_VOICE,
-        isMockVoice: this.env.MOCK_VOICE === '1',
-        announceKind: 'critical',
+      const deliveryOutcome = await this.#deliverInitiativeUtterance({
+        source: 'low_battery',
+        priority: 'critical',
+        message: evaluation.message,
+        earconName: 'low_battery',
       });
-      await setSessionPreference(
-        this.#sqlExecutor(),
-        LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
-        String(Date.now()),
-      );
+      if (deliveryOutcome === 'delivered') {
+        await setSessionPreference(
+          this.#sqlExecutor(),
+          LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY,
+          String(Date.now()),
+        );
+      }
     } finally {
       this.#isAnnouncingLowBattery = false;
     }

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -47,6 +47,20 @@ import {
   DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS,
   summarizeDeviceToolResult,
 } from '@/mcp/bridge';
+import {
+  buildExtractionRetryMessageList,
+  buildMemoryExtractionMessageList,
+  flattenRecentHistoryToTranscript,
+  mergeOwnerFacts,
+  OWNER_MEMORY_CONSOLIDATION_CRON,
+  OWNER_MEMORY_MIN_RUN_INTERVAL_MS,
+  OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
+  parseMemoryExtractionResult,
+  parseStoredOwnerMemoryState,
+  renderOwnerMemoryBlock,
+  seedOwnerFactsFromMemoryBlock,
+  type OwnerMemoryState,
+} from '@/memory/consolidate';
 import { deletePendingDeviceMessage, listPendingDeviceMessages } from '@/memory/pending';
 import { readFirmwareManifest } from '@/ota/manifest';
 import {
@@ -61,12 +75,14 @@ import {
 } from '@/ota/push';
 import { createApolloSession } from '@/memory/session';
 import {
+  addMemoryRecord,
   getSessionPreference,
   setSessionPreference,
   type MemorySqlExecutor,
 } from '@/memory/store';
 import { cycleDeskSpeechMode, resolveDeskSpeechMode } from '@/persona/catalog';
 import { resolveDeskFaceEmotion } from '@/persona/face';
+import { enqueueMemoryIndexJob } from '@/queues/consume';
 import { APOLLO_TTS_VOICE } from '@/persona/soul';
 import {
   encodeServerToDeviceMessage,
@@ -93,6 +109,7 @@ import {
   savePendingToolConfirmation,
 } from '@/tools/pending';
 import type { PendingToolConfirmation, ToolExecutionResult } from '@/tools/types';
+import { chatWithOpenRouter } from '@/voice/llm';
 import type { DeskWeatherSnapshot } from '@/weather/fetch';
 import {
   resolveDeskWeatherLocationFromPreferences,
@@ -110,6 +127,7 @@ const INITIATIVE_STATE_PREFERENCE_KEY = 'initiativeState';
 const FIRMWARE_PUSH_STATE_PREFERENCE_KEY = 'firmwarePushState';
 const FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY = 'firmwareChangelogState';
 const PUBLIC_ORIGIN_PREFERENCE_KEY = 'publicOrigin';
+const OWNER_MEMORY_STATE_PREFERENCE_KEY = 'ownerMemoryState';
 
 function mapUnknownScheduleListToAgentScheduleLikeList(
   scheduleList: readonly {
@@ -173,6 +191,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
   #isAnnouncingLowBattery = false;
   #isDeliveringInitiative = false;
+  #isConsolidatingMemory = false;
   #deviceMcpRequestRegistry = createDeviceMcpRequestRegistry();
   #ttsSequence = 0;
   #lastPlaybackAck: {
@@ -235,6 +254,7 @@ export class Apollo extends Agent<Env, ApolloState> {
       DESK_DASHBOARD_REFRESH_INTERVAL_SECONDS,
       'refreshDashboardWeather',
     );
+    await this.schedule(OWNER_MEMORY_CONSOLIDATION_CRON, 'consolidateOwnerMemory');
   }
 
   async #resolveWeatherLocation() {
@@ -612,6 +632,135 @@ export class Apollo extends Agent<Env, ApolloState> {
         : {}),
       deferCount: parsedPayload.deferCount + 1,
     });
+  }
+
+  // Roadmap item 18: the nightly cron owns the previously append-only memory
+  // context block — it reads the recent transcript, asks the LLM to extract,
+  // reinforce, and retire owner facts, and rewrites the block consolidated.
+  async consolidateOwnerMemory(): Promise<void> {
+    // Mock mode has no LLM to call; a dev session must not burn tokens.
+    if (this.env.MOCK_VOICE === '1') {
+      return;
+    }
+    if (this.#isConsolidatingMemory) {
+      return;
+    }
+    const nowMilliseconds = Date.now();
+    const sqlExecutor = this.#sqlExecutor();
+    const storedState = await getSessionPreference(
+      sqlExecutor,
+      OWNER_MEMORY_STATE_PREFERENCE_KEY,
+    );
+    const state =
+      storedState === null ? undefined : parseStoredOwnerMemoryState(storedState);
+    if (
+      state !== undefined &&
+      nowMilliseconds - state.lastConsolidatedAtMilliseconds <
+        OWNER_MEMORY_MIN_RUN_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.#isConsolidatingMemory = true;
+    try {
+      const latestLeaf = await this.session.getLatestLeaf();
+      if (latestLeaf === null || latestLeaf.id === state?.lastProcessedLeafId) {
+        // An idle day: nothing new happened, so the run costs zero LLM calls.
+        const idleState: OwnerMemoryState = {
+          factList: state?.factList ?? [],
+          lastConsolidatedAtMilliseconds: nowMilliseconds,
+          ...(state?.lastProcessedLeafId !== undefined
+            ? { lastProcessedLeafId: state.lastProcessedLeafId }
+            : {}),
+        };
+        await setSessionPreference(
+          sqlExecutor,
+          OWNER_MEMORY_STATE_PREFERENCE_KEY,
+          JSON.stringify(idleState),
+        );
+        return;
+      }
+      const recentHistory = await this.session.getRecentHistory(
+        OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
+      );
+      const seededFactList = seedOwnerFactsFromMemoryBlock({
+        blockContent: this.session.getContextBlock('memory')?.content ?? '',
+        knownFactList: state?.factList ?? [],
+        nowMilliseconds,
+        createIdentifier: () => crypto.randomUUID(),
+      });
+      const extractionMessageList = buildMemoryExtractionMessageList({
+        transcriptText: flattenRecentHistoryToTranscript(recentHistory.messages),
+        existingFactList: seededFactList,
+        nowIso: new Date(nowMilliseconds).toISOString(),
+      });
+      const firstChatResult = await chatWithOpenRouter({
+        openRouterApiKey: this.env.OPENROUTER_API_KEY,
+        modelId: this.env.OPENROUTER_MODEL,
+        messageList: extractionMessageList,
+      });
+      let extraction = parseMemoryExtractionResult(firstChatResult.text);
+      if (extraction === undefined) {
+        const retryChatResult = await chatWithOpenRouter({
+          openRouterApiKey: this.env.OPENROUTER_API_KEY,
+          modelId: this.env.OPENROUTER_MODEL,
+          messageList: buildExtractionRetryMessageList(
+            extractionMessageList,
+            firstChatResult.text,
+          ),
+        });
+        extraction = parseMemoryExtractionResult(retryChatResult.text);
+      }
+      if (extraction === undefined) {
+        // State stays untouched so the next night retries over the same window.
+        console.error(
+          JSON.stringify({ level: 'error', message: 'owner_memory_extraction_invalid' }),
+        );
+        return;
+      }
+      const merge = mergeOwnerFacts({
+        existingFactList: seededFactList,
+        extraction,
+        nowMilliseconds,
+        createIdentifier: () => crypto.randomUUID(),
+      });
+      const nextState: OwnerMemoryState = {
+        factList: merge.nextFactList,
+        lastConsolidatedAtMilliseconds: nowMilliseconds,
+        lastProcessedLeafId: latestLeaf.id,
+      };
+      await setSessionPreference(
+        sqlExecutor,
+        OWNER_MEMORY_STATE_PREFERENCE_KEY,
+        JSON.stringify(nextState),
+      );
+      await this.session.replaceContextBlock(
+        'memory',
+        renderOwnerMemoryBlock(merge.nextFactList),
+      );
+      await this.session.refreshSystemPrompt();
+      // Decayed facts stay in the memories table and Vectorize on purpose:
+      // that layer is the provenance log recall_memory searches, while the
+      // consolidated block only governs what occupies prompt budget.
+      for (const genuinelyNewFact of merge.genuinelyNewFactList) {
+        const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
+        await enqueueMemoryIndexJob(this.env, {
+          memoryId: memoryRecord.id,
+          content: genuinelyNewFact.content,
+          deviceId: this.name ?? 'default',
+        });
+      }
+      console.log(
+        JSON.stringify({
+          level: 'info',
+          message: 'owner_memory_consolidated',
+          factCount: merge.nextFactList.length,
+          newFactCount: merge.genuinelyNewFactList.length,
+          transcriptTruncated: recentHistory.truncated,
+        }),
+      );
+    } finally {
+      this.#isConsolidatingMemory = false;
+    }
   }
 
   #currentFocusState(): DeskFocusState {

--- a/src/agents/apollo.ts
+++ b/src/agents/apollo.ts
@@ -36,10 +36,12 @@ import {
 } from '@/focus/logic';
 import {
   evaluateInitiativeCandidate,
+  INITIATIVE_MAX_RETRY_ATTEMPTS,
+  INITIATIVE_SUPPRESSED_RETRY_DELAY_SECONDS,
   parseStoredInitiativeState,
   recordInitiativeDelivery,
-  type InitiativePriority,
-  type InitiativeSource,
+  type InitiativeDeliveryOutcome,
+  type InitiativeUtteranceInput,
 } from '@/initiative/logic';
 import {
   buildDeviceToolCallPayload,
@@ -47,42 +49,18 @@ import {
   DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS,
   summarizeDeviceToolResult,
 } from '@/mcp/bridge';
-import {
-  buildExtractionRetryMessageList,
-  buildMemoryExtractionMessageList,
-  flattenRecentHistoryToTranscript,
-  mergeOwnerFacts,
-  OWNER_MEMORY_CONSOLIDATION_CRON,
-  OWNER_MEMORY_MIN_RUN_INTERVAL_MS,
-  OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
-  parseMemoryExtractionResult,
-  parseStoredOwnerMemoryState,
-  renderOwnerMemoryBlock,
-  seedOwnerFactsFromMemoryBlock,
-  type OwnerMemoryState,
-} from '@/memory/consolidate';
+import { OWNER_MEMORY_CONSOLIDATION_CRON } from '@/memory/consolidate';
+import { runOwnerMemoryConsolidation } from '@/memory/nightly';
 import { deletePendingDeviceMessage, listPendingDeviceMessages } from '@/memory/pending';
-import { readFirmwareManifest } from '@/ota/manifest';
-import {
-  buildFirmwareChangelogMessage,
-  detectFirmwareVersionChange,
-  evaluateFirmwarePush,
-  parseStoredFirmwareChangelogState,
-  parseStoredFirmwarePushState,
-  recordFirmwareManifestCheck,
-  recordFirmwarePushAttempt,
-  shouldCheckFirmwareManifest,
-} from '@/ota/push';
 import { createApolloSession } from '@/memory/session';
 import {
-  addMemoryRecord,
   getSessionPreference,
   setSessionPreference,
   type MemorySqlExecutor,
 } from '@/memory/store';
+import { PUBLIC_ORIGIN_PREFERENCE_KEY, runFirmwareLifecycle } from '@/ota/lifecycle';
 import { cycleDeskSpeechMode, resolveDeskSpeechMode } from '@/persona/catalog';
 import { resolveDeskFaceEmotion } from '@/persona/face';
-import { enqueueMemoryIndexJob } from '@/queues/consume';
 import { APOLLO_TTS_VOICE } from '@/persona/soul';
 import {
   encodeServerToDeviceMessage,
@@ -109,7 +87,6 @@ import {
   savePendingToolConfirmation,
 } from '@/tools/pending';
 import type { PendingToolConfirmation, ToolExecutionResult } from '@/tools/types';
-import { chatWithOpenRouter } from '@/voice/llm';
 import type { DeskWeatherSnapshot } from '@/weather/fetch';
 import {
   resolveDeskWeatherLocationFromPreferences,
@@ -124,10 +101,6 @@ const MINIMUM_TURN_AUDIO_BYTE_LENGTH = 8000;
 const LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY = 'lowBatteryLastAnnounceAt';
 const TELEMETRY_SNAPSHOT_PREFERENCE_KEY = 'lastTelemetrySnapshot';
 const INITIATIVE_STATE_PREFERENCE_KEY = 'initiativeState';
-const FIRMWARE_PUSH_STATE_PREFERENCE_KEY = 'firmwarePushState';
-const FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY = 'firmwareChangelogState';
-const PUBLIC_ORIGIN_PREFERENCE_KEY = 'publicOrigin';
-const OWNER_MEMORY_STATE_PREFERENCE_KEY = 'ownerMemoryState';
 
 function mapUnknownScheduleListToAgentScheduleLikeList(
   scheduleList: readonly {
@@ -533,13 +506,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   // The single chokepoint for self-initiated speech (roadmap item 17): every
   // source of proactive utterances goes through the initiative policy so quiet
   // hours, focus, and the daily budget are enforced in exactly one place.
-  async #deliverInitiativeUtterance(input: {
-    readonly source: InitiativeSource;
-    readonly priority: InitiativePriority;
-    readonly message: string;
-    readonly earconName?: DeskSoundEffectName;
-    readonly deferCount?: number;
-  }): Promise<'delivered' | 'suppressed' | 'deferred'> {
+  async #deliverInitiativeUtterance(
+    input: InitiativeUtteranceInput,
+  ): Promise<InitiativeDeliveryOutcome> {
     const nowMilliseconds = Date.now();
     const storedInitiativeState = await getSessionPreference(
       this.#sqlExecutor(),
@@ -623,20 +592,35 @@ export class Apollo extends Agent<Env, ApolloState> {
 
   async retryInitiativeUtterance(payload: unknown): Promise<void> {
     const parsedPayload = retryInitiativeUtterancePayloadSchema.parse(payload);
-    await this.#deliverInitiativeUtterance({
+    const nextDeferCount = parsedPayload.deferCount + 1;
+    const retryPayload = {
       source: parsedPayload.source,
       priority: parsedPayload.priority,
       message: parsedPayload.message,
       ...(parsedPayload.earconName !== undefined
         ? { earconName: parsedPayload.earconName }
         : {}),
-      deferCount: parsedPayload.deferCount + 1,
+    };
+    const deliveryOutcome = await this.#deliverInitiativeUtterance({
+      ...retryPayload,
+      deferCount: nextDeferCount,
     });
+    // A deferred utterance already survived one policy window; letting its
+    // retry vanish on a transient suppression (device offline at 09:00, budget
+    // spent) would lose it for good — so it re-schedules itself, bounded by
+    // the attempt cap.
+    if (
+      deliveryOutcome === 'suppressed' &&
+      nextDeferCount < INITIATIVE_MAX_RETRY_ATTEMPTS
+    ) {
+      await this.schedule(
+        INITIATIVE_SUPPRESSED_RETRY_DELAY_SECONDS,
+        'retryInitiativeUtterance',
+        { ...retryPayload, deferCount: nextDeferCount },
+      );
+    }
   }
 
-  // Roadmap item 18: the nightly cron owns the previously append-only memory
-  // context block — it reads the recent transcript, asks the LLM to extract,
-  // reinforce, and retire owner facts, and rewrites the block consolidated.
   async consolidateOwnerMemory(): Promise<void> {
     // Mock mode has no LLM to call; a dev session must not burn tokens.
     if (this.env.MOCK_VOICE === '1') {
@@ -645,119 +629,16 @@ export class Apollo extends Agent<Env, ApolloState> {
     if (this.#isConsolidatingMemory) {
       return;
     }
-    const nowMilliseconds = Date.now();
-    const sqlExecutor = this.#sqlExecutor();
-    const storedState = await getSessionPreference(
-      sqlExecutor,
-      OWNER_MEMORY_STATE_PREFERENCE_KEY,
-    );
-    const state =
-      storedState === null ? undefined : parseStoredOwnerMemoryState(storedState);
-    if (
-      state !== undefined &&
-      nowMilliseconds - state.lastConsolidatedAtMilliseconds <
-        OWNER_MEMORY_MIN_RUN_INTERVAL_MS
-    ) {
-      return;
-    }
     this.#isConsolidatingMemory = true;
     try {
-      const latestLeaf = await this.session.getLatestLeaf();
-      if (latestLeaf === null || latestLeaf.id === state?.lastProcessedLeafId) {
-        // An idle day: nothing new happened, so the run costs zero LLM calls.
-        const idleState: OwnerMemoryState = {
-          factList: state?.factList ?? [],
-          lastConsolidatedAtMilliseconds: nowMilliseconds,
-          ...(state?.lastProcessedLeafId !== undefined
-            ? { lastProcessedLeafId: state.lastProcessedLeafId }
-            : {}),
-        };
-        await setSessionPreference(
-          sqlExecutor,
-          OWNER_MEMORY_STATE_PREFERENCE_KEY,
-          JSON.stringify(idleState),
-        );
-        return;
-      }
-      const recentHistory = await this.session.getRecentHistory(
-        OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
-      );
-      const seededFactList = seedOwnerFactsFromMemoryBlock({
-        blockContent: this.session.getContextBlock('memory')?.content ?? '',
-        knownFactList: state?.factList ?? [],
-        nowMilliseconds,
+      await runOwnerMemoryConsolidation({
+        sqlExecutor: this.#sqlExecutor(),
+        session: this.session,
+        environment: this.env,
+        deviceId: this.name ?? 'default',
+        nowMilliseconds: Date.now(),
         createIdentifier: () => crypto.randomUUID(),
       });
-      const extractionMessageList = buildMemoryExtractionMessageList({
-        transcriptText: flattenRecentHistoryToTranscript(recentHistory.messages),
-        existingFactList: seededFactList,
-        nowIso: new Date(nowMilliseconds).toISOString(),
-      });
-      const firstChatResult = await chatWithOpenRouter({
-        openRouterApiKey: this.env.OPENROUTER_API_KEY,
-        modelId: this.env.OPENROUTER_MODEL,
-        messageList: extractionMessageList,
-      });
-      let extraction = parseMemoryExtractionResult(firstChatResult.text);
-      if (extraction === undefined) {
-        const retryChatResult = await chatWithOpenRouter({
-          openRouterApiKey: this.env.OPENROUTER_API_KEY,
-          modelId: this.env.OPENROUTER_MODEL,
-          messageList: buildExtractionRetryMessageList(
-            extractionMessageList,
-            firstChatResult.text,
-          ),
-        });
-        extraction = parseMemoryExtractionResult(retryChatResult.text);
-      }
-      if (extraction === undefined) {
-        // State stays untouched so the next night retries over the same window.
-        console.error(
-          JSON.stringify({ level: 'error', message: 'owner_memory_extraction_invalid' }),
-        );
-        return;
-      }
-      const merge = mergeOwnerFacts({
-        existingFactList: seededFactList,
-        extraction,
-        nowMilliseconds,
-        createIdentifier: () => crypto.randomUUID(),
-      });
-      const nextState: OwnerMemoryState = {
-        factList: merge.nextFactList,
-        lastConsolidatedAtMilliseconds: nowMilliseconds,
-        lastProcessedLeafId: latestLeaf.id,
-      };
-      await setSessionPreference(
-        sqlExecutor,
-        OWNER_MEMORY_STATE_PREFERENCE_KEY,
-        JSON.stringify(nextState),
-      );
-      await this.session.replaceContextBlock(
-        'memory',
-        renderOwnerMemoryBlock(merge.nextFactList),
-      );
-      await this.session.refreshSystemPrompt();
-      // Decayed facts stay in the memories table and Vectorize on purpose:
-      // that layer is the provenance log recall_memory searches, while the
-      // consolidated block only governs what occupies prompt budget.
-      for (const genuinelyNewFact of merge.genuinelyNewFactList) {
-        const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
-        await enqueueMemoryIndexJob(this.env, {
-          memoryId: memoryRecord.id,
-          content: genuinelyNewFact.content,
-          deviceId: this.name ?? 'default',
-        });
-      }
-      console.log(
-        JSON.stringify({
-          level: 'info',
-          message: 'owner_memory_consolidated',
-          factCount: merge.nextFactList.length,
-          newFactCount: merge.genuinelyNewFactList.length,
-          transcriptTruncated: recentHistory.truncated,
-        }),
-      );
     } finally {
       this.#isConsolidatingMemory = false;
     }
@@ -955,11 +836,29 @@ export class Apollo extends Agent<Env, ApolloState> {
 
     await this.#handleLowBatteryAnnouncement(snapshot);
     try {
-      await this.#handleFirmwareLifecycle({
-        previousFirmwareVersion: previousSnapshot?.firmwareVersion,
-        snapshot,
-        didChargingEdgeOccur,
-      });
+      await runFirmwareLifecycle(
+        {
+          previousFirmwareVersion: previousSnapshot?.firmwareVersion,
+          snapshot,
+          didChargingEdgeOccur,
+        },
+        {
+          sqlExecutor: this.#sqlExecutor(),
+          mediaBucket: this.env.MEDIA,
+          deviceSharedSecret: this.env.DEVICE_SHARED_SECRET,
+          isPushDisabled: this.env.FIRMWARE_PUSH_DISABLED === '1',
+          uiState: this.state.uiState,
+          isFocusActive: this.#currentFocusState().active,
+          hasPendingConfirmation: this.state.pendingConfirmId !== null,
+          isAnnouncementInFlight:
+            this.#isAnnouncingLowBattery || this.#isDeliveringInitiative,
+          nowMilliseconds: Date.now(),
+          deliverInitiativeUtterance: (utterance) =>
+            this.#deliverInitiativeUtterance(utterance),
+          callDeviceTool: (deviceToolName, argumentRecord) =>
+            this.#callDeviceTool(deviceToolName, argumentRecord),
+        },
+      );
     } catch (error) {
       // OTA plumbing must never take telemetry handling down with it.
       console.error(
@@ -1022,180 +921,6 @@ export class Apollo extends Agent<Env, ApolloState> {
     } finally {
       this.#isAnnouncingLowBattery = false;
     }
-  }
-
-  // Roadmap item 23: after a reboot the first telemetry reports the new
-  // version (the changelog edge), and every telemetry tick is a chance to
-  // push a pending update when the device is idle and powered.
-  async #handleFirmwareLifecycle(input: {
-    readonly previousFirmwareVersion: string | undefined;
-    readonly snapshot: DeskTelemetrySnapshot;
-    readonly didChargingEdgeOccur: boolean;
-  }): Promise<void> {
-    const nowMilliseconds = Date.now();
-    const sqlExecutor = this.#sqlExecutor();
-
-    const storedChangelogState = await getSessionPreference(
-      sqlExecutor,
-      FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
-    );
-    let changelogState =
-      storedChangelogState === null
-        ? undefined
-        : parseStoredFirmwareChangelogState(storedChangelogState);
-
-    const versionChange = detectFirmwareVersionChange({
-      previousFirmwareVersion: input.previousFirmwareVersion,
-      nextFirmwareVersion: input.snapshot.firmwareVersion,
-    });
-    if (versionChange !== undefined) {
-      changelogState = { ...changelogState, pendingVersion: versionChange.toVersion };
-      await setSessionPreference(
-        sqlExecutor,
-        FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
-        JSON.stringify(changelogState),
-      );
-      // The device came back on the new version: the attempt marker did its
-      // job and must not throttle the next release.
-      await setSessionPreference(
-        sqlExecutor,
-        FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
-        JSON.stringify(recordFirmwareManifestCheck(undefined, nowMilliseconds)),
-      );
-      console.log(
-        JSON.stringify({
-          level: 'info',
-          message: 'firmware_changelog_pending',
-          fromVersion: versionChange.fromVersion,
-          toVersion: versionChange.toVersion,
-        }),
-      );
-    }
-
-    if (
-      changelogState?.pendingVersion !== undefined &&
-      changelogState.pendingVersion !== changelogState.announcedVersion
-    ) {
-      const manifest = await readFirmwareManifest(this.env.MEDIA);
-      const changelogText =
-        manifest !== undefined && manifest.version === changelogState.pendingVersion
-          ? manifest.changelog
-          : undefined;
-      const deliveryOutcome = await this.#deliverInitiativeUtterance({
-        source: 'firmware_changelog',
-        priority: 'normal',
-        message: buildFirmwareChangelogMessage({
-          toVersion: changelogState.pendingVersion,
-          ...(changelogText !== undefined ? { changelogText } : {}),
-        }),
-        earconName: 'chime',
-      });
-      // A deferred utterance carries its message in the schedule payload, so
-      // it counts as announced here — otherwise the next telemetry tick would
-      // schedule a duplicate. Only a suppression leaves it pending for retry.
-      if (deliveryOutcome !== 'suppressed') {
-        changelogState = { announcedVersion: changelogState.pendingVersion };
-        await setSessionPreference(
-          sqlExecutor,
-          FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
-          JSON.stringify(changelogState),
-        );
-      }
-    }
-
-    if (this.env.FIRMWARE_PUSH_DISABLED === '1') {
-      return;
-    }
-    const storedPushState = await getSessionPreference(
-      sqlExecutor,
-      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
-    );
-    const pushState =
-      storedPushState === null
-        ? undefined
-        : parseStoredFirmwarePushState(storedPushState);
-    if (
-      !shouldCheckFirmwareManifest({
-        pushState,
-        didChargingEdgeOccur: input.didChargingEdgeOccur,
-        nowMilliseconds,
-      })
-    ) {
-      return;
-    }
-    const manifest = await readFirmwareManifest(this.env.MEDIA);
-    const checkedPushState = recordFirmwareManifestCheck(pushState, nowMilliseconds);
-    await setSessionPreference(
-      sqlExecutor,
-      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
-      JSON.stringify(checkedPushState),
-    );
-    if (manifest === undefined) {
-      return;
-    }
-    const evaluation = evaluateFirmwarePush({
-      snapshot: input.snapshot,
-      manifestVersion: manifest.version,
-      uiState: this.state.uiState,
-      isFocusActive: this.#currentFocusState().active,
-      hasPendingConfirmation: this.state.pendingConfirmId !== null,
-      isAnnouncementInFlight:
-        this.#isAnnouncingLowBattery || this.#isDeliveringInitiative,
-      pushState: checkedPushState,
-      nowMilliseconds,
-    });
-    if (!evaluation.shouldPush) {
-      if (evaluation.reason !== 'already_current') {
-        console.log(
-          JSON.stringify({
-            level: 'info',
-            message: 'firmware_push_skipped',
-            reason: evaluation.reason,
-          }),
-        );
-      }
-      return;
-    }
-    const publicOrigin = await getSessionPreference(
-      sqlExecutor,
-      PUBLIC_ORIGIN_PREFERENCE_KEY,
-    );
-    if (publicOrigin === null) {
-      console.error(
-        JSON.stringify({ level: 'error', message: 'firmware_push_missing_origin' }),
-      );
-      return;
-    }
-    const firmwareBinaryUrl = new URL('/ota/firmware.bin', publicOrigin);
-    firmwareBinaryUrl.searchParams.set('token', this.env.DEVICE_SHARED_SECRET);
-    // Recorded before the call: a crash mid-push must read as an attempt, or
-    // the device could be flashed in a loop.
-    await setSessionPreference(
-      sqlExecutor,
-      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
-      JSON.stringify(
-        recordFirmwarePushAttempt(checkedPushState, manifest.version, nowMilliseconds),
-      ),
-    );
-    console.log(
-      JSON.stringify({
-        level: 'info',
-        message: 'firmware_push_attempted',
-        manifestVersion: manifest.version,
-        deviceVersion: input.snapshot.firmwareVersion,
-      }),
-    );
-    const pushResult = await this.#callDeviceTool('self.upgrade_firmware', {
-      url: firmwareBinaryUrl.toString(),
-    });
-    console.log(
-      JSON.stringify({
-        level: 'info',
-        message: 'firmware_push_result',
-        ok: pushResult.ok,
-        summary: pushResult.summary,
-      }),
-    );
   }
 
   async #callDeviceTool(

--- a/src/agents/rpc.ts
+++ b/src/agents/rpc.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+import { initiativePrioritySchema, initiativeSourceSchema } from '@/initiative/logic';
+import { deskSoundEffectSchema } from '@/protocol/schema';
+
 export const notifyBackgroundResultInputSchema = z.object({
   prompt: z.string().min(1),
   summary: z.string().min(1),
@@ -12,4 +15,12 @@ export const deliverReminderPayloadSchema = z.object({
 
 export const expireConfirmPayloadSchema = z.object({
   confirmationId: z.string().min(1),
+});
+
+export const retryInitiativeUtterancePayloadSchema = z.object({
+  source: initiativeSourceSchema,
+  priority: initiativePrioritySchema,
+  message: z.string().min(1),
+  earconName: deskSoundEffectSchema.optional(),
+  deferCount: z.number().int().min(0).max(5),
 });

--- a/src/agents/rpc.ts
+++ b/src/agents/rpc.ts
@@ -23,4 +23,5 @@ export const retryInitiativeUtterancePayloadSchema = z.object({
   message: z.string().min(1),
   earconName: deskSoundEffectSchema.optional(),
   deferCount: z.number().int().min(0).max(5),
+  utteranceKey: z.string().min(1).optional(),
 });

--- a/src/configuration/environment.d.ts
+++ b/src/configuration/environment.d.ts
@@ -9,6 +9,7 @@ interface Env {
   MOCK_VOICE?: string;
   CODING_PROXY_ORIGIN?: string;
   CODING_ENGINE?: string;
+  FIRMWARE_PUSH_DISABLED?: string;
 }
 
 declare namespace Cloudflare {
@@ -23,5 +24,6 @@ declare namespace Cloudflare {
     MOCK_VOICE?: string;
     CODING_PROXY_ORIGIN?: string;
     CODING_ENGINE?: string;
+    FIRMWARE_PUSH_DISABLED?: string;
   }
 }

--- a/src/configuration/environment.d.ts
+++ b/src/configuration/environment.d.ts
@@ -1,9 +1,16 @@
 interface Env {
   DEVICE_SHARED_SECRET: string;
   OPENROUTER_API_KEY: string;
+  OPENROUTER_MODEL: string;
+  OPENROUTER_STT_MODEL: string;
+  OPENROUTER_RESEARCH_MODEL: string;
+  OPENROUTER_CODING_MODEL: string;
+  OPENROUTER_EMBEDDING_MODEL: string;
   ELEVENLABS_API_KEY: string;
+  ELEVENLABS_TTS_MODEL: string;
   TAVILY_API_KEY: string;
   RESEND_API_KEY: string;
+  APOLLO_OWNER_EMAIL: string;
   GITHUB_APP_ID: string;
   GITHUB_APP_PRIVATE_KEY: string;
   MOCK_VOICE?: string;
@@ -16,9 +23,16 @@ declare namespace Cloudflare {
   interface Env {
     DEVICE_SHARED_SECRET: string;
     OPENROUTER_API_KEY: string;
+    OPENROUTER_MODEL: string;
+    OPENROUTER_STT_MODEL: string;
+    OPENROUTER_RESEARCH_MODEL: string;
+    OPENROUTER_CODING_MODEL: string;
+    OPENROUTER_EMBEDDING_MODEL: string;
     ELEVENLABS_API_KEY: string;
+    ELEVENLABS_TTS_MODEL: string;
     TAVILY_API_KEY: string;
     RESEND_API_KEY: string;
+    APOLLO_OWNER_EMAIL: string;
     GITHUB_APP_ID: string;
     GITHUB_APP_PRIVATE_KEY: string;
     MOCK_VOICE?: string;

--- a/src/initiative/__tests__/logic.spec.ts
+++ b/src/initiative/__tests__/logic.spec.ts
@@ -118,14 +118,17 @@ describe('evaluateInitiativeCandidate', () => {
     });
   });
 
-  it('always delivers critical candidates, even offline inside quiet hours', () => {
+  it('delivers critical candidates through quiet hours, budget, and cooldown', () => {
+    const nightMilliseconds = buildBuenosAiresEpochMilliseconds(2026, 7, 12, 3, 0);
     const decision = evaluateInitiativeCandidate(
       createEvaluationInput({
         priority: 'critical',
-        connectionCount: 0,
-        nowMilliseconds: buildBuenosAiresEpochMilliseconds(2026, 7, 12, 3, 0),
+        source: 'low_battery',
+        nowMilliseconds: nightMilliseconds,
         state: createState({
+          budgetDate: resolveLocalCalendarDate(nightMilliseconds),
           utterancesUsed: INITIATIVE_DAILY_UTTERANCE_BUDGET,
+          lastUtteranceAtBySource: { low_battery: nightMilliseconds - 1 },
         }),
       }),
     );
@@ -135,6 +138,13 @@ describe('evaluateInitiativeCandidate', () => {
   it('suppresses when the device is offline', () => {
     const decision = evaluateInitiativeCandidate(
       createEvaluationInput({ connectionCount: 0 }),
+    );
+    expect(decision).toEqual({ action: 'suppress', reason: 'device_offline' });
+  });
+
+  it('suppresses even critical candidates while offline, so cooldowns stay unwritten', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({ priority: 'critical', connectionCount: 0 }),
     );
     expect(decision).toEqual({ action: 'suppress', reason: 'device_offline' });
   });

--- a/src/initiative/__tests__/logic.spec.ts
+++ b/src/initiative/__tests__/logic.spec.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  computeQuietHoursEndMilliseconds,
+  evaluateInitiativeCandidate,
+  INITIATIVE_DAILY_UTTERANCE_BUDGET,
+  INITIATIVE_FOCUS_DEFER_GRACE_MS,
+  INITIATIVE_MAX_DEFER_COUNT,
+  INITIATIVE_SOURCE_COOLDOWN_MS,
+  isWithinQuietHours,
+  parseStoredInitiativeState,
+  recordInitiativeDelivery,
+  resolveLocalCalendarDate,
+  type InitiativeCandidateEvaluationInput,
+  type InitiativeState,
+} from '@/initiative/logic';
+
+// Buenos Aires sits at UTC-3 year-round (no DST), so local wall time maps to
+// UTC by adding three hours.
+function buildBuenosAiresEpochMilliseconds(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hour: number,
+  minute = 0,
+  second = 0,
+): number {
+  return Date.UTC(year, monthIndex, day, hour + 3, minute, second);
+}
+
+const DAYTIME_MILLISECONDS = buildBuenosAiresEpochMilliseconds(2026, 7, 11, 15, 30);
+
+function createEvaluationInput(
+  overrides: Partial<InitiativeCandidateEvaluationInput> = {},
+): InitiativeCandidateEvaluationInput {
+  return {
+    source: 'firmware_changelog',
+    priority: 'normal',
+    state: undefined,
+    nowMilliseconds: DAYTIME_MILLISECONDS,
+    focusEndsAtMilliseconds: null,
+    connectionCount: 1,
+    deferCount: 0,
+    ...overrides,
+  };
+}
+
+function createState(overrides: Partial<InitiativeState> = {}): InitiativeState {
+  return {
+    budgetDate: resolveLocalCalendarDate(DAYTIME_MILLISECONDS),
+    utterancesUsed: 0,
+    lastUtteranceAtBySource: {},
+    ...overrides,
+  };
+}
+
+describe('isWithinQuietHours', () => {
+  it('is outside quiet hours just before they start', () => {
+    expect(
+      isWithinQuietHours(buildBuenosAiresEpochMilliseconds(2026, 7, 11, 21, 59)),
+    ).toBe(false);
+  });
+
+  it('enters quiet hours exactly at the start hour', () => {
+    expect(
+      isWithinQuietHours(buildBuenosAiresEpochMilliseconds(2026, 7, 11, 22, 0)),
+    ).toBe(true);
+  });
+
+  it('is still quiet just before the end hour', () => {
+    expect(
+      isWithinQuietHours(buildBuenosAiresEpochMilliseconds(2026, 7, 12, 8, 59)),
+    ).toBe(true);
+  });
+
+  it('leaves quiet hours exactly at the end hour', () => {
+    expect(isWithinQuietHours(buildBuenosAiresEpochMilliseconds(2026, 7, 12, 9, 0))).toBe(
+      false,
+    );
+  });
+
+  it('is quiet in the middle of the night', () => {
+    expect(isWithinQuietHours(buildBuenosAiresEpochMilliseconds(2026, 7, 12, 3, 0))).toBe(
+      true,
+    );
+  });
+});
+
+describe('computeQuietHoursEndMilliseconds', () => {
+  it('targets the same morning during the early hours', () => {
+    const nowMilliseconds = buildBuenosAiresEpochMilliseconds(2026, 7, 12, 3, 15, 30);
+    expect(computeQuietHoursEndMilliseconds(nowMilliseconds)).toBe(
+      buildBuenosAiresEpochMilliseconds(2026, 7, 12, 9, 0),
+    );
+  });
+
+  it('targets the next morning during the late evening', () => {
+    const nowMilliseconds = buildBuenosAiresEpochMilliseconds(2026, 7, 11, 23, 0);
+    expect(computeQuietHoursEndMilliseconds(nowMilliseconds)).toBe(
+      buildBuenosAiresEpochMilliseconds(2026, 7, 12, 9, 0),
+    );
+  });
+});
+
+describe('resolveLocalCalendarDate', () => {
+  it('uses the Buenos Aires date, not the UTC date', () => {
+    // 22:00 local on the 11th is already the 12th in UTC.
+    expect(
+      resolveLocalCalendarDate(buildBuenosAiresEpochMilliseconds(2026, 7, 11, 22, 0)),
+    ).toBe('2026-08-11');
+  });
+});
+
+describe('evaluateInitiativeCandidate', () => {
+  it('delivers with no prior state during the day', () => {
+    expect(evaluateInitiativeCandidate(createEvaluationInput())).toEqual({
+      action: 'deliver',
+    });
+  });
+
+  it('always delivers critical candidates, even offline inside quiet hours', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        priority: 'critical',
+        connectionCount: 0,
+        nowMilliseconds: buildBuenosAiresEpochMilliseconds(2026, 7, 12, 3, 0),
+        state: createState({
+          utterancesUsed: INITIATIVE_DAILY_UTTERANCE_BUDGET,
+        }),
+      }),
+    );
+    expect(decision).toEqual({ action: 'deliver' });
+  });
+
+  it('suppresses when the device is offline', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({ connectionCount: 0 }),
+    );
+    expect(decision).toEqual({ action: 'suppress', reason: 'device_offline' });
+  });
+
+  it('defers to the end of quiet hours at night', () => {
+    const nowMilliseconds = buildBuenosAiresEpochMilliseconds(2026, 7, 11, 23, 30);
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({ nowMilliseconds }),
+    );
+    expect(decision).toEqual({
+      action: 'defer',
+      reason: 'quiet_hours',
+      retryAtMilliseconds: buildBuenosAiresEpochMilliseconds(2026, 7, 12, 9, 0),
+    });
+  });
+
+  it('suppresses instead of deferring past the defer limit', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        nowMilliseconds: buildBuenosAiresEpochMilliseconds(2026, 7, 11, 23, 30),
+        deferCount: INITIATIVE_MAX_DEFER_COUNT,
+      }),
+    );
+    expect(decision).toEqual({ action: 'suppress', reason: 'defer_limit' });
+  });
+
+  it('defers past an active focus window with grace', () => {
+    const focusEndsAtMilliseconds = DAYTIME_MILLISECONDS + 10 * 60_000;
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({ focusEndsAtMilliseconds }),
+    );
+    expect(decision).toEqual({
+      action: 'defer',
+      reason: 'focus_active',
+      retryAtMilliseconds: focusEndsAtMilliseconds + INITIATIVE_FOCUS_DEFER_GRACE_MS,
+    });
+  });
+
+  it('ignores an already-expired focus window', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        focusEndsAtMilliseconds: DAYTIME_MILLISECONDS - 1,
+      }),
+    );
+    expect(decision).toEqual({ action: 'deliver' });
+  });
+
+  it('suppresses once the daily budget is exhausted', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        state: createState({ utterancesUsed: INITIATIVE_DAILY_UTTERANCE_BUDGET }),
+      }),
+    );
+    expect(decision).toEqual({ action: 'suppress', reason: 'budget_exhausted' });
+  });
+
+  it('rolls the budget over on a new local day', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        state: createState({
+          budgetDate: '2026-08-10',
+          utterancesUsed: INITIATIVE_DAILY_UTTERANCE_BUDGET,
+        }),
+      }),
+    );
+    expect(decision).toEqual({ action: 'deliver' });
+  });
+
+  it('suppresses a source still inside its cooldown', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        state: createState({
+          lastUtteranceAtBySource: {
+            firmware_changelog: DAYTIME_MILLISECONDS - INITIATIVE_SOURCE_COOLDOWN_MS + 1,
+          },
+        }),
+      }),
+    );
+    expect(decision).toEqual({ action: 'suppress', reason: 'source_cooldown' });
+  });
+
+  it('lets a different source speak during another source cooldown', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        source: 'curiosity',
+        state: createState({
+          lastUtteranceAtBySource: {
+            firmware_changelog: DAYTIME_MILLISECONDS - 1,
+          },
+        }),
+      }),
+    );
+    expect(decision).toEqual({ action: 'deliver' });
+  });
+
+  it('delivers again once the source cooldown expires', () => {
+    const decision = evaluateInitiativeCandidate(
+      createEvaluationInput({
+        state: createState({
+          lastUtteranceAtBySource: {
+            firmware_changelog: DAYTIME_MILLISECONDS - INITIATIVE_SOURCE_COOLDOWN_MS,
+          },
+        }),
+      }),
+    );
+    expect(decision).toEqual({ action: 'deliver' });
+  });
+});
+
+describe('recordInitiativeDelivery', () => {
+  it('starts a fresh day from undefined state', () => {
+    const nextState = recordInitiativeDelivery(
+      undefined,
+      'firmware_changelog',
+      'normal',
+      DAYTIME_MILLISECONDS,
+    );
+    expect(nextState).toEqual({
+      budgetDate: '2026-08-11',
+      utterancesUsed: 1,
+      lastUtteranceAtBySource: { firmware_changelog: DAYTIME_MILLISECONDS },
+    });
+  });
+
+  it('increments the same-day counter and keeps other source timestamps', () => {
+    const nextState = recordInitiativeDelivery(
+      createState({
+        utterancesUsed: 2,
+        lastUtteranceAtBySource: { low_battery: DAYTIME_MILLISECONDS - 5_000 },
+      }),
+      'curiosity',
+      'normal',
+      DAYTIME_MILLISECONDS,
+    );
+    expect(nextState.utterancesUsed).toBe(3);
+    expect(nextState.lastUtteranceAtBySource).toEqual({
+      low_battery: DAYTIME_MILLISECONDS - 5_000,
+      curiosity: DAYTIME_MILLISECONDS,
+    });
+  });
+
+  it('resets the counter across a local day boundary', () => {
+    const nextState = recordInitiativeDelivery(
+      createState({ budgetDate: '2026-08-10', utterancesUsed: 6 }),
+      'firmware_changelog',
+      'normal',
+      DAYTIME_MILLISECONDS,
+    );
+    expect(nextState.budgetDate).toBe('2026-08-11');
+    expect(nextState.utterancesUsed).toBe(1);
+  });
+
+  it('records a critical delivery without consuming budget', () => {
+    const nextState = recordInitiativeDelivery(
+      createState({ utterancesUsed: 2 }),
+      'low_battery',
+      'critical',
+      DAYTIME_MILLISECONDS,
+    );
+    expect(nextState.utterancesUsed).toBe(2);
+    expect(nextState.lastUtteranceAtBySource).toEqual({
+      low_battery: DAYTIME_MILLISECONDS,
+    });
+  });
+});
+
+describe('parseStoredInitiativeState', () => {
+  it('restores a stored state', () => {
+    const state = createState({ utterancesUsed: 3 });
+    expect(parseStoredInitiativeState(JSON.stringify(state))).toEqual(state);
+  });
+
+  it('rejects malformed json', () => {
+    expect(parseStoredInitiativeState('{"budgetDate":')).toBeUndefined();
+  });
+
+  it('rejects json with the wrong shape', () => {
+    expect(parseStoredInitiativeState('{"budgetDate":"2026-08-11"}')).toBeUndefined();
+    expect(parseStoredInitiativeState('null')).toBeUndefined();
+  });
+});

--- a/src/initiative/__tests__/logic.spec.ts
+++ b/src/initiative/__tests__/logic.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  buildInitiativeDeliveryMarkerKey,
   computeQuietHoursEndMilliseconds,
   evaluateInitiativeCandidate,
+  hasScheduledInitiativeRetryForSource,
   INITIATIVE_DAILY_UTTERANCE_BUDGET,
   INITIATIVE_FOCUS_DEFER_GRACE_MS,
   INITIATIVE_MAX_DEFER_COUNT,
@@ -308,6 +310,55 @@ describe('recordInitiativeDelivery', () => {
     expect(nextState.lastUtteranceAtBySource).toEqual({
       low_battery: DAYTIME_MILLISECONDS,
     });
+  });
+});
+
+describe('buildInitiativeDeliveryMarkerKey', () => {
+  it('namespaces the utterance key', () => {
+    expect(buildInitiativeDeliveryMarkerKey('firmware-changelog-2.7.0')).toBe(
+      'initiativeDeliveredAt:firmware-changelog-2.7.0',
+    );
+  });
+});
+
+describe('hasScheduledInitiativeRetryForSource', () => {
+  it('finds a scheduled retry for the source', () => {
+    expect(
+      hasScheduledInitiativeRetryForSource(
+        [
+          { callback: 'deliverReminder', payload: { message: 'Timer' } },
+          {
+            callback: 'retryInitiativeUtterance',
+            payload: { source: 'firmware_changelog', message: 'hola' },
+          },
+        ],
+        'firmware_changelog',
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores retries for other sources and other callbacks', () => {
+    expect(
+      hasScheduledInitiativeRetryForSource(
+        [
+          {
+            callback: 'retryInitiativeUtterance',
+            payload: { source: 'curiosity', message: 'hola' },
+          },
+          { callback: 'deliverReminder', payload: { source: 'firmware_changelog' } },
+        ],
+        'firmware_changelog',
+      ),
+    ).toBe(false);
+  });
+
+  it('tolerates malformed payloads', () => {
+    expect(
+      hasScheduledInitiativeRetryForSource(
+        [{ callback: 'retryInitiativeUtterance', payload: 'garbage' }],
+        'firmware_changelog',
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/initiative/logic.ts
+++ b/src/initiative/logic.ts
@@ -37,7 +37,28 @@ export type InitiativeUtteranceInput = {
   readonly message: string;
   readonly earconName?: DeskSoundEffectName;
   readonly deferCount?: number;
+  // When set, a successful delivery writes a durable marker under this key,
+  // so an at-most-once caller can requeue lost utterances without ever
+  // double-speaking one that a deferred retry already delivered.
+  readonly utteranceKey?: string;
 };
+
+export function buildInitiativeDeliveryMarkerKey(utteranceKey: string): string {
+  return `initiativeDeliveredAt:${utteranceKey}`;
+}
+
+export function hasScheduledInitiativeRetryForSource(
+  scheduleList: readonly { readonly callback: string; readonly payload: unknown }[],
+  source: InitiativeSource,
+): boolean {
+  return scheduleList.some((schedule) => {
+    if (schedule.callback !== 'retryInitiativeUtterance') {
+      return false;
+    }
+    const parsedPayload = z.object({ source: z.string() }).safeParse(schedule.payload);
+    return parsedPayload.success && parsedPayload.data.source === source;
+  });
+}
 
 export type InitiativeDecision =
   | { readonly action: 'deliver' }

--- a/src/initiative/logic.ts
+++ b/src/initiative/logic.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod';
+
+import { APOLLO_TIME_ZONE } from '@/persona/clock';
+
+export const initiativeSourceSchema = z.enum([
+  'firmware_changelog',
+  'low_battery',
+  'curiosity',
+  'follow_up',
+  'sentinel',
+]);
+
+export type InitiativeSource = z.infer<typeof initiativeSourceSchema>;
+
+export const initiativePrioritySchema = z.enum(['critical', 'normal', 'low']);
+
+export type InitiativePriority = z.infer<typeof initiativePrioritySchema>;
+
+const initiativeStateSchema = z.object({
+  budgetDate: z.string().min(1),
+  utterancesUsed: z.number().int().min(0),
+  lastUtteranceAtBySource: z.record(z.string(), z.number()),
+});
+
+export type InitiativeState = {
+  readonly budgetDate: string;
+  readonly utterancesUsed: number;
+  readonly lastUtteranceAtBySource: Readonly<Record<string, number>>;
+};
+
+export type InitiativeDecision =
+  | { readonly action: 'deliver' }
+  | {
+      readonly action: 'suppress';
+      readonly reason:
+        | 'budget_exhausted'
+        | 'source_cooldown'
+        | 'device_offline'
+        | 'defer_limit';
+    }
+  | {
+      readonly action: 'defer';
+      readonly reason: 'quiet_hours' | 'focus_active';
+      readonly retryAtMilliseconds: number;
+    };
+
+export const INITIATIVE_QUIET_HOURS_START_HOUR = 22;
+export const INITIATIVE_QUIET_HOURS_END_HOUR = 9;
+export const INITIATIVE_DAILY_UTTERANCE_BUDGET = 6;
+export const INITIATIVE_SOURCE_COOLDOWN_MS = 60 * 60_000;
+export const INITIATIVE_MAX_DEFER_COUNT = 2;
+export const INITIATIVE_FOCUS_DEFER_GRACE_MS = 60_000;
+
+type LocalTimeParts = {
+  readonly calendarDate: string;
+  readonly secondsSinceLocalMidnight: number;
+};
+
+// Argentina has no DST, but resolving through Intl instead of a fixed offset
+// keeps this correct if the country ever reinstates it.
+function resolveLocalTimeParts(nowMilliseconds: number): LocalTimeParts {
+  const formattedPartList = new Intl.DateTimeFormat('en-CA', {
+    timeZone: APOLLO_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date(nowMilliseconds));
+  const partValueByType = new Map(
+    formattedPartList.map((formattedPart) => [formattedPart.type, formattedPart.value]),
+  );
+  // Intl reports midnight as hour "24" in some runtimes; normalize it to 0.
+  const localHour = Number(partValueByType.get('hour')) % 24;
+  const localMinute = Number(partValueByType.get('minute'));
+  const localSecond = Number(partValueByType.get('second'));
+  return {
+    calendarDate: `${partValueByType.get('year')}-${partValueByType.get('month')}-${partValueByType.get('day')}`,
+    secondsSinceLocalMidnight: localHour * 3600 + localMinute * 60 + localSecond,
+  };
+}
+
+export function resolveLocalCalendarDate(nowMilliseconds: number): string {
+  return resolveLocalTimeParts(nowMilliseconds).calendarDate;
+}
+
+export function isWithinQuietHours(nowMilliseconds: number): boolean {
+  const localHour = Math.floor(
+    resolveLocalTimeParts(nowMilliseconds).secondsSinceLocalMidnight / 3600,
+  );
+  return (
+    localHour >= INITIATIVE_QUIET_HOURS_START_HOUR ||
+    localHour < INITIATIVE_QUIET_HOURS_END_HOUR
+  );
+}
+
+export function computeQuietHoursEndMilliseconds(nowMilliseconds: number): number {
+  const { secondsSinceLocalMidnight } = resolveLocalTimeParts(nowMilliseconds);
+  const quietHoursEndSeconds = INITIATIVE_QUIET_HOURS_END_HOUR * 3600;
+  const secondsUntilQuietHoursEnd =
+    secondsSinceLocalMidnight < quietHoursEndSeconds
+      ? quietHoursEndSeconds - secondsSinceLocalMidnight
+      : 24 * 3600 - secondsSinceLocalMidnight + quietHoursEndSeconds;
+  return nowMilliseconds + secondsUntilQuietHoursEnd * 1000;
+}
+
+export type InitiativeCandidateEvaluationInput = {
+  readonly source: InitiativeSource;
+  readonly priority: InitiativePriority;
+  readonly state: InitiativeState | undefined;
+  readonly nowMilliseconds: number;
+  readonly focusEndsAtMilliseconds: number | null;
+  readonly connectionCount: number;
+  readonly deferCount: number;
+};
+
+export function evaluateInitiativeCandidate(
+  input: InitiativeCandidateEvaluationInput,
+): InitiativeDecision {
+  const { state, nowMilliseconds } = input;
+  if (input.priority === 'critical') {
+    return { action: 'deliver' };
+  }
+  // With nobody connected the notify layer would enqueue a card that is
+  // replayed silently on reconnect — self-initiated speech arriving as a stale
+  // mute card is worse than not speaking, and shouldn't burn budget.
+  if (input.connectionCount === 0) {
+    return { action: 'suppress', reason: 'device_offline' };
+  }
+  if (isWithinQuietHours(nowMilliseconds)) {
+    if (input.deferCount >= INITIATIVE_MAX_DEFER_COUNT) {
+      return { action: 'suppress', reason: 'defer_limit' };
+    }
+    return {
+      action: 'defer',
+      reason: 'quiet_hours',
+      retryAtMilliseconds: computeQuietHoursEndMilliseconds(nowMilliseconds),
+    };
+  }
+  const isFocusActive =
+    input.focusEndsAtMilliseconds !== null &&
+    input.focusEndsAtMilliseconds > nowMilliseconds;
+  if (isFocusActive && input.focusEndsAtMilliseconds !== null) {
+    if (input.deferCount >= INITIATIVE_MAX_DEFER_COUNT) {
+      return { action: 'suppress', reason: 'defer_limit' };
+    }
+    // The notify layer would deliver during focus as a silent card; deferring
+    // past the focus window preserves the spoken half of the utterance.
+    return {
+      action: 'defer',
+      reason: 'focus_active',
+      retryAtMilliseconds:
+        input.focusEndsAtMilliseconds + INITIATIVE_FOCUS_DEFER_GRACE_MS,
+    };
+  }
+  const isBudgetExhausted =
+    state !== undefined &&
+    state.budgetDate === resolveLocalCalendarDate(nowMilliseconds) &&
+    state.utterancesUsed >= INITIATIVE_DAILY_UTTERANCE_BUDGET;
+  if (isBudgetExhausted) {
+    return { action: 'suppress', reason: 'budget_exhausted' };
+  }
+  const lastUtteranceAtMilliseconds = state?.lastUtteranceAtBySource[input.source];
+  const isSourceCoolingDown =
+    lastUtteranceAtMilliseconds !== undefined &&
+    nowMilliseconds - lastUtteranceAtMilliseconds < INITIATIVE_SOURCE_COOLDOWN_MS;
+  if (isSourceCoolingDown) {
+    return { action: 'suppress', reason: 'source_cooldown' };
+  }
+  return { action: 'deliver' };
+}
+
+export function recordInitiativeDelivery(
+  state: InitiativeState | undefined,
+  source: InitiativeSource,
+  priority: InitiativePriority,
+  nowMilliseconds: number,
+): InitiativeState {
+  const currentCalendarDate = resolveLocalCalendarDate(nowMilliseconds);
+  const utterancesUsedToday =
+    state !== undefined && state.budgetDate === currentCalendarDate
+      ? state.utterancesUsed
+      : 0;
+  // Critical utterances bypass the budget on evaluation, so counting them here
+  // would let a low-battery night starve the next day's normal utterances.
+  const shouldCountAgainstBudget = priority !== 'critical';
+  return {
+    budgetDate: currentCalendarDate,
+    utterancesUsed: utterancesUsedToday + (shouldCountAgainstBudget ? 1 : 0),
+    lastUtteranceAtBySource: {
+      ...state?.lastUtteranceAtBySource,
+      [source]: nowMilliseconds,
+    },
+  };
+}
+
+export function parseStoredInitiativeState(
+  storedValue: string,
+): InitiativeState | undefined {
+  try {
+    const parsedState = initiativeStateSchema.safeParse(JSON.parse(storedValue));
+    return parsedState.success ? parsedState.data : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/initiative/logic.ts
+++ b/src/initiative/logic.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { APOLLO_TIME_ZONE } from '@/persona/clock';
+import type { DeskSoundEffectName } from '@/protocol/schema';
 
 export const initiativeSourceSchema = z.enum([
   'firmware_changelog',
@@ -28,6 +29,16 @@ export type InitiativeState = {
   readonly lastUtteranceAtBySource: Readonly<Record<string, number>>;
 };
 
+export type InitiativeDeliveryOutcome = 'delivered' | 'suppressed' | 'deferred';
+
+export type InitiativeUtteranceInput = {
+  readonly source: InitiativeSource;
+  readonly priority: InitiativePriority;
+  readonly message: string;
+  readonly earconName?: DeskSoundEffectName;
+  readonly deferCount?: number;
+};
+
 export type InitiativeDecision =
   | { readonly action: 'deliver' }
   | {
@@ -50,6 +61,11 @@ export const INITIATIVE_DAILY_UTTERANCE_BUDGET = 6;
 export const INITIATIVE_SOURCE_COOLDOWN_MS = 60 * 60_000;
 export const INITIATIVE_MAX_DEFER_COUNT = 2;
 export const INITIATIVE_FOCUS_DEFER_GRACE_MS = 60_000;
+// A deferred utterance whose retry lands in a suppressing moment (device
+// offline at 09:00, budget spent) re-schedules itself instead of vanishing;
+// this bounds that loop.
+export const INITIATIVE_MAX_RETRY_ATTEMPTS = 5;
+export const INITIATIVE_SUPPRESSED_RETRY_DELAY_SECONDS = 30 * 60;
 
 type LocalTimeParts = {
   readonly calendarDate: string;
@@ -120,14 +136,16 @@ export function evaluateInitiativeCandidate(
   input: InitiativeCandidateEvaluationInput,
 ): InitiativeDecision {
   const { state, nowMilliseconds } = input;
-  if (input.priority === 'critical') {
-    return { action: 'deliver' };
-  }
   // With nobody connected the notify layer would enqueue a card that is
   // replayed silently on reconnect — self-initiated speech arriving as a stale
-  // mute card is worse than not speaking, and shouldn't burn budget.
+  // mute card is worse than not speaking, and shouldn't burn budget. This
+  // outranks critical: suppressing keeps the caller's cooldown unwritten, so
+  // the utterance retries promptly once the device reconnects.
   if (input.connectionCount === 0) {
     return { action: 'suppress', reason: 'device_offline' };
+  }
+  if (input.priority === 'critical') {
+    return { action: 'deliver' };
   }
   if (isWithinQuietHours(nowMilliseconds)) {
     if (input.deferCount >= INITIATIVE_MAX_DEFER_COUNT) {

--- a/src/memory/__tests__/consolidate.spec.ts
+++ b/src/memory/__tests__/consolidate.spec.ts
@@ -9,6 +9,7 @@ import {
   OWNER_MEMORY_MAX_FACT_COUNT,
   OWNER_MEMORY_STALE_FACT_WINDOW_MS,
   parseMemoryExtractionResult,
+  parseStoredMemoryIndexIntentList,
   parseStoredOwnerMemoryState,
   renderOwnerMemoryBlock,
   seedOwnerFactsFromMemoryBlock,
@@ -317,6 +318,22 @@ describe('renderOwnerMemoryBlock', () => {
           renderedLine === '',
       ).toBe(true);
     }
+  });
+});
+
+describe('parseStoredMemoryIndexIntentList', () => {
+  it('round-trips an intent list', () => {
+    const intentList = [{ memoryId: 'memory-1', content: 'Toma mate amargo' }];
+    expect(parseStoredMemoryIndexIntentList(JSON.stringify(intentList))).toEqual(
+      intentList,
+    );
+    expect(parseStoredMemoryIndexIntentList('[]')).toEqual([]);
+  });
+
+  it('rejects garbage', () => {
+    expect(parseStoredMemoryIndexIntentList('[{"memoryId":')).toBeUndefined();
+    expect(parseStoredMemoryIndexIntentList('[{"memoryId":"x"}]')).toBeUndefined();
+    expect(parseStoredMemoryIndexIntentList('null')).toBeUndefined();
   });
 });
 

--- a/src/memory/__tests__/consolidate.spec.ts
+++ b/src/memory/__tests__/consolidate.spec.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildExtractionRetryMessageList,
+  buildMemoryExtractionMessageList,
+  flattenRecentHistoryToTranscript,
+  mergeOwnerFacts,
+  OWNER_MEMORY_BLOCK_MAX_CHARACTERS,
+  OWNER_MEMORY_MAX_FACT_COUNT,
+  OWNER_MEMORY_STALE_FACT_WINDOW_MS,
+  parseMemoryExtractionResult,
+  parseStoredOwnerMemoryState,
+  renderOwnerMemoryBlock,
+  seedOwnerFactsFromMemoryBlock,
+  type MemoryExtractionResult,
+  type OwnerFact,
+} from '@/memory/consolidate';
+
+const NOW_MILLISECONDS = 1_786_540_000_000;
+
+function createFact(overrides: Partial<OwnerFact> = {}): OwnerFact {
+  return {
+    id: 'fact-1',
+    content: 'Toma mate amargo',
+    category: 'preference',
+    lastConfirmedAtMilliseconds: NOW_MILLISECONDS,
+    sourceCount: 1,
+    ...overrides,
+  };
+}
+
+function createExtraction(
+  overrides: Partial<MemoryExtractionResult> = {},
+): MemoryExtractionResult {
+  return {
+    newFactList: [],
+    reinforcedFactIdList: [],
+    staleFactIdList: [],
+    ...overrides,
+  };
+}
+
+function createSequentialIdentifierFactory(): () => string {
+  let nextIdentifierNumber = 0;
+  return () => {
+    nextIdentifierNumber += 1;
+    return `generated-${nextIdentifierNumber}`;
+  };
+}
+
+describe('flattenRecentHistoryToTranscript', () => {
+  it('labels speakers and joins text parts', () => {
+    const transcript = flattenRecentHistoryToTranscript([
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'Hola' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [{ type: 'text', text: '¿Cómo andás?' }],
+      },
+    ]);
+    expect(transcript).toBe('Usuario: Hola\nApollo: ¿Cómo andás?');
+  });
+
+  it('skips messages without spoken text', () => {
+    const transcript = flattenRecentHistoryToTranscript([
+      { id: '1', role: 'user', parts: [{ type: 'tool-call', toolName: 'set_timer' }] },
+      { id: '2', role: 'user', parts: [{ type: 'text', text: 'Poné un timer' }] },
+    ]);
+    expect(transcript).toBe('Usuario: Poné un timer');
+  });
+});
+
+describe('parseMemoryExtractionResult', () => {
+  const validExtractionJson = JSON.stringify(
+    createExtraction({
+      newFactList: [{ content: 'Trabaja en Apollo', category: 'context' }],
+    }),
+  );
+
+  it('parses clean json', () => {
+    const extraction = parseMemoryExtractionResult(validExtractionJson);
+    expect(extraction?.newFactList).toHaveLength(1);
+  });
+
+  it('parses json wrapped in a fence', () => {
+    const extraction = parseMemoryExtractionResult(
+      '```json\n' + validExtractionJson + '\n```',
+    );
+    expect(extraction?.newFactList).toHaveLength(1);
+  });
+
+  it('parses json wrapped in prose', () => {
+    const extraction = parseMemoryExtractionResult(
+      `Acá está el resultado:\n${validExtractionJson}\nEspero que sirva.`,
+    );
+    expect(extraction?.newFactList).toHaveLength(1);
+  });
+
+  it('rejects text without json', () => {
+    expect(parseMemoryExtractionResult('no hay nada acá')).toBeUndefined();
+  });
+
+  it('rejects json with the wrong shape', () => {
+    expect(parseMemoryExtractionResult('{"newFactList": "no"}')).toBeUndefined();
+  });
+});
+
+describe('buildMemoryExtractionMessageList', () => {
+  it('lists existing facts with ids for the model to reference', () => {
+    const messageList = buildMemoryExtractionMessageList({
+      transcriptText: 'Usuario: Hola',
+      existingFactList: [createFact()],
+      nowIso: '2026-08-12T06:00:00.000Z',
+    });
+    expect(messageList).toHaveLength(2);
+    expect(messageList[1]?.content).toContain('fact-1: [preference] Toma mate amargo');
+    expect(messageList[1]?.content).toContain('Usuario: Hola');
+  });
+});
+
+describe('buildExtractionRetryMessageList', () => {
+  it('appends the invalid response and a corrective instruction', () => {
+    const originalMessageList = buildMemoryExtractionMessageList({
+      transcriptText: 'Usuario: Hola',
+      existingFactList: [],
+      nowIso: '2026-08-12T06:00:00.000Z',
+    });
+    const retryMessageList = buildExtractionRetryMessageList(
+      originalMessageList,
+      'respuesta inválida',
+    );
+    expect(retryMessageList).toHaveLength(4);
+    expect(retryMessageList[2]).toEqual({
+      role: 'assistant',
+      content: 'respuesta inválida',
+    });
+    expect(retryMessageList[3]?.content).toContain('únicamente el JSON');
+  });
+});
+
+describe('seedOwnerFactsFromMemoryBlock', () => {
+  it('migrates legacy block lines into facts', () => {
+    const seededFactList = seedOwnerFactsFromMemoryBlock({
+      blockContent: '\n- Le gusta el rock nacional\n- Toma mate amargo',
+      knownFactList: [createFact()],
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(seededFactList).toHaveLength(2);
+    expect(seededFactList[1]?.content).toBe('Le gusta el rock nacional');
+    expect(seededFactList[1]?.category).toBe('fact');
+  });
+
+  it('skips lines already known, ignoring case and trailing periods', () => {
+    const seededFactList = seedOwnerFactsFromMemoryBlock({
+      blockContent: '- toma mate amargo.',
+      knownFactList: [createFact()],
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(seededFactList).toHaveLength(1);
+  });
+
+  it('ignores headers and blank lines', () => {
+    const seededFactList = seedOwnerFactsFromMemoryBlock({
+      blockContent: 'Preferencias:\n\n- Nueva preferencia',
+      knownFactList: [],
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(seededFactList).toHaveLength(1);
+    expect(seededFactList[0]?.content).toBe('Nueva preferencia');
+  });
+});
+
+describe('mergeOwnerFacts', () => {
+  it('adds new facts and reports them as genuinely new', () => {
+    const merge = mergeOwnerFacts({
+      existingFactList: [createFact()],
+      extraction: createExtraction({
+        newFactList: [
+          { content: 'Tiene una gata que se llama Mora', category: 'relationship' },
+        ],
+      }),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList).toHaveLength(2);
+    expect(merge.genuinelyNewFactList).toHaveLength(1);
+  });
+
+  it('dedupes new facts against existing content', () => {
+    const merge = mergeOwnerFacts({
+      existingFactList: [createFact()],
+      extraction: createExtraction({
+        newFactList: [{ content: 'Toma mate amargo.', category: 'preference' }],
+      }),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList).toHaveLength(1);
+    expect(merge.genuinelyNewFactList).toHaveLength(0);
+  });
+
+  it('reinforces referenced facts', () => {
+    const staleConfirmedAt = NOW_MILLISECONDS - OWNER_MEMORY_STALE_FACT_WINDOW_MS;
+    const merge = mergeOwnerFacts({
+      existingFactList: [
+        createFact({ lastConfirmedAtMilliseconds: staleConfirmedAt, sourceCount: 2 }),
+      ],
+      extraction: createExtraction({ reinforcedFactIdList: ['fact-1'] }),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList[0]?.sourceCount).toBe(3);
+    expect(merge.nextFactList[0]?.lastConfirmedAtMilliseconds).toBe(NOW_MILLISECONDS);
+  });
+
+  it('drops facts the extraction marked stale', () => {
+    const merge = mergeOwnerFacts({
+      existingFactList: [createFact()],
+      extraction: createExtraction({ staleFactIdList: ['fact-1'] }),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList).toHaveLength(0);
+  });
+
+  it('decays facts unconfirmed past the window', () => {
+    const merge = mergeOwnerFacts({
+      existingFactList: [
+        createFact({
+          lastConfirmedAtMilliseconds:
+            NOW_MILLISECONDS - OWNER_MEMORY_STALE_FACT_WINDOW_MS - 1,
+        }),
+      ],
+      extraction: createExtraction(),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList).toHaveLength(0);
+  });
+
+  it('keeps a reinforced fact that would otherwise decay', () => {
+    const merge = mergeOwnerFacts({
+      existingFactList: [
+        createFact({
+          lastConfirmedAtMilliseconds:
+            NOW_MILLISECONDS - OWNER_MEMORY_STALE_FACT_WINDOW_MS - 1,
+        }),
+      ],
+      extraction: createExtraction({ reinforcedFactIdList: ['fact-1'] }),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList).toHaveLength(1);
+  });
+
+  it('caps the list evicting the weakest facts first', () => {
+    const existingFactList = Array.from(
+      { length: OWNER_MEMORY_MAX_FACT_COUNT },
+      (_, factIndex) =>
+        createFact({
+          id: `existing-${factIndex}`,
+          content: `Hecho número ${factIndex}`,
+          sourceCount: 5,
+        }),
+    );
+    const merge = mergeOwnerFacts({
+      existingFactList,
+      extraction: createExtraction({
+        newFactList: [{ content: 'Hecho recién llegado', category: 'fact' }],
+      }),
+      nowMilliseconds: NOW_MILLISECONDS,
+      createIdentifier: createSequentialIdentifierFactory(),
+    });
+    expect(merge.nextFactList).toHaveLength(OWNER_MEMORY_MAX_FACT_COUNT);
+    // The newcomer has sourceCount 1 against a wall of 5s: it is the eviction
+    // victim and must not be reported as genuinely new.
+    expect(
+      merge.nextFactList.some((fact) => fact.content === 'Hecho recién llegado'),
+    ).toBe(false);
+    expect(merge.genuinelyNewFactList).toHaveLength(0);
+  });
+});
+
+describe('renderOwnerMemoryBlock', () => {
+  it('groups facts under Spanish category headers', () => {
+    const renderedBlock = renderOwnerMemoryBlock([
+      createFact(),
+      createFact({ id: 'fact-2', content: 'Trabaja en Apollo', category: 'context' }),
+    ]);
+    expect(renderedBlock).toBe(
+      'Preferencias:\n- Toma mate amargo\n\nContexto actual:\n- Trabaja en Apollo',
+    );
+  });
+
+  it('omits empty categories', () => {
+    expect(renderOwnerMemoryBlock([createFact()])).not.toContain('Relaciones');
+  });
+
+  it('truncates on a line boundary at the character cap', () => {
+    const longFactList = Array.from({ length: 100 }, (_, factIndex) =>
+      createFact({
+        id: `long-${factIndex}`,
+        content: `Hecho ${factIndex} ${'relleno '.repeat(12)}`.trim(),
+        category: 'fact',
+      }),
+    );
+    const renderedBlock = renderOwnerMemoryBlock(longFactList);
+    expect(renderedBlock.length).toBeLessThanOrEqual(OWNER_MEMORY_BLOCK_MAX_CHARACTERS);
+    expect(renderedBlock.endsWith('\n')).toBe(false);
+    for (const renderedLine of renderedBlock.split('\n')) {
+      expect(
+        renderedLine.startsWith('- ') ||
+          renderedLine.endsWith(':') ||
+          renderedLine === '',
+      ).toBe(true);
+    }
+  });
+});
+
+describe('parseStoredOwnerMemoryState', () => {
+  it('round-trips a stored state', () => {
+    const state = {
+      factList: [createFact()],
+      lastConsolidatedAtMilliseconds: NOW_MILLISECONDS,
+      lastProcessedLeafId: 'leaf-1',
+    };
+    expect(parseStoredOwnerMemoryState(JSON.stringify(state))).toEqual(state);
+  });
+
+  it('rejects garbage', () => {
+    expect(parseStoredOwnerMemoryState('{"factList":')).toBeUndefined();
+    expect(parseStoredOwnerMemoryState('{"factList":[]}')).toBeUndefined();
+    expect(parseStoredOwnerMemoryState('null')).toBeUndefined();
+  });
+});

--- a/src/memory/consolidate.ts
+++ b/src/memory/consolidate.ts
@@ -1,0 +1,316 @@
+import type { SessionMessage } from 'agents/experimental/memory/session';
+import { z } from 'zod';
+
+import type { OpenRouterChatMessage } from '@/voice/llm';
+
+export const OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET = 48_000;
+export const OWNER_MEMORY_MAX_FACT_COUNT = 50;
+export const OWNER_MEMORY_STALE_FACT_WINDOW_MS = 60 * 24 * 60 * 60_000;
+// Fits comfortably inside the memory block's 1100-token budget.
+export const OWNER_MEMORY_BLOCK_MAX_CHARACTERS = 4_000;
+export const OWNER_MEMORY_MIN_RUN_INTERVAL_MS = 20 * 60 * 60_000;
+// The DO scheduler evaluates cron in UTC: 06:00 UTC is 03:00 in Buenos Aires.
+export const OWNER_MEMORY_CONSOLIDATION_CRON = '0 6 * * *';
+
+export const ownerFactCategorySchema = z.enum([
+  'preference',
+  'fact',
+  'context',
+  'relationship',
+]);
+
+export type OwnerFactCategory = z.infer<typeof ownerFactCategorySchema>;
+
+const ownerFactSchema = z.object({
+  id: z.string().min(1),
+  content: z.string().min(1),
+  category: ownerFactCategorySchema,
+  lastConfirmedAtMilliseconds: z.number(),
+  sourceCount: z.number().int().min(1),
+});
+
+export type OwnerFact = {
+  readonly id: string;
+  readonly content: string;
+  readonly category: OwnerFactCategory;
+  readonly lastConfirmedAtMilliseconds: number;
+  readonly sourceCount: number;
+};
+
+const ownerMemoryStateSchema = z.object({
+  factList: z.array(ownerFactSchema),
+  lastConsolidatedAtMilliseconds: z.number(),
+  lastProcessedLeafId: z.string().optional(),
+});
+
+export type OwnerMemoryState = {
+  readonly factList: readonly OwnerFact[];
+  readonly lastConsolidatedAtMilliseconds: number;
+  readonly lastProcessedLeafId?: string;
+};
+
+export const memoryExtractionResultSchema = z.object({
+  newFactList: z
+    .array(
+      z.object({
+        content: z.string().min(1).max(300),
+        category: ownerFactCategorySchema,
+      }),
+    )
+    .max(20),
+  reinforcedFactIdList: z.array(z.string()).max(80),
+  staleFactIdList: z.array(z.string()).max(80),
+});
+
+export type MemoryExtractionResult = z.infer<typeof memoryExtractionResultSchema>;
+
+export function flattenRecentHistoryToTranscript(
+  messageList: readonly SessionMessage[],
+): string {
+  const lineList: string[] = [];
+  for (const message of messageList) {
+    const spokenText = message.parts
+      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .map((part) => part.text)
+      .join(' ')
+      .trim();
+    if (spokenText.length === 0) {
+      continue;
+    }
+    const speakerLabel = message.role === 'user' ? 'Usuario' : 'Apollo';
+    lineList.push(`${speakerLabel}: ${spokenText}`);
+  }
+  return lineList.join('\n');
+}
+
+const EXTRACTION_SYSTEM_PROMPT = [
+  'Sos el módulo de memoria de Apollo, un asistente de escritorio. Analizás la',
+  'transcripción reciente de conversaciones con su dueño y mantenés una lista de',
+  'hechos duraderos sobre esa persona: preferencias, datos personales, contexto',
+  'en curso (proyectos, trabajo, rutinas) y relaciones (personas, mascotas).',
+  'Ignorá lo efímero: timers, clima, pedidos puntuales ya resueltos.',
+  '',
+  'Respondé únicamente con JSON válido, sin markdown ni texto adicional, con',
+  'esta forma exacta:',
+  '{"newFactList":[{"content":"una oración en español, máximo 300 caracteres",',
+  '"category":"preference"|"fact"|"context"|"relationship"}],',
+  '"reinforcedFactIdList":["id de un hecho existente que la transcripción vuelve a confirmar"],',
+  '"staleFactIdList":["id de un hecho existente que la transcripción contradice o dio de baja"]}',
+  '',
+  'Máximo 20 hechos nuevos. No repitas hechos existentes como nuevos: si un',
+  'hecho ya está en la lista, referencialo por id en reinforcedFactIdList.',
+].join('\n');
+
+export function buildMemoryExtractionMessageList(input: {
+  readonly transcriptText: string;
+  readonly existingFactList: readonly OwnerFact[];
+  readonly nowIso: string;
+}): readonly OpenRouterChatMessage[] {
+  const existingFactsText =
+    input.existingFactList.length === 0
+      ? '(ninguno todavía)'
+      : input.existingFactList
+          .map((fact) => `${fact.id}: [${fact.category}] ${fact.content}`)
+          .join('\n');
+  return [
+    { role: 'system', content: EXTRACTION_SYSTEM_PROMPT },
+    {
+      role: 'user',
+      content:
+        `Hechos existentes:\n${existingFactsText}\n\n` +
+        `Transcripción reciente (consolidación del ${input.nowIso}):\n${input.transcriptText}`,
+    },
+  ];
+}
+
+export function buildExtractionRetryMessageList(
+  previousMessageList: readonly OpenRouterChatMessage[],
+  invalidResponseText: string,
+): readonly OpenRouterChatMessage[] {
+  return [
+    ...previousMessageList,
+    { role: 'assistant', content: invalidResponseText },
+    {
+      role: 'user',
+      content:
+        'Tu respuesta no fue JSON válido. Respondé únicamente el JSON pedido, sin ningún otro texto.',
+    },
+  ];
+}
+
+export function parseMemoryExtractionResult(
+  rawText: string,
+): MemoryExtractionResult | undefined {
+  // Models wrap JSON in fences or prose despite instructions; the outermost
+  // brace pair is the only part worth trying to parse.
+  const withoutFences = rawText.replace(/```(?:json)?/gi, '');
+  const firstBraceIndex = withoutFences.indexOf('{');
+  const lastBraceIndex = withoutFences.lastIndexOf('}');
+  if (firstBraceIndex === -1 || lastBraceIndex <= firstBraceIndex) {
+    return undefined;
+  }
+  try {
+    const parsedResult = memoryExtractionResultSchema.safeParse(
+      JSON.parse(withoutFences.slice(firstBraceIndex, lastBraceIndex + 1)),
+    );
+    return parsedResult.success ? parsedResult.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeFactContent(content: string): string {
+  return content.trim().toLowerCase().replace(/\s+/g, ' ').replace(/\.+$/, '');
+}
+
+// The legacy memory block (and same-day remember_fact appends) hold facts that
+// exist nowhere else in structured form; folding them in here both migrates
+// the old block on first run and closes the race with a fact remembered after
+// the transcript window was read.
+export function seedOwnerFactsFromMemoryBlock(input: {
+  readonly blockContent: string;
+  readonly knownFactList: readonly OwnerFact[];
+  readonly nowMilliseconds: number;
+  readonly createIdentifier: () => string;
+}): readonly OwnerFact[] {
+  const knownContentSet = new Set(
+    input.knownFactList.map((fact) => normalizeFactContent(fact.content)),
+  );
+  const seededFactList: OwnerFact[] = [...input.knownFactList];
+  for (const blockLine of input.blockContent.split('\n')) {
+    const trimmedLine = blockLine.trim();
+    if (!trimmedLine.startsWith('- ')) {
+      continue;
+    }
+    const factContent = trimmedLine.slice(2).trim();
+    if (factContent.length === 0) {
+      continue;
+    }
+    const normalizedContent = normalizeFactContent(factContent);
+    if (knownContentSet.has(normalizedContent)) {
+      continue;
+    }
+    knownContentSet.add(normalizedContent);
+    seededFactList.push({
+      id: input.createIdentifier(),
+      content: factContent,
+      category: 'fact',
+      lastConfirmedAtMilliseconds: input.nowMilliseconds,
+      sourceCount: 1,
+    });
+  }
+  return seededFactList;
+}
+
+export function mergeOwnerFacts(input: {
+  readonly existingFactList: readonly OwnerFact[];
+  readonly extraction: MemoryExtractionResult;
+  readonly nowMilliseconds: number;
+  readonly createIdentifier: () => string;
+}): {
+  readonly nextFactList: readonly OwnerFact[];
+  readonly genuinelyNewFactList: readonly OwnerFact[];
+} {
+  const reinforcedIdSet = new Set(input.extraction.reinforcedFactIdList);
+  const staleIdSet = new Set(input.extraction.staleFactIdList);
+  const decayCutoffMilliseconds =
+    input.nowMilliseconds - OWNER_MEMORY_STALE_FACT_WINDOW_MS;
+
+  const survivingFactList = input.existingFactList
+    .filter((fact) => !staleIdSet.has(fact.id))
+    .map((fact) =>
+      reinforcedIdSet.has(fact.id)
+        ? {
+            ...fact,
+            lastConfirmedAtMilliseconds: input.nowMilliseconds,
+            sourceCount: fact.sourceCount + 1,
+          }
+        : fact,
+    )
+    .filter((fact) => fact.lastConfirmedAtMilliseconds >= decayCutoffMilliseconds);
+
+  const knownContentSet = new Set(
+    survivingFactList.map((fact) => normalizeFactContent(fact.content)),
+  );
+  const genuinelyNewFactList: OwnerFact[] = [];
+  for (const extractedFact of input.extraction.newFactList) {
+    const normalizedContent = normalizeFactContent(extractedFact.content);
+    if (knownContentSet.has(normalizedContent)) {
+      continue;
+    }
+    knownContentSet.add(normalizedContent);
+    genuinelyNewFactList.push({
+      id: input.createIdentifier(),
+      content: extractedFact.content,
+      category: extractedFact.category,
+      lastConfirmedAtMilliseconds: input.nowMilliseconds,
+      sourceCount: 1,
+    });
+  }
+
+  const nextFactList = [...survivingFactList, ...genuinelyNewFactList]
+    .toSorted((leftFact, rightFact) => {
+      if (leftFact.sourceCount !== rightFact.sourceCount) {
+        return rightFact.sourceCount - leftFact.sourceCount;
+      }
+      return rightFact.lastConfirmedAtMilliseconds - leftFact.lastConfirmedAtMilliseconds;
+    })
+    .slice(0, OWNER_MEMORY_MAX_FACT_COUNT);
+
+  const keptIdSet = new Set(nextFactList.map((fact) => fact.id));
+  return {
+    nextFactList,
+    genuinelyNewFactList: genuinelyNewFactList.filter((fact) => keptIdSet.has(fact.id)),
+  };
+}
+
+const CATEGORY_HEADER_LIST: readonly {
+  readonly category: OwnerFactCategory;
+  readonly header: string;
+}[] = [
+  { category: 'preference', header: 'Preferencias' },
+  { category: 'fact', header: 'Datos' },
+  { category: 'context', header: 'Contexto actual' },
+  { category: 'relationship', header: 'Relaciones' },
+];
+
+export function renderOwnerMemoryBlock(factList: readonly OwnerFact[]): string {
+  const sectionList: string[] = [];
+  for (const { category, header } of CATEGORY_HEADER_LIST) {
+    const categoryFactList = factList.filter((fact) => fact.category === category);
+    if (categoryFactList.length === 0) {
+      continue;
+    }
+    sectionList.push(
+      `${header}:\n${categoryFactList.map((fact) => `- ${fact.content}`).join('\n')}`,
+    );
+  }
+  const renderedBlock = sectionList.join('\n\n');
+  if (renderedBlock.length <= OWNER_MEMORY_BLOCK_MAX_CHARACTERS) {
+    return renderedBlock;
+  }
+  // Truncate on a line boundary: a fact cut mid-sentence reads as nonsense in
+  // the prompt.
+  const lineList = renderedBlock.split('\n');
+  const keptLineList: string[] = [];
+  let renderedLength = 0;
+  for (const line of lineList) {
+    if (renderedLength + line.length + 1 > OWNER_MEMORY_BLOCK_MAX_CHARACTERS) {
+      break;
+    }
+    keptLineList.push(line);
+    renderedLength += line.length + 1;
+  }
+  return keptLineList.join('\n');
+}
+
+export function parseStoredOwnerMemoryState(
+  storedValue: string,
+): OwnerMemoryState | undefined {
+  try {
+    const parsedState = ownerMemoryStateSchema.safeParse(JSON.parse(storedValue));
+    return parsedState.success ? parsedState.data : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/memory/consolidate.ts
+++ b/src/memory/consolidate.ts
@@ -304,6 +304,29 @@ export function renderOwnerMemoryBlock(factList: readonly OwnerFact[]): string {
   return keptLineList.join('\n');
 }
 
+const memoryIndexIntentListSchema = z.array(
+  z.object({
+    memoryId: z.string().min(1),
+    content: z.string().min(1),
+  }),
+);
+
+export type MemoryIndexIntent = {
+  readonly memoryId: string;
+  readonly content: string;
+};
+
+export function parseStoredMemoryIndexIntentList(
+  storedValue: string,
+): readonly MemoryIndexIntent[] | undefined {
+  try {
+    const parsedList = memoryIndexIntentListSchema.safeParse(JSON.parse(storedValue));
+    return parsedList.success ? parsedList.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function parseStoredOwnerMemoryState(
   storedValue: string,
 ): OwnerMemoryState | undefined {

--- a/src/memory/nightly.ts
+++ b/src/memory/nightly.ts
@@ -8,6 +8,7 @@ import {
   OWNER_MEMORY_MIN_RUN_INTERVAL_MS,
   OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
   parseMemoryExtractionResult,
+  parseStoredMemoryIndexIntentList,
   parseStoredOwnerMemoryState,
   renderOwnerMemoryBlock,
   seedOwnerFactsFromMemoryBlock,
@@ -24,6 +25,35 @@ import { enqueueMemoryIndexJob } from '@/queues/consume';
 import { chatWithOpenRouter } from '@/voice/llm';
 
 export const OWNER_MEMORY_STATE_PREFERENCE_KEY = 'ownerMemoryState';
+export const OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY = 'ownerMemoryIndexIntents';
+
+async function drainMemoryIndexIntents(
+  dependencies: OwnerMemoryConsolidationDependencies,
+): Promise<void> {
+  const storedIntentList = await getSessionPreference(
+    dependencies.sqlExecutor,
+    OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY,
+  );
+  const intentList =
+    storedIntentList === null
+      ? undefined
+      : parseStoredMemoryIndexIntentList(storedIntentList);
+  if (intentList === undefined || intentList.length === 0) {
+    return;
+  }
+  for (const intent of intentList) {
+    await enqueueMemoryIndexJob(dependencies.environment, {
+      memoryId: intent.memoryId,
+      content: intent.content,
+      deviceId: dependencies.deviceId,
+    });
+  }
+  await setSessionPreference(
+    dependencies.sqlExecutor,
+    OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY,
+    '[]',
+  );
+}
 
 export type OwnerMemoryConsolidationDependencies = {
   readonly sqlExecutor: MemorySqlExecutor;
@@ -47,6 +77,7 @@ export async function runOwnerMemoryConsolidation(
   );
   const state =
     storedState === null ? undefined : parseStoredOwnerMemoryState(storedState);
+  await drainMemoryIndexIntents(dependencies);
   if (
     state !== undefined &&
     nowMilliseconds - state.lastConsolidatedAtMilliseconds <
@@ -120,22 +151,36 @@ export async function runOwnerMemoryConsolidation(
   // Decayed facts stay in the memories table and Vectorize on purpose: that
   // layer is the provenance log recall_memory searches, while the consolidated
   // block only governs what occupies prompt budget. The existence check makes
-  // the insert idempotent, and the index job is enqueued even for an existing
-  // row — Vectorize upserts by memory id, so a run that died between insert
-  // and enqueue heals here instead of leaving the row unsearchable forever.
+  // the insert idempotent; already-present rows are skipped outright because
+  // any enqueue they might have missed was healed by the intent drain above.
   for (const genuinelyNewFact of merge.genuinelyNewFactList) {
     const existingMemoryId = await findMemoryRecordIdByContent(
       sqlExecutor,
       genuinelyNewFact.content,
     );
-    const memoryId =
-      existingMemoryId ??
-      (await addMemoryRecord(sqlExecutor, genuinelyNewFact.content)).id;
+    if (existingMemoryId !== undefined) {
+      continue;
+    }
+    const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
+    // The intent is durable before the enqueue and cleared right after, so a
+    // crash in between re-enqueues exactly this row on the next run: indexing
+    // is at-least-once (Vectorize upserts by id) without ever re-enqueueing
+    // rows whose indexing already succeeded.
+    await setSessionPreference(
+      sqlExecutor,
+      OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY,
+      JSON.stringify([{ memoryId: memoryRecord.id, content: genuinelyNewFact.content }]),
+    );
     await enqueueMemoryIndexJob(dependencies.environment, {
-      memoryId,
+      memoryId: memoryRecord.id,
       content: genuinelyNewFact.content,
       deviceId: dependencies.deviceId,
     });
+    await setSessionPreference(
+      sqlExecutor,
+      OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY,
+      '[]',
+    );
   }
   // The checkpoint is written only after every durable output above succeeded:
   // a failure mid-run leaves lastProcessedLeafId untouched, so the next night

--- a/src/memory/nightly.ts
+++ b/src/memory/nightly.ts
@@ -120,19 +120,19 @@ export async function runOwnerMemoryConsolidation(
   // Decayed facts stay in the memories table and Vectorize on purpose: that
   // layer is the provenance log recall_memory searches, while the consolidated
   // block only governs what occupies prompt budget. The existence check makes
-  // the inserts idempotent — a run that failed after some inserts reprocesses
-  // this window next night without duplicating rows or index entries.
+  // the insert idempotent, and the index job is enqueued even for an existing
+  // row — Vectorize upserts by memory id, so a run that died between insert
+  // and enqueue heals here instead of leaving the row unsearchable forever.
   for (const genuinelyNewFact of merge.genuinelyNewFactList) {
     const existingMemoryId = await findMemoryRecordIdByContent(
       sqlExecutor,
       genuinelyNewFact.content,
     );
-    if (existingMemoryId !== undefined) {
-      continue;
-    }
-    const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
+    const memoryId =
+      existingMemoryId ??
+      (await addMemoryRecord(sqlExecutor, genuinelyNewFact.content)).id;
     await enqueueMemoryIndexJob(dependencies.environment, {
-      memoryId: memoryRecord.id,
+      memoryId,
       content: genuinelyNewFact.content,
       deviceId: dependencies.deviceId,
     });

--- a/src/memory/nightly.ts
+++ b/src/memory/nightly.ts
@@ -15,6 +15,7 @@ import {
 } from '@/memory/consolidate';
 import {
   addMemoryRecord,
+  findMemoryRecordIdByContent,
   getSessionPreference,
   setSessionPreference,
   type MemorySqlExecutor,
@@ -118,8 +119,17 @@ export async function runOwnerMemoryConsolidation(
   await session.refreshSystemPrompt();
   // Decayed facts stay in the memories table and Vectorize on purpose: that
   // layer is the provenance log recall_memory searches, while the consolidated
-  // block only governs what occupies prompt budget.
+  // block only governs what occupies prompt budget. The existence check makes
+  // the inserts idempotent — a run that failed after some inserts reprocesses
+  // this window next night without duplicating rows or index entries.
   for (const genuinelyNewFact of merge.genuinelyNewFactList) {
+    const existingMemoryId = await findMemoryRecordIdByContent(
+      sqlExecutor,
+      genuinelyNewFact.content,
+    );
+    if (existingMemoryId !== undefined) {
+      continue;
+    }
     const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
     await enqueueMemoryIndexJob(dependencies.environment, {
       memoryId: memoryRecord.id,

--- a/src/memory/nightly.ts
+++ b/src/memory/nightly.ts
@@ -1,0 +1,153 @@
+import type { Session } from 'agents/experimental/memory/session';
+
+import {
+  buildExtractionRetryMessageList,
+  buildMemoryExtractionMessageList,
+  flattenRecentHistoryToTranscript,
+  mergeOwnerFacts,
+  OWNER_MEMORY_MIN_RUN_INTERVAL_MS,
+  OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
+  parseMemoryExtractionResult,
+  parseStoredOwnerMemoryState,
+  renderOwnerMemoryBlock,
+  seedOwnerFactsFromMemoryBlock,
+  type OwnerMemoryState,
+} from '@/memory/consolidate';
+import {
+  addMemoryRecord,
+  getSessionPreference,
+  setSessionPreference,
+  type MemorySqlExecutor,
+} from '@/memory/store';
+import { enqueueMemoryIndexJob } from '@/queues/consume';
+import { chatWithOpenRouter } from '@/voice/llm';
+
+export const OWNER_MEMORY_STATE_PREFERENCE_KEY = 'ownerMemoryState';
+
+export type OwnerMemoryConsolidationDependencies = {
+  readonly sqlExecutor: MemorySqlExecutor;
+  readonly session: Session;
+  readonly environment: Env;
+  readonly deviceId: string;
+  readonly nowMilliseconds: number;
+  readonly createIdentifier: () => string;
+};
+
+// Roadmap item 18: the nightly cron owns the previously append-only memory
+// context block — it reads the recent transcript, asks the LLM to extract,
+// reinforce, and retire owner facts, and rewrites the block consolidated.
+export async function runOwnerMemoryConsolidation(
+  dependencies: OwnerMemoryConsolidationDependencies,
+): Promise<void> {
+  const { sqlExecutor, session, nowMilliseconds } = dependencies;
+  const storedState = await getSessionPreference(
+    sqlExecutor,
+    OWNER_MEMORY_STATE_PREFERENCE_KEY,
+  );
+  const state =
+    storedState === null ? undefined : parseStoredOwnerMemoryState(storedState);
+  if (
+    state !== undefined &&
+    nowMilliseconds - state.lastConsolidatedAtMilliseconds <
+      OWNER_MEMORY_MIN_RUN_INTERVAL_MS
+  ) {
+    return;
+  }
+  const latestLeaf = await session.getLatestLeaf();
+  if (latestLeaf === null || latestLeaf.id === state?.lastProcessedLeafId) {
+    // An idle day: nothing new happened, so the run costs zero LLM calls.
+    const idleState: OwnerMemoryState = {
+      factList: state?.factList ?? [],
+      lastConsolidatedAtMilliseconds: nowMilliseconds,
+      ...(state?.lastProcessedLeafId !== undefined
+        ? { lastProcessedLeafId: state.lastProcessedLeafId }
+        : {}),
+    };
+    await setSessionPreference(
+      sqlExecutor,
+      OWNER_MEMORY_STATE_PREFERENCE_KEY,
+      JSON.stringify(idleState),
+    );
+    return;
+  }
+  const recentHistory = await session.getRecentHistory(
+    OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
+  );
+  const seededFactList = seedOwnerFactsFromMemoryBlock({
+    blockContent: session.getContextBlock('memory')?.content ?? '',
+    knownFactList: state?.factList ?? [],
+    nowMilliseconds,
+    createIdentifier: dependencies.createIdentifier,
+  });
+  const extractionMessageList = buildMemoryExtractionMessageList({
+    transcriptText: flattenRecentHistoryToTranscript(recentHistory.messages),
+    existingFactList: seededFactList,
+    nowIso: new Date(nowMilliseconds).toISOString(),
+  });
+  const firstChatResult = await chatWithOpenRouter({
+    openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
+    modelId: dependencies.environment.OPENROUTER_MODEL,
+    messageList: extractionMessageList,
+  });
+  let extraction = parseMemoryExtractionResult(firstChatResult.text);
+  if (extraction === undefined) {
+    const retryChatResult = await chatWithOpenRouter({
+      openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
+      modelId: dependencies.environment.OPENROUTER_MODEL,
+      messageList: buildExtractionRetryMessageList(
+        extractionMessageList,
+        firstChatResult.text,
+      ),
+    });
+    extraction = parseMemoryExtractionResult(retryChatResult.text);
+  }
+  if (extraction === undefined) {
+    // State stays untouched so the next night retries over the same window.
+    console.error(
+      JSON.stringify({ level: 'error', message: 'owner_memory_extraction_invalid' }),
+    );
+    return;
+  }
+  const merge = mergeOwnerFacts({
+    existingFactList: seededFactList,
+    extraction,
+    nowMilliseconds,
+    createIdentifier: dependencies.createIdentifier,
+  });
+  await session.replaceContextBlock('memory', renderOwnerMemoryBlock(merge.nextFactList));
+  await session.refreshSystemPrompt();
+  // Decayed facts stay in the memories table and Vectorize on purpose: that
+  // layer is the provenance log recall_memory searches, while the consolidated
+  // block only governs what occupies prompt budget.
+  for (const genuinelyNewFact of merge.genuinelyNewFactList) {
+    const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
+    await enqueueMemoryIndexJob(dependencies.environment, {
+      memoryId: memoryRecord.id,
+      content: genuinelyNewFact.content,
+      deviceId: dependencies.deviceId,
+    });
+  }
+  // The checkpoint is written only after every durable output above succeeded:
+  // a failure mid-run leaves lastProcessedLeafId untouched, so the next night
+  // reprocesses the same window (the content dedupe makes that idempotent)
+  // instead of silently skipping it.
+  const nextState: OwnerMemoryState = {
+    factList: merge.nextFactList,
+    lastConsolidatedAtMilliseconds: nowMilliseconds,
+    lastProcessedLeafId: latestLeaf.id,
+  };
+  await setSessionPreference(
+    sqlExecutor,
+    OWNER_MEMORY_STATE_PREFERENCE_KEY,
+    JSON.stringify(nextState),
+  );
+  console.log(
+    JSON.stringify({
+      level: 'info',
+      message: 'owner_memory_consolidated',
+      factCount: merge.nextFactList.length,
+      newFactCount: merge.genuinelyNewFactList.length,
+      transcriptTruncated: recentHistory.truncated,
+    }),
+  );
+}

--- a/src/memory/nightly.ts
+++ b/src/memory/nightly.ts
@@ -27,6 +27,10 @@ import { chatWithOpenRouter } from '@/voice/llm';
 export const OWNER_MEMORY_STATE_PREFERENCE_KEY = 'ownerMemoryState';
 export const OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY = 'ownerMemoryIndexIntents';
 
+// The intent list is a write-ahead log for the persist+index pair: an entry
+// is durable before the row insert, so a crash at any point replays here —
+// inserting the row if it never landed, then re-enqueueing its index job
+// (an upsert by id, so replays are idempotent).
 async function drainMemoryIndexIntents(
   dependencies: OwnerMemoryConsolidationDependencies,
 ): Promise<void> {
@@ -42,8 +46,20 @@ async function drainMemoryIndexIntents(
     return;
   }
   for (const intent of intentList) {
+    const existingMemoryId = await findMemoryRecordIdByContent(
+      dependencies.sqlExecutor,
+      intent.content,
+    );
+    if (existingMemoryId === undefined) {
+      await addMemoryRecord(
+        dependencies.sqlExecutor,
+        intent.content,
+        dependencies.nowMilliseconds,
+        () => intent.memoryId,
+      );
+    }
     await enqueueMemoryIndexJob(dependencies.environment, {
-      memoryId: intent.memoryId,
+      memoryId: existingMemoryId ?? intent.memoryId,
       content: intent.content,
       deviceId: dependencies.deviceId,
     });
@@ -161,18 +177,25 @@ export async function runOwnerMemoryConsolidation(
     if (existingMemoryId !== undefined) {
       continue;
     }
-    const memoryRecord = await addMemoryRecord(sqlExecutor, genuinelyNewFact.content);
-    // The intent is durable before the enqueue and cleared right after, so a
-    // crash in between re-enqueues exactly this row on the next run: indexing
-    // is at-least-once (Vectorize upserts by id) without ever re-enqueueing
-    // rows whose indexing already succeeded.
+    // Write-ahead ordering: the intent (with a pre-generated id) is durable
+    // before the insert, the insert before the enqueue, and the intent is
+    // cleared only once the enqueue succeeded. A crash in any window replays
+    // through the drain above — the fact is never persisted without its index
+    // job, and never re-enqueued once the pair completed.
+    const memoryId = dependencies.createIdentifier();
     await setSessionPreference(
       sqlExecutor,
       OWNER_MEMORY_INDEX_INTENT_PREFERENCE_KEY,
-      JSON.stringify([{ memoryId: memoryRecord.id, content: genuinelyNewFact.content }]),
+      JSON.stringify([{ memoryId, content: genuinelyNewFact.content }]),
+    );
+    await addMemoryRecord(
+      sqlExecutor,
+      genuinelyNewFact.content,
+      nowMilliseconds,
+      () => memoryId,
     );
     await enqueueMemoryIndexJob(dependencies.environment, {
-      memoryId: memoryRecord.id,
+      memoryId,
       content: genuinelyNewFact.content,
       deviceId: dependencies.deviceId,
     });

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -31,6 +31,17 @@ export async function addMemoryRecord(
   return memoryRecord;
 }
 
+export async function findMemoryRecordIdByContent(
+  sqlExecutor: MemorySqlExecutor,
+  content: string,
+): Promise<string | undefined> {
+  const rows = sqlExecutor.execute<{ id: string }>(
+    'SELECT id FROM memories WHERE content = ? LIMIT 1',
+    content,
+  );
+  return rows[0]?.id;
+}
+
 export async function listRecentMemoryRecords(
   sqlExecutor: MemorySqlExecutor,
   limit: number,

--- a/src/ota/__tests__/push.spec.ts
+++ b/src/ota/__tests__/push.spec.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildFirmwareChangelogMessage,
+  compareFirmwareVersions,
+  detectFirmwareVersionChange,
+  evaluateFirmwarePush,
+  FIRMWARE_PUSH_CHECK_INTERVAL_MS,
+  FIRMWARE_PUSH_MAX_ATTEMPTS_PER_VERSION,
+  FIRMWARE_PUSH_MINIMUM_BATTERY_PERCENT,
+  FIRMWARE_PUSH_RETRY_COOLDOWN_MS,
+  parseStoredFirmwareChangelogState,
+  parseStoredFirmwarePushState,
+  recordFirmwareManifestCheck,
+  recordFirmwarePushAttempt,
+  shouldCheckFirmwareManifest,
+  type FirmwarePushState,
+} from '@/ota/push';
+import type { DeskTelemetrySnapshot } from '@/telemetry/logic';
+
+const NOW_MILLISECONDS = 1_786_540_000_000;
+
+function createSnapshot(
+  overrides: Partial<DeskTelemetrySnapshot> = {},
+): DeskTelemetrySnapshot {
+  return {
+    battery: 90,
+    charging: true,
+    firmwareVersion: '2.6.0',
+    receivedAtMs: NOW_MILLISECONDS,
+    ...overrides,
+  };
+}
+
+function createPushEvaluationInput(
+  overrides: Partial<Parameters<typeof evaluateFirmwarePush>[0]> = {},
+): Parameters<typeof evaluateFirmwarePush>[0] {
+  return {
+    snapshot: createSnapshot(),
+    manifestVersion: '2.7.0',
+    uiState: 'idle',
+    isFocusActive: false,
+    hasPendingConfirmation: false,
+    isAnnouncementInFlight: false,
+    pushState: undefined,
+    nowMilliseconds: NOW_MILLISECONDS,
+    ...overrides,
+  };
+}
+
+function createPushState(overrides: Partial<FirmwarePushState> = {}): FirmwarePushState {
+  return {
+    attemptCount: 0,
+    lastCheckedAtMilliseconds: NOW_MILLISECONDS,
+    ...overrides,
+  };
+}
+
+describe('compareFirmwareVersions', () => {
+  it('orders plain numeric versions', () => {
+    expect(compareFirmwareVersions('2.7.0', '2.6.0')).toBeGreaterThan(0);
+    expect(compareFirmwareVersions('2.6.0', '2.7.0')).toBeLessThan(0);
+    expect(compareFirmwareVersions('2.6.0', '2.6.0')).toBe(0);
+  });
+
+  it('compares segments numerically, not lexically', () => {
+    expect(compareFirmwareVersions('2.10.0', '2.9.9')).toBeGreaterThan(0);
+  });
+
+  it('treats the longer version as newer on a tie prefix', () => {
+    expect(compareFirmwareVersions('2.6.0', '2.6')).toBeGreaterThan(0);
+    expect(compareFirmwareVersions('2.6', '2.6.0')).toBeLessThan(0);
+  });
+});
+
+describe('shouldCheckFirmwareManifest', () => {
+  it('checks with no prior state', () => {
+    expect(
+      shouldCheckFirmwareManifest({
+        pushState: undefined,
+        didChargingEdgeOccur: false,
+        nowMilliseconds: NOW_MILLISECONDS,
+      }),
+    ).toBe(true);
+  });
+
+  it('throttles inside the check interval', () => {
+    expect(
+      shouldCheckFirmwareManifest({
+        pushState: createPushState({
+          lastCheckedAtMilliseconds:
+            NOW_MILLISECONDS - FIRMWARE_PUSH_CHECK_INTERVAL_MS + 1,
+        }),
+        didChargingEdgeOccur: false,
+        nowMilliseconds: NOW_MILLISECONDS,
+      }),
+    ).toBe(false);
+  });
+
+  it('checks again once the interval elapses', () => {
+    expect(
+      shouldCheckFirmwareManifest({
+        pushState: createPushState({
+          lastCheckedAtMilliseconds: NOW_MILLISECONDS - FIRMWARE_PUSH_CHECK_INTERVAL_MS,
+        }),
+        didChargingEdgeOccur: false,
+        nowMilliseconds: NOW_MILLISECONDS,
+      }),
+    ).toBe(true);
+  });
+
+  it('bypasses the throttle on a charging edge', () => {
+    expect(
+      shouldCheckFirmwareManifest({
+        pushState: createPushState({ lastCheckedAtMilliseconds: NOW_MILLISECONDS }),
+        didChargingEdgeOccur: true,
+        nowMilliseconds: NOW_MILLISECONDS,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('evaluateFirmwarePush', () => {
+  it('pushes a newer version in the safe window', () => {
+    expect(evaluateFirmwarePush(createPushEvaluationInput())).toEqual({
+      shouldPush: true,
+    });
+  });
+
+  it('skips without a reported firmware version', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        snapshot: createSnapshot({ firmwareVersion: undefined }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'no_reported_version' });
+  });
+
+  it('skips when the device is already current', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({ manifestVersion: '2.6.0' }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'already_current' });
+  });
+
+  it('skips when the device runs a version newer than the manifest', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({ manifestVersion: '2.5.0' }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'already_current' });
+  });
+
+  it('skips outside the safe ui states', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({ uiState: 'speaking' }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'unsafe_ui_state' });
+  });
+
+  it('allows the dashboard as a safe ui state', () => {
+    expect(
+      evaluateFirmwarePush(createPushEvaluationInput({ uiState: 'dashboard' })),
+    ).toEqual({ shouldPush: true });
+  });
+
+  it('skips with a confirmation pending', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({ hasPendingConfirmation: true }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'confirm_pending' });
+  });
+
+  it('skips while an announcement is in flight', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({ isAnnouncementInFlight: true }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'announcement_in_flight' });
+  });
+
+  it('skips during focus', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({ isFocusActive: true }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'focus_active' });
+  });
+
+  it('skips on battery below the minimum when not charging', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        snapshot: createSnapshot({
+          charging: false,
+          battery: FIRMWARE_PUSH_MINIMUM_BATTERY_PERCENT - 1,
+        }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'insufficient_power' });
+  });
+
+  it('accepts a full battery without charging', () => {
+    expect(
+      evaluateFirmwarePush(
+        createPushEvaluationInput({
+          snapshot: createSnapshot({
+            charging: false,
+            battery: FIRMWARE_PUSH_MINIMUM_BATTERY_PERCENT,
+          }),
+        }),
+      ),
+    ).toEqual({ shouldPush: true });
+  });
+
+  it('skips without any power reading', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        snapshot: createSnapshot({ charging: undefined, battery: undefined }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'insufficient_power' });
+  });
+
+  it('cools down between attempts at the same version', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        pushState: createPushState({
+          attemptedVersion: '2.7.0',
+          attemptedAtMilliseconds: NOW_MILLISECONDS - FIRMWARE_PUSH_RETRY_COOLDOWN_MS + 1,
+          attemptCount: 1,
+        }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'retry_cooldown' });
+  });
+
+  it('retries the same version once the cooldown elapses', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        pushState: createPushState({
+          attemptedVersion: '2.7.0',
+          attemptedAtMilliseconds: NOW_MILLISECONDS - FIRMWARE_PUSH_RETRY_COOLDOWN_MS,
+          attemptCount: 1,
+        }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: true });
+  });
+
+  it('gives up on a version after the attempt limit', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        pushState: createPushState({
+          attemptedVersion: '2.7.0',
+          attemptedAtMilliseconds: NOW_MILLISECONDS - 2 * FIRMWARE_PUSH_RETRY_COOLDOWN_MS,
+          attemptCount: FIRMWARE_PUSH_MAX_ATTEMPTS_PER_VERSION,
+        }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: false, reason: 'attempt_limit' });
+  });
+
+  it('resets the attempt policy for a new manifest version', () => {
+    const evaluation = evaluateFirmwarePush(
+      createPushEvaluationInput({
+        manifestVersion: '2.8.0',
+        pushState: createPushState({
+          attemptedVersion: '2.7.0',
+          attemptedAtMilliseconds: NOW_MILLISECONDS - 1,
+          attemptCount: FIRMWARE_PUSH_MAX_ATTEMPTS_PER_VERSION,
+        }),
+      }),
+    );
+    expect(evaluation).toEqual({ shouldPush: true });
+  });
+});
+
+describe('recordFirmwarePushAttempt', () => {
+  it('starts the counter for a first attempt', () => {
+    const nextState = recordFirmwarePushAttempt(undefined, '2.7.0', NOW_MILLISECONDS);
+    expect(nextState).toEqual({
+      attemptedVersion: '2.7.0',
+      attemptedAtMilliseconds: NOW_MILLISECONDS,
+      attemptCount: 1,
+      lastCheckedAtMilliseconds: NOW_MILLISECONDS,
+    });
+  });
+
+  it('increments the counter for a retry of the same version', () => {
+    const nextState = recordFirmwarePushAttempt(
+      createPushState({
+        attemptedVersion: '2.7.0',
+        attemptedAtMilliseconds: NOW_MILLISECONDS - 1,
+        attemptCount: 2,
+      }),
+      '2.7.0',
+      NOW_MILLISECONDS,
+    );
+    expect(nextState.attemptCount).toBe(3);
+  });
+
+  it('resets the counter for a new version', () => {
+    const nextState = recordFirmwarePushAttempt(
+      createPushState({
+        attemptedVersion: '2.7.0',
+        attemptedAtMilliseconds: NOW_MILLISECONDS - 1,
+        attemptCount: 3,
+      }),
+      '2.8.0',
+      NOW_MILLISECONDS,
+    );
+    expect(nextState.attemptCount).toBe(1);
+    expect(nextState.attemptedVersion).toBe('2.8.0');
+  });
+});
+
+describe('recordFirmwareManifestCheck', () => {
+  it('stamps the check time preserving attempt history', () => {
+    const nextState = recordFirmwareManifestCheck(
+      createPushState({
+        attemptedVersion: '2.7.0',
+        attemptedAtMilliseconds: NOW_MILLISECONDS - 10,
+        attemptCount: 2,
+        lastCheckedAtMilliseconds: NOW_MILLISECONDS - 10,
+      }),
+      NOW_MILLISECONDS,
+    );
+    expect(nextState).toEqual({
+      attemptedVersion: '2.7.0',
+      attemptedAtMilliseconds: NOW_MILLISECONDS - 10,
+      attemptCount: 2,
+      lastCheckedAtMilliseconds: NOW_MILLISECONDS,
+    });
+  });
+});
+
+describe('detectFirmwareVersionChange', () => {
+  it('detects a real upgrade edge', () => {
+    expect(
+      detectFirmwareVersionChange({
+        previousFirmwareVersion: '2.6.0',
+        nextFirmwareVersion: '2.7.0',
+      }),
+    ).toEqual({ fromVersion: '2.6.0', toVersion: '2.7.0' });
+  });
+
+  it('ignores a rollback', () => {
+    expect(
+      detectFirmwareVersionChange({
+        previousFirmwareVersion: '2.7.0',
+        nextFirmwareVersion: '2.6.0',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores an unchanged version', () => {
+    expect(
+      detectFirmwareVersionChange({
+        previousFirmwareVersion: '2.6.0',
+        nextFirmwareVersion: '2.6.0',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores missing versions on either side', () => {
+    expect(
+      detectFirmwareVersionChange({
+        previousFirmwareVersion: undefined,
+        nextFirmwareVersion: '2.7.0',
+      }),
+    ).toBeUndefined();
+    expect(
+      detectFirmwareVersionChange({
+        previousFirmwareVersion: '2.6.0',
+        nextFirmwareVersion: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('buildFirmwareChangelogMessage', () => {
+  it('speaks the changelog when present', () => {
+    expect(
+      buildFirmwareChangelogMessage({
+        toVersion: '2.7.0',
+        changelogText: 'ahora la cuenta regresiva se ve en el aro.',
+      }),
+    ).toBe('Me actualicé al firmware 2.7.0: ahora la cuenta regresiva se ve en el aro.');
+  });
+
+  it('falls back to a generic sentence without a changelog', () => {
+    expect(buildFirmwareChangelogMessage({ toVersion: '2.7.0' })).toBe(
+      'Me actualicé al firmware 2.7.0 mientras no me usabas.',
+    );
+  });
+});
+
+describe('stored state parsers', () => {
+  it('round-trip the push state', () => {
+    const pushState = createPushState({
+      attemptedVersion: '2.7.0',
+      attemptedAtMilliseconds: NOW_MILLISECONDS,
+      attemptCount: 1,
+    });
+    expect(parseStoredFirmwarePushState(JSON.stringify(pushState))).toEqual(pushState);
+  });
+
+  it('round-trip the changelog state', () => {
+    const changelogState = { pendingVersion: '2.7.0', announcedVersion: '2.6.0' };
+    expect(parseStoredFirmwareChangelogState(JSON.stringify(changelogState))).toEqual(
+      changelogState,
+    );
+  });
+
+  it('reject garbage', () => {
+    expect(parseStoredFirmwarePushState('{"attemptCount":')).toBeUndefined();
+    expect(parseStoredFirmwarePushState('{"attemptCount":1}')).toBeUndefined();
+    expect(parseStoredFirmwareChangelogState('null')).toBeUndefined();
+  });
+});

--- a/src/ota/lifecycle.ts
+++ b/src/ota/lifecycle.ts
@@ -1,0 +1,219 @@
+import type {
+  InitiativeDeliveryOutcome,
+  InitiativeUtteranceInput,
+} from '@/initiative/logic';
+import {
+  getSessionPreference,
+  setSessionPreference,
+  type MemorySqlExecutor,
+} from '@/memory/store';
+import { readFirmwareManifest } from '@/ota/manifest';
+import {
+  buildFirmwareChangelogMessage,
+  detectFirmwareVersionChange,
+  evaluateFirmwarePush,
+  parseStoredFirmwareChangelogState,
+  parseStoredFirmwarePushState,
+  recordFirmwareManifestCheck,
+  recordFirmwarePushAttempt,
+  shouldCheckFirmwareManifest,
+} from '@/ota/push';
+import type { DeskTelemetrySnapshot } from '@/telemetry/logic';
+import type { ToolExecutionResult } from '@/tools/types';
+
+export const FIRMWARE_PUSH_STATE_PREFERENCE_KEY = 'firmwarePushState';
+export const FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY = 'firmwareChangelogState';
+export const PUBLIC_ORIGIN_PREFERENCE_KEY = 'publicOrigin';
+
+export type FirmwareLifecycleDependencies = {
+  readonly sqlExecutor: MemorySqlExecutor;
+  readonly mediaBucket: R2Bucket;
+  readonly deviceSharedSecret: string;
+  readonly isPushDisabled: boolean;
+  readonly uiState: string;
+  readonly isFocusActive: boolean;
+  readonly hasPendingConfirmation: boolean;
+  readonly isAnnouncementInFlight: boolean;
+  readonly nowMilliseconds: number;
+  readonly deliverInitiativeUtterance: (
+    utterance: InitiativeUtteranceInput,
+  ) => Promise<InitiativeDeliveryOutcome>;
+  readonly callDeviceTool: (
+    deviceToolName: string,
+    argumentRecord: Record<string, unknown>,
+  ) => Promise<ToolExecutionResult>;
+};
+
+// Roadmap item 23: after a reboot the first telemetry reports the new version
+// (the changelog edge), and every telemetry tick is a chance to push a pending
+// update when the device is idle and powered.
+export async function runFirmwareLifecycle(
+  input: {
+    readonly previousFirmwareVersion: string | undefined;
+    readonly snapshot: DeskTelemetrySnapshot;
+    readonly didChargingEdgeOccur: boolean;
+  },
+  dependencies: FirmwareLifecycleDependencies,
+): Promise<void> {
+  const { sqlExecutor, nowMilliseconds } = dependencies;
+
+  const storedChangelogState = await getSessionPreference(
+    sqlExecutor,
+    FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+  );
+  let changelogState =
+    storedChangelogState === null
+      ? undefined
+      : parseStoredFirmwareChangelogState(storedChangelogState);
+
+  const versionChange = detectFirmwareVersionChange({
+    previousFirmwareVersion: input.previousFirmwareVersion,
+    nextFirmwareVersion: input.snapshot.firmwareVersion,
+  });
+  if (versionChange !== undefined) {
+    changelogState = { ...changelogState, pendingVersion: versionChange.toVersion };
+    await setSessionPreference(
+      sqlExecutor,
+      FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+      JSON.stringify(changelogState),
+    );
+    // The device came back on the new version: the attempt marker did its job
+    // and must not throttle the next release.
+    await setSessionPreference(
+      sqlExecutor,
+      FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+      JSON.stringify(recordFirmwareManifestCheck(undefined, nowMilliseconds)),
+    );
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        message: 'firmware_changelog_pending',
+        fromVersion: versionChange.fromVersion,
+        toVersion: versionChange.toVersion,
+      }),
+    );
+  }
+
+  if (
+    changelogState?.pendingVersion !== undefined &&
+    changelogState.pendingVersion !== changelogState.announcedVersion
+  ) {
+    const manifest = await readFirmwareManifest(dependencies.mediaBucket);
+    const changelogText =
+      manifest !== undefined && manifest.version === changelogState.pendingVersion
+        ? manifest.changelog
+        : undefined;
+    const deliveryOutcome = await dependencies.deliverInitiativeUtterance({
+      source: 'firmware_changelog',
+      priority: 'normal',
+      message: buildFirmwareChangelogMessage({
+        toVersion: changelogState.pendingVersion,
+        ...(changelogText !== undefined ? { changelogText } : {}),
+      }),
+      earconName: 'chime',
+    });
+    // A deferred utterance carries its message in the schedule payload and its
+    // retry re-schedules itself on transient suppressions, so it counts as
+    // announced here — otherwise the next telemetry tick would schedule a
+    // duplicate. Only an immediate suppression leaves it pending for retry.
+    if (deliveryOutcome !== 'suppressed') {
+      changelogState = { announcedVersion: changelogState.pendingVersion };
+      await setSessionPreference(
+        sqlExecutor,
+        FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+        JSON.stringify(changelogState),
+      );
+    }
+  }
+
+  if (dependencies.isPushDisabled) {
+    return;
+  }
+  const storedPushState = await getSessionPreference(
+    sqlExecutor,
+    FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+  );
+  const pushState =
+    storedPushState === null ? undefined : parseStoredFirmwarePushState(storedPushState);
+  if (
+    !shouldCheckFirmwareManifest({
+      pushState,
+      didChargingEdgeOccur: input.didChargingEdgeOccur,
+      nowMilliseconds,
+    })
+  ) {
+    return;
+  }
+  const manifest = await readFirmwareManifest(dependencies.mediaBucket);
+  const checkedPushState = recordFirmwareManifestCheck(pushState, nowMilliseconds);
+  await setSessionPreference(
+    sqlExecutor,
+    FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+    JSON.stringify(checkedPushState),
+  );
+  if (manifest === undefined) {
+    return;
+  }
+  const evaluation = evaluateFirmwarePush({
+    snapshot: input.snapshot,
+    manifestVersion: manifest.version,
+    uiState: dependencies.uiState,
+    isFocusActive: dependencies.isFocusActive,
+    hasPendingConfirmation: dependencies.hasPendingConfirmation,
+    isAnnouncementInFlight: dependencies.isAnnouncementInFlight,
+    pushState: checkedPushState,
+    nowMilliseconds,
+  });
+  if (!evaluation.shouldPush) {
+    if (evaluation.reason !== 'already_current') {
+      console.log(
+        JSON.stringify({
+          level: 'info',
+          message: 'firmware_push_skipped',
+          reason: evaluation.reason,
+        }),
+      );
+    }
+    return;
+  }
+  const publicOrigin = await getSessionPreference(
+    sqlExecutor,
+    PUBLIC_ORIGIN_PREFERENCE_KEY,
+  );
+  if (publicOrigin === null) {
+    console.error(
+      JSON.stringify({ level: 'error', message: 'firmware_push_missing_origin' }),
+    );
+    return;
+  }
+  const firmwareBinaryUrl = new URL('/ota/firmware.bin', publicOrigin);
+  firmwareBinaryUrl.searchParams.set('token', dependencies.deviceSharedSecret);
+  // Recorded before the call: a crash mid-push must read as an attempt, or the
+  // device could be flashed in a loop.
+  await setSessionPreference(
+    sqlExecutor,
+    FIRMWARE_PUSH_STATE_PREFERENCE_KEY,
+    JSON.stringify(
+      recordFirmwarePushAttempt(checkedPushState, manifest.version, nowMilliseconds),
+    ),
+  );
+  console.log(
+    JSON.stringify({
+      level: 'info',
+      message: 'firmware_push_attempted',
+      manifestVersion: manifest.version,
+      deviceVersion: input.snapshot.firmwareVersion,
+    }),
+  );
+  const pushResult = await dependencies.callDeviceTool('self.upgrade_firmware', {
+    url: firmwareBinaryUrl.toString(),
+  });
+  console.log(
+    JSON.stringify({
+      level: 'info',
+      message: 'firmware_push_result',
+      ok: pushResult.ok,
+      summary: pushResult.summary,
+    }),
+  );
+}

--- a/src/ota/lifecycle.ts
+++ b/src/ota/lifecycle.ts
@@ -1,6 +1,8 @@
-import type {
-  InitiativeDeliveryOutcome,
-  InitiativeUtteranceInput,
+import {
+  buildInitiativeDeliveryMarkerKey,
+  type InitiativeDeliveryOutcome,
+  type InitiativeSource,
+  type InitiativeUtteranceInput,
 } from '@/initiative/logic';
 import {
   getSessionPreference,
@@ -38,6 +40,7 @@ export type FirmwareLifecycleDependencies = {
   readonly deliverInitiativeUtterance: (
     utterance: InitiativeUtteranceInput,
   ) => Promise<InitiativeDeliveryOutcome>;
+  readonly hasScheduledInitiativeRetry: (source: InitiativeSource) => Promise<boolean>;
   readonly callDeviceTool: (
     deviceToolName: string,
     argumentRecord: Record<string, unknown>,
@@ -98,31 +101,47 @@ export async function runFirmwareLifecycle(
     changelogState?.pendingVersion !== undefined &&
     changelogState.pendingVersion !== changelogState.announcedVersion
   ) {
-    const manifest = await readFirmwareManifest(dependencies.mediaBucket);
-    const changelogText =
-      manifest !== undefined && manifest.version === changelogState.pendingVersion
-        ? manifest.changelog
-        : undefined;
-    const deliveryOutcome = await dependencies.deliverInitiativeUtterance({
-      source: 'firmware_changelog',
-      priority: 'normal',
-      message: buildFirmwareChangelogMessage({
-        toVersion: changelogState.pendingVersion,
-        ...(changelogText !== undefined ? { changelogText } : {}),
-      }),
-      earconName: 'chime',
-    });
-    // A deferred utterance carries its message in the schedule payload and its
-    // retry re-schedules itself on transient suppressions, so it counts as
-    // announced here — otherwise the next telemetry tick would schedule a
-    // duplicate. Only an immediate suppression leaves it pending for retry.
-    if (deliveryOutcome !== 'suppressed') {
-      changelogState = { announcedVersion: changelogState.pendingVersion };
+    const pendingVersion = changelogState.pendingVersion;
+    // The version is only marked announced once it was actually spoken: the
+    // delivery marker survives a deferred retry chain, the in-flight check
+    // prevents duplicate scheduling while one is pending, and if the whole
+    // retry chain dies suppressed, the still-pending version re-queues here
+    // on a later telemetry tick — the changelog can be late, never lost.
+    const deliveryMarkerKey = buildInitiativeDeliveryMarkerKey(
+      `firmware-changelog-${pendingVersion}`,
+    );
+    const deliveredAt = await getSessionPreference(sqlExecutor, deliveryMarkerKey);
+    if (deliveredAt !== null) {
+      changelogState = { announcedVersion: pendingVersion };
       await setSessionPreference(
         sqlExecutor,
         FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
         JSON.stringify(changelogState),
       );
+    } else if (!(await dependencies.hasScheduledInitiativeRetry('firmware_changelog'))) {
+      const manifest = await readFirmwareManifest(dependencies.mediaBucket);
+      const changelogText =
+        manifest !== undefined && manifest.version === pendingVersion
+          ? manifest.changelog
+          : undefined;
+      const deliveryOutcome = await dependencies.deliverInitiativeUtterance({
+        source: 'firmware_changelog',
+        priority: 'normal',
+        message: buildFirmwareChangelogMessage({
+          toVersion: pendingVersion,
+          ...(changelogText !== undefined ? { changelogText } : {}),
+        }),
+        earconName: 'chime',
+        utteranceKey: `firmware-changelog-${pendingVersion}`,
+      });
+      if (deliveryOutcome === 'delivered') {
+        changelogState = { announcedVersion: pendingVersion };
+        await setSessionPreference(
+          sqlExecutor,
+          FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY,
+          JSON.stringify(changelogState),
+        );
+      }
     }
   }
 

--- a/src/ota/manifest.ts
+++ b/src/ota/manifest.ts
@@ -9,6 +9,9 @@ const firmwareVersionPattern = /^\d+(\.\d+)*$/;
 export const firmwareManifestSchema = z.object({
   version: z.string().regex(firmwareVersionPattern),
   key: z.string().min(1),
+  // Optional so every manifest published before the field existed keeps
+  // parsing; the whole manifest degrades to "no update" on a schema miss.
+  changelog: z.string().min(1).max(500).optional(),
 });
 
 export type FirmwareManifest = z.infer<typeof firmwareManifestSchema>;

--- a/src/ota/push.ts
+++ b/src/ota/push.ts
@@ -1,0 +1,220 @@
+import { z } from 'zod';
+
+import type { DeskTelemetrySnapshot } from '@/telemetry/logic';
+
+export const FIRMWARE_PUSH_CHECK_INTERVAL_MS = 15 * 60_000;
+export const FIRMWARE_PUSH_RETRY_COOLDOWN_MS = 6 * 60 * 60_000;
+export const FIRMWARE_PUSH_MAX_ATTEMPTS_PER_VERSION = 3;
+export const FIRMWARE_PUSH_MINIMUM_BATTERY_PERCENT = 50;
+
+const FIRMWARE_PUSH_SAFE_UI_STATE_LIST: readonly string[] = ['idle', 'dashboard'];
+
+const firmwarePushStateSchema = z.object({
+  attemptedVersion: z.string().optional(),
+  attemptedAtMilliseconds: z.number().optional(),
+  attemptCount: z.number().int().min(0),
+  lastCheckedAtMilliseconds: z.number(),
+});
+
+export type FirmwarePushState = {
+  readonly attemptedVersion?: string;
+  readonly attemptedAtMilliseconds?: number;
+  readonly attemptCount: number;
+  readonly lastCheckedAtMilliseconds: number;
+};
+
+const firmwareChangelogStateSchema = z.object({
+  pendingVersion: z.string().optional(),
+  announcedVersion: z.string().optional(),
+});
+
+export type FirmwareChangelogState = {
+  readonly pendingVersion?: string;
+  readonly announcedVersion?: string;
+};
+
+// Mirrors the device's Ota::IsNewVersionAvailable exactly: numeric compare per
+// dot-segment, and on a tie prefix the longer version wins ("2.6.0" > "2.6").
+// Diverging from the firmware here would push an upgrade the device rejects.
+export function compareFirmwareVersions(
+  leftVersion: string,
+  rightVersion: string,
+): number {
+  const leftSegmentList = leftVersion.split('.').map(Number);
+  const rightSegmentList = rightVersion.split('.').map(Number);
+  const sharedSegmentCount = Math.min(leftSegmentList.length, rightSegmentList.length);
+  for (let segmentIndex = 0; segmentIndex < sharedSegmentCount; segmentIndex += 1) {
+    const difference =
+      (leftSegmentList[segmentIndex] ?? 0) - (rightSegmentList[segmentIndex] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return leftSegmentList.length - rightSegmentList.length;
+}
+
+export function shouldCheckFirmwareManifest(input: {
+  readonly pushState: FirmwarePushState | undefined;
+  readonly didChargingEdgeOccur: boolean;
+  readonly nowMilliseconds: number;
+}): boolean {
+  if (input.didChargingEdgeOccur || input.pushState === undefined) {
+    return true;
+  }
+  return (
+    input.nowMilliseconds - input.pushState.lastCheckedAtMilliseconds >=
+    FIRMWARE_PUSH_CHECK_INTERVAL_MS
+  );
+}
+
+export type FirmwarePushSkipReason =
+  | 'no_reported_version'
+  | 'already_current'
+  | 'attempt_limit'
+  | 'retry_cooldown'
+  | 'unsafe_ui_state'
+  | 'confirm_pending'
+  | 'announcement_in_flight'
+  | 'focus_active'
+  | 'insufficient_power';
+
+export type FirmwarePushEvaluation = {
+  readonly shouldPush: boolean;
+  readonly reason?: FirmwarePushSkipReason;
+};
+
+export function evaluateFirmwarePush(input: {
+  readonly snapshot: DeskTelemetrySnapshot;
+  readonly manifestVersion: string;
+  readonly uiState: string;
+  readonly isFocusActive: boolean;
+  readonly hasPendingConfirmation: boolean;
+  readonly isAnnouncementInFlight: boolean;
+  readonly pushState: FirmwarePushState | undefined;
+  readonly nowMilliseconds: number;
+}): FirmwarePushEvaluation {
+  if (input.snapshot.firmwareVersion === undefined) {
+    return { shouldPush: false, reason: 'no_reported_version' };
+  }
+  if (
+    compareFirmwareVersions(input.manifestVersion, input.snapshot.firmwareVersion) <= 0
+  ) {
+    return { shouldPush: false, reason: 'already_current' };
+  }
+  // A device that accepted the push but reappeared on the old version rolled
+  // back or failed to flash — hammering it in a loop wastes its battery and
+  // bandwidth, so attempts per manifest version are capped and spaced out.
+  if (input.pushState?.attemptedVersion === input.manifestVersion) {
+    if (input.pushState.attemptCount >= FIRMWARE_PUSH_MAX_ATTEMPTS_PER_VERSION) {
+      return { shouldPush: false, reason: 'attempt_limit' };
+    }
+    if (
+      input.pushState.attemptedAtMilliseconds !== undefined &&
+      input.nowMilliseconds - input.pushState.attemptedAtMilliseconds <
+        FIRMWARE_PUSH_RETRY_COOLDOWN_MS
+    ) {
+      return { shouldPush: false, reason: 'retry_cooldown' };
+    }
+  }
+  if (!FIRMWARE_PUSH_SAFE_UI_STATE_LIST.includes(input.uiState)) {
+    return { shouldPush: false, reason: 'unsafe_ui_state' };
+  }
+  if (input.hasPendingConfirmation) {
+    return { shouldPush: false, reason: 'confirm_pending' };
+  }
+  if (input.isAnnouncementInFlight) {
+    return { shouldPush: false, reason: 'announcement_in_flight' };
+  }
+  if (input.isFocusActive) {
+    return { shouldPush: false, reason: 'focus_active' };
+  }
+  const hasEnoughPower =
+    input.snapshot.charging === true ||
+    (input.snapshot.battery !== undefined &&
+      input.snapshot.battery >= FIRMWARE_PUSH_MINIMUM_BATTERY_PERCENT);
+  if (!hasEnoughPower) {
+    return { shouldPush: false, reason: 'insufficient_power' };
+  }
+  return { shouldPush: true };
+}
+
+export function recordFirmwareManifestCheck(
+  pushState: FirmwarePushState | undefined,
+  nowMilliseconds: number,
+): FirmwarePushState {
+  return {
+    ...pushState,
+    attemptCount: pushState?.attemptCount ?? 0,
+    lastCheckedAtMilliseconds: nowMilliseconds,
+  };
+}
+
+export function recordFirmwarePushAttempt(
+  pushState: FirmwarePushState | undefined,
+  manifestVersion: string,
+  nowMilliseconds: number,
+): FirmwarePushState {
+  const isRetryOfSameVersion = pushState?.attemptedVersion === manifestVersion;
+  return {
+    attemptedVersion: manifestVersion,
+    attemptedAtMilliseconds: nowMilliseconds,
+    attemptCount: isRetryOfSameVersion ? pushState.attemptCount + 1 : 1,
+    lastCheckedAtMilliseconds: pushState?.lastCheckedAtMilliseconds ?? nowMilliseconds,
+  };
+}
+
+export function detectFirmwareVersionChange(input: {
+  readonly previousFirmwareVersion: string | undefined;
+  readonly nextFirmwareVersion: string | undefined;
+}): { readonly fromVersion: string; readonly toVersion: string } | undefined {
+  if (
+    input.previousFirmwareVersion === undefined ||
+    input.nextFirmwareVersion === undefined
+  ) {
+    return undefined;
+  }
+  // Only a real upgrade edge counts: a rollback reporting the old version
+  // must not produce a false "me actualicé".
+  if (
+    compareFirmwareVersions(input.nextFirmwareVersion, input.previousFirmwareVersion) <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    fromVersion: input.previousFirmwareVersion,
+    toVersion: input.nextFirmwareVersion,
+  };
+}
+
+export function buildFirmwareChangelogMessage(input: {
+  readonly toVersion: string;
+  readonly changelogText?: string;
+}): string {
+  if (input.changelogText === undefined) {
+    return `Me actualicé al firmware ${input.toVersion} mientras no me usabas.`;
+  }
+  const normalizedChangelogText = input.changelogText.trim().replace(/\.+$/, '');
+  return `Me actualicé al firmware ${input.toVersion}: ${normalizedChangelogText}.`;
+}
+
+export function parseStoredFirmwarePushState(
+  storedValue: string,
+): FirmwarePushState | undefined {
+  try {
+    const parsedState = firmwarePushStateSchema.safeParse(JSON.parse(storedValue));
+    return parsedState.success ? parsedState.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseStoredFirmwareChangelogState(
+  storedValue: string,
+): FirmwareChangelogState | undefined {
+  try {
+    const parsedState = firmwareChangelogStateSchema.safeParse(JSON.parse(storedValue));
+    return parsedState.success ? parsedState.data : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/persona/soul.ts
+++ b/src/persona/soul.ts
@@ -25,6 +25,7 @@ const apolloOperatingBasePrompt =
   'Para guardar la ciudad default del clima usá set_weather_location. Si solo preguntan el clima en otra ciudad, weather_now con locationQuery (no guarda). ' +
   'Con focus activo: menos announces y más breve. No inventes hechos: preguntá o usá una tool. ' +
   'Los datos de "Estado del dispositivo" (batería, volumen, WiFi, versión de firmware) son tu propio estado: respondé con ellos directamente. ' +
+  'El bloque de hechos y preferencias es lo que aprendiste de tu dueño con el tiempo: si te preguntan qué sabés o qué aprendiste de él, contestá desde ahí en primera persona. ' +
   'No narres el uso de tools al pedo.';
 
 export function buildApolloSoulPrompt(speechModeId: string): string {


### PR DESCRIPTION
Implements roadmap items **17, 23, and 18** (the independence & proactivity round, PR #26), in that order — the changelog announcement of #23 delivers through #17's quiet-hours deferral, which is why the initiative engine went first.

## 17 — Initiative engine (`src/initiative/logic.ts`)
Pure policy evaluator behind a single DO chokepoint (`#deliverInitiativeUtterance`): quiet hours (22:00–09:00 Buenos Aires) defer to morning via the DO scheduler, active focus defers past the window +60 s, a daily budget of 6 and per-source hourly cooldowns suppress, `critical` bypasses everything, offline suppresses (a queued card is never spoken). State in `session_prefs`, recorded only after delivery succeeds. Low battery adopted as first source — behavior unchanged.

## 23 — Self-maintaining device (`src/ota/push.ts`)
Every telemetry tick (manifest read throttled 15 min, bypassed on charging edges) compares the reported version with the device's own compare rules and pushes `self.upgrade_firmware` over the MCP bridge in the safe window (idle/dashboard, no confirm, no announcement in flight, focus off, charging or ≥50%). 3 attempts/version, 6 h apart, recorded before the call. The post-reboot version edge queues a spoken changelog (new optional `changelog` manifest field; companion PR in apollo-firmware embeds `changelog/<version>.md` via `publish.yml`). `FIRMWARE_PUSH_DISABLED=1` is the kill switch.

## 18 — Owner memory consolidation (`src/memory/consolidate.ts`)
A nightly cron (03:00 local) takes ownership of the previously append-only `memory` context block: 48 KB transcript tail → strict-JSON extraction (one corrective retry) → merge with content dedupe, 60-day decay, 50-fact cap → block rewritten grouped by category. `memories` + Vectorize stay as the append-only provenance log. Idle days skip the LLM call; `MOCK_VOICE` skips the run. "¿Qué aprendiste de mí?" answered from the block, no new tool.

Also declares the model/email env secrets in `environment.d.ts` — `tsc --noEmit` goes from 17 pre-existing errors to green.

## Verification
- 423 tests pass (87 new across the three pure modules), lint and format clean, typecheck green.
- Local e2e against `wrangler dev` with a simulated device: push frame emitted with the origin-derived URL and acked, post-reboot edge detected, changelog announcement deferred for quiet hours (`initiative_decision defer quiet_hours` — it was 23:00 in Buenos Aires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vy3eMy7EgW4j3ajdnvCn7m

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds proactive initiative policy, server-driven firmware updates with spoken changelogs, and nightly owner-memory consolidation.
- Routes initiative speech through quiet-hours, focus, connectivity, budget, cooldown, and retry policy.
- Pushes eligible firmware upgrades and tracks post-reboot changelog delivery durably.
- Consolidates transcript-derived owner facts into the prompt memory block while retaining append-only searchable provenance.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(review): write-ahead intent closes t..."](https://github.com/galfrevn/apollo/commit/aca6928701fdd83fa2eb19c8488ea0069f4a4fe4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52441983)</sub>

<!-- /greptile_comment -->