### PR TITLE
chore(skills): mark vendored skills as vendored and exclude them from lint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Skills are vendored copies from the open skills registry, pinned by skills-lock.json.
+# Without this they outweigh src/ and GitHub reports the repo as JavaScript.
+.agents/skills/** linguist-vendored
+.claude/skills/** linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Desktop.ini
 .claude/assistant-daemon-state.json
 .claude/first-run
 .claude/settings.local.json
+
+# skills
+.impeccable/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,5 +3,14 @@
   "printWidth": 90,
   "singleQuote": true,
   "endOfLine": "lf",
-  "ignorePatterns": ["*.md", "*.yml", "*.yaml", "*.toml", "*.json", "firmware/**"]
+  "ignorePatterns": [
+    "*.md",
+    "*.yml",
+    "*.yaml",
+    "*.toml",
+    "*.json",
+    "firmware/**",
+    ".agents/skills/**",
+    ".claude/skills/**"
+  ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,5 +20,5 @@
   "env": {
     "builtin": true
   },
-  "ignorePatterns": []
+  "ignorePatterns": [".agents/skills/**", ".claude/skills/**"]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,6 +11,7 @@ pre-commit:
         - '*.cjs'
       exclude:
         - '.agents/skills/**'
+        - '.claude/skills/**'
       run: bunx oxfmt --write {staged_files}
       stage_fixed: true
     - name: lint
@@ -23,6 +24,7 @@ pre-commit:
         - '*.cjs'
       exclude:
         - '.agents/skills/**'
+        - '.claude/skills/**'
       run: bunx oxlint --deny-warnings {staged_files}
 
 commit-msg:


### PR DESCRIPTION
## Why

PR #30 vendored the skill trees into the repo. Two side effects landed with them:

1. **GitHub reports the repo as JavaScript.** The skills carry 2.8 MB of `.mjs`/`.js` (`impeccable/scripts/live-browser.js` alone is ~11k lines) against 673 KB of TypeScript in `src/`. Linguist counts bytes, so the language bar flipped.
2. **`bun run lint` and `bun run format:check` fail.** Both walk the whole repo, so they lint and format-check third-party code this repo does not own and cannot fix. `lefthook` already excluded `.agents/skills/**`, but the repo-wide scripts — the ones `.github/workflows/quality.yml` runs — did not.

The skills themselves stay committed. They're pinned by `skills-lock.json`, several carry local edits recorded in `.claude/skills-provenance.md`, and vendoring is what makes them work for every agent without a network fetch.

## What

- **`.gitattributes`** (new) marks `.agents/skills/**` and `.claude/skills/**` as `linguist-vendored`, which drops them from the language stats and collapses them in diffs.
- **`.oxlintrc.json` / `.oxfmtrc.json`** ignore both the real tree and the `.claude/skills/` symlinks — oxlint was walking the symlinks too, so it reported every finding twice.
- **`lefthook.yml`** gains `.claude/skills/**` alongside the `.agents/skills/**` exclude it already had.
- **`.gitignore`** picks up `.impeccable/` (the impeccable skill's local config), which until now only stayed out of commits via each clone's untracked `.git/info/exclude`.

## Verification

| gate | before | after |
| --- | --- | --- |
| `bun run lint` | fails, 20+ errors in skills | passes |
| `bun run format:check` | fails, 100 files | passes, 165 files checked |
| `bun run typecheck` | passes | passes |
| `bun test` | passes | 490 pass, 0 fail |

Confirmed lint still covers `src/` — a probe file with an unused variable is still caught. `git check-attr linguist-vendored` reports `set` for the skill trees and `unspecified` for `src/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyzzEWpLf9DhE6S2vYNY3A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR classifies committed skill trees as vendored and excludes them from repository-owned linting and formatting while preserving checks for first-party code.
- Adds Linguist vendoring attributes for the real and symlinked skill paths.
- Excludes both paths from oxlint, oxfmt, and pre-commit processing.
- Ignores the Impeccable skill’s local configuration directory.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The configuration changes consistently exclude only the vendored skill paths, representative attribute checks confirm first-party source remains unaffected, and no accepted runtime, build, security, or quality failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(skills): mark vendored skills as v..."](https://github.com/galfrevn/apollo/commit/f37ade4bcfbff6a377d730622b413cd6d82335b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52648171)</sub>

<!-- /greptile_comment -->