### PR TITLE
fix: carry recent turn history into each voice reply

### DIFF
--- a/documentation/capabilities/memory.md
+++ b/documentation/capabilities/memory.md
@@ -15,6 +15,8 @@ Apollo keeps both conversational session memory and longer-lived facts.
 
 Both layers key off the **transcript**, not the raw input: a hold-to-talk turn arrives as audio and only becomes text after STT runs inside `src/turn/run.ts`, which returns it as `TurnOutput.transcript`. `src/agents/runtime.ts` appends that transcript (and the reply) to the session, and runs semantic recall with it. Gating either on the caller's `text` instead would skip every spoken turn.
 
+Each turn also reads a small recency window back out: `buildRecentTurnHistoryMessageList` (`src/memory/session.ts`) calls `session.getRecentHistory` with an 8 KB budget and a 10-message floor, and `src/turn/run.ts` splices those prior user/assistant turns into the LLM message list ahead of the current utterance. This is what lets a follow-up said moments after a reply — including one after a fresh wake-word activation — reference what was just discussed; a new wake word does not reset the session or its history.
+
 ## Tools
 
 - `remember_fact` stores something worth recalling later

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -4,7 +4,10 @@ import type { Session } from 'agents/experimental/memory/session';
 import type { ApolloState } from '@/agents/apollo';
 import { createInactiveDeskFocusState, tickDeskFocus } from '@/focus/logic';
 import { isNamespacedMcpToolName } from '@/mcp/naming';
-import { buildSessionSystemPrompt } from '@/memory/session';
+import {
+  buildRecentTurnHistoryMessageList,
+  buildSessionSystemPrompt,
+} from '@/memory/session';
 import type { MemorySqlExecutor } from '@/memory/store';
 import { recallSemanticMemoryContent } from '@/memory/vector';
 import { resolveDeskSpeechMode } from '@/persona/catalog';
@@ -74,6 +77,9 @@ export async function executeApolloTurn(
 
   const isMockVoice = dependencies.environment.MOCK_VOICE === '1';
   const sessionSystemPrompt = await buildSessionSystemPrompt(dependencies.session);
+  const recentHistoryMessageList = await buildRecentTurnHistoryMessageList(
+    dependencies.session,
+  );
   const recallSemanticMemoryContentList = async (
     queryText: string,
   ): Promise<readonly string[]> =>
@@ -102,7 +108,7 @@ export async function executeApolloTurn(
     ? {
         stt: async () => turnPart.text ?? 'hola',
         llm: async ({ messageList }) => {
-          const userMessage = messageList.find((message) => message.role === 'user');
+          const userMessage = messageList.findLast((message) => message.role === 'user');
           const userText = userMessage?.role === 'user' ? userMessage.content : '';
           return {
             text: `Mock: ${userText}`,
@@ -147,6 +153,7 @@ export async function executeApolloTurn(
     nowMilliseconds,
     deviceId: dependencies.deviceId,
     systemPromptOverride: `${sessionSystemPrompt}${focusNote}${telemetryNote}${installedToolNote}`,
+    recentHistoryMessageList,
     ...(isMockVoice ? {} : { recallSemanticMemoryContentList }),
     effects: dependencies.effects,
     onThinkingCaption: async (caption) => {

--- a/src/memory/__tests__/session.spec.ts
+++ b/src/memory/__tests__/session.spec.ts
@@ -1,6 +1,55 @@
+import {
+  Session,
+  type RecentHistoryResult,
+  type SessionMessage,
+  type SessionProvider,
+  type StoredCompaction,
+} from 'agents/experimental/memory/session';
 import { describe, expect, it } from 'bun:test';
 
-import { mapRecentHistoryToChatMessageList } from '@/memory/session';
+import {
+  buildRecentTurnHistoryMessageList,
+  mapRecentHistoryToChatMessageList,
+} from '@/memory/session';
+
+function createFakeSessionProvider(recentHistoryResult: RecentHistoryResult): {
+  readonly provider: SessionProvider;
+  readonly getRecentHistoryCallArgList: readonly [
+    leafId: string | null | undefined,
+    maxContentBytes: number,
+    minRecentMessages: number | undefined,
+  ][];
+} {
+  const getRecentHistoryCallArgList: [
+    leafId: string | null | undefined,
+    maxContentBytes: number,
+    minRecentMessages: number | undefined,
+  ][] = [];
+  const provider: SessionProvider = {
+    getMessage: () => null,
+    getHistory: () => [],
+    getLatestLeaf: () => null,
+    getBranches: () => [],
+    getPathLength: () => 0,
+    getRecentHistory: (leafId, maxContentBytes, minRecentMessages) => {
+      getRecentHistoryCallArgList.push([leafId, maxContentBytes, minRecentMessages]);
+      return recentHistoryResult;
+    },
+    appendMessage: () => {},
+    updateMessage: () => {},
+    deleteMessages: () => {},
+    clearMessages: () => {},
+    addCompaction: (summary, fromMessageId, toMessageId): StoredCompaction => ({
+      id: 'compaction-1',
+      summary,
+      fromMessageId,
+      toMessageId,
+      createdAt: new Date(0).toISOString(),
+    }),
+    getCompactions: () => [],
+  };
+  return { provider, getRecentHistoryCallArgList };
+}
 
 describe('mapRecentHistoryToChatMessageList', () => {
   it('keeps user and assistant turns in chronological order', () => {
@@ -60,5 +109,35 @@ describe('mapRecentHistoryToChatMessageList', () => {
     expect(chatMessageList).toEqual([
       { role: 'assistant', content: 'Primera parte. Segunda parte.' },
     ]);
+  });
+});
+
+describe('buildRecentTurnHistoryMessageList', () => {
+  it('reads the session recency window and maps it to chat messages', async () => {
+    const storedMessageList: SessionMessage[] = [
+      {
+        id: '1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'dame ideas para el finde' }],
+      },
+      { id: '2', role: 'assistant', parts: [{ type: 'text', text: 'andá a la costa' }] },
+    ];
+    const { provider, getRecentHistoryCallArgList } = createFakeSessionProvider({
+      messages: storedMessageList,
+      truncated: false,
+      totalContentBytes: 42,
+    });
+    const session = Session.create(provider).forSession('test-session');
+
+    const chatMessageList = await buildRecentTurnHistoryMessageList(session);
+
+    expect(chatMessageList).toEqual([
+      { role: 'user', content: 'dame ideas para el finde' },
+      { role: 'assistant', content: 'andá a la costa' },
+    ]);
+    expect(getRecentHistoryCallArgList).toHaveLength(1);
+    const [, maxContentBytes, minRecentMessages] = getRecentHistoryCallArgList[0];
+    expect(maxContentBytes).toBe(8_000);
+    expect(minRecentMessages).toBe(10);
   });
 });

--- a/src/memory/__tests__/session.spec.ts
+++ b/src/memory/__tests__/session.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+
+import { mapRecentHistoryToChatMessageList } from '@/memory/session';
+
+describe('mapRecentHistoryToChatMessageList', () => {
+  it('keeps user and assistant turns in chronological order', () => {
+    const chatMessageList = mapRecentHistoryToChatMessageList([
+      {
+        id: '1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Dame ideas para el finde' }],
+      },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Podés ir a la costa o quedarte a leer.' }],
+      },
+      { id: '3', role: 'user', parts: [{ type: 'text', text: 'Mandámelas por mail' }] },
+    ]);
+
+    expect(chatMessageList).toEqual([
+      { role: 'user', content: 'Dame ideas para el finde' },
+      { role: 'assistant', content: 'Podés ir a la costa o quedarte a leer.' },
+      { role: 'user', content: 'Mandámelas por mail' },
+    ]);
+  });
+
+  it('drops roles other than user and assistant', () => {
+    const chatMessageList = mapRecentHistoryToChatMessageList([
+      { id: '1', role: 'system', parts: [{ type: 'text', text: 'Prompt de sistema' }] },
+      { id: '2', role: 'tool', parts: [{ type: 'text', text: 'resultado de tool' }] },
+      { id: '3', role: 'user', parts: [{ type: 'text', text: 'Hola' }] },
+    ]);
+
+    expect(chatMessageList).toEqual([{ role: 'user', content: 'Hola' }]);
+  });
+
+  it('skips messages that carry no spoken text', () => {
+    const chatMessageList = mapRecentHistoryToChatMessageList([
+      { id: '1', role: 'user', parts: [{ type: 'tool-call', toolName: 'set_timer' }] },
+      { id: '2', role: 'user', parts: [{ type: 'text', text: '  ' }] },
+      { id: '3', role: 'assistant', parts: [{ type: 'text', text: 'Listo el timer.' }] },
+    ]);
+
+    expect(chatMessageList).toEqual([{ role: 'assistant', content: 'Listo el timer.' }]);
+  });
+
+  it('joins multiple text parts of the same message', () => {
+    const chatMessageList = mapRecentHistoryToChatMessageList([
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Primera parte.' },
+          { type: 'text', text: 'Segunda parte.' },
+        ],
+      },
+    ]);
+
+    expect(chatMessageList).toEqual([
+      { role: 'assistant', content: 'Primera parte. Segunda parte.' },
+    ]);
+  });
+});

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -2,10 +2,15 @@ import {
   AgentSearchProvider,
   R2SkillProvider,
   Session,
+  type SessionMessage,
 } from 'agents/experimental/memory/session';
 
 import type { Apollo } from '@/agents/apollo';
 import { buildApolloSoulPrompt } from '@/persona/soul';
+import type { OpenRouterChatMessage } from '@/voice/llm';
+
+const RECENT_TURN_HISTORY_BYTE_BUDGET = 8_000;
+const RECENT_TURN_HISTORY_MIN_MESSAGE_COUNT = 10;
 
 export function createApolloSession(agent: Apollo, mediaBucket: R2Bucket): Session {
   return Session.create(agent)
@@ -42,4 +47,35 @@ export async function rememberFactInSession(
 
 export async function buildSessionSystemPrompt(session: Session): Promise<string> {
   return session.freezeSystemPrompt();
+}
+
+function mapSessionMessageToChatMessage(
+  message: SessionMessage,
+): OpenRouterChatMessage | undefined {
+  if (message.role !== 'user' && message.role !== 'assistant') {
+    return undefined;
+  }
+  const messageText = message.parts
+    .filter((part) => part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join(' ')
+    .trim();
+  if (messageText.length === 0) {
+    return undefined;
+  }
+  return message.role === 'user'
+    ? { role: 'user', content: messageText }
+    : { role: 'assistant', content: messageText };
+}
+
+export async function buildRecentTurnHistoryMessageList(
+  session: Session,
+): Promise<readonly OpenRouterChatMessage[]> {
+  const recentHistory = await session.getRecentHistory(
+    RECENT_TURN_HISTORY_BYTE_BUDGET,
+    RECENT_TURN_HISTORY_MIN_MESSAGE_COUNT,
+  );
+  return recentHistory.messages
+    .map(mapSessionMessageToChatMessage)
+    .filter((message): message is OpenRouterChatMessage => message !== undefined);
 }

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -68,6 +68,14 @@ function mapSessionMessageToChatMessage(
     : { role: 'assistant', content: messageText };
 }
 
+export function mapRecentHistoryToChatMessageList(
+  messageList: readonly SessionMessage[],
+): readonly OpenRouterChatMessage[] {
+  return messageList
+    .map(mapSessionMessageToChatMessage)
+    .filter((message): message is OpenRouterChatMessage => message !== undefined);
+}
+
 export async function buildRecentTurnHistoryMessageList(
   session: Session,
 ): Promise<readonly OpenRouterChatMessage[]> {
@@ -75,7 +83,5 @@ export async function buildRecentTurnHistoryMessageList(
     RECENT_TURN_HISTORY_BYTE_BUDGET,
     RECENT_TURN_HISTORY_MIN_MESSAGE_COUNT,
   );
-  return recentHistory.messages
-    .map(mapSessionMessageToChatMessage)
-    .filter((message): message is OpenRouterChatMessage => message !== undefined);
+  return mapRecentHistoryToChatMessageList(recentHistory.messages);
 }

--- a/src/turn/__tests__/run.spec.ts
+++ b/src/turn/__tests__/run.spec.ts
@@ -118,6 +118,51 @@ describe('runDeskTurn', () => {
     expect(capturedSystemPrompt).toContain('café cargado');
   });
 
+  it('places recent turn history between the system prompt and the current utterance', async () => {
+    let capturedMessageList: readonly OpenRouterChatMessage[] = [];
+
+    await runDeskTurn({
+      text: 'mandámelas por mail',
+      speechMode: 'default',
+      focusState: createInactiveDeskFocusState(),
+      sqlExecutor: createInMemorySqlExecutor(),
+      environment: fakeEnvironment,
+      toolDefinitionMap: buildToolDefinitionMap([]),
+      nowMilliseconds: 10,
+      recentHistoryMessageList: [
+        { role: 'user', content: 'dame ideas para el finde' },
+        { role: 'assistant', content: 'podés ir a la costa o quedarte a leer' },
+      ],
+      adapters: {
+        stt: async () => '',
+        llm: async ({ messageList }) => {
+          capturedMessageList = messageList;
+          return { text: 'Listo, te las mando.', toolCallList: [] };
+        },
+        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+      },
+    });
+
+    expect(capturedMessageList.map((message) => message.role)).toEqual([
+      'system',
+      'user',
+      'assistant',
+      'user',
+    ]);
+    expect(capturedMessageList[1]).toEqual({
+      role: 'user',
+      content: 'dame ideas para el finde',
+    });
+    expect(capturedMessageList[2]).toEqual({
+      role: 'assistant',
+      content: 'podés ir a la costa o quedarte a leer',
+    });
+    expect(capturedMessageList[3]).toEqual({
+      role: 'user',
+      content: 'mandámelas por mail',
+    });
+  });
+
   it('treats whitespace-only speech as nothing heard', async () => {
     let didRecallSemanticMemory = false;
 

--- a/src/turn/run.ts
+++ b/src/turn/run.ts
@@ -61,6 +61,7 @@ export type TurnInput = {
   readonly nowMilliseconds: number;
   readonly deviceId?: string;
   readonly systemPromptOverride?: string;
+  readonly recentHistoryMessageList?: readonly OpenRouterChatMessage[];
   readonly recallSemanticMemoryContentList?: (
     queryText: string,
   ) => Promise<readonly string[]>;
@@ -226,11 +227,9 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
 
   const messageList: OpenRouterChatMessage[] = [
     { role: 'system', content: systemPrompt },
+    ...(input.recentHistoryMessageList ?? []),
     { role: 'user', content: userText },
   ];
-  // Each turn builds the LLM conversation from scratch, so an approved
-  // confirmation has to be replayed into it: without the tool call and its
-  // result the model only sees "confirmado" and asks what was approved.
   if (resolvedConfirmation !== undefined && resolvedConfirmationResult !== undefined) {
     messageList.push(
       buildAssistantToolCallMessage('', [


### PR DESCRIPTION
## Summary
- `runDeskTurn` rebuilt the LLM message list from scratch every turn (system prompt + current utterance only). `session.appendMessage` recorded every turn, but nothing in the interactive path ever read it back — only the once-daily owner-memory cron did, for fact extraction. So a follow-up right after a reply (e.g. saying the wake word again a moment later and asking "send me those by email") got no context, and Apollo would say it didn't know what was being referenced.
- `buildRecentTurnHistoryMessageList` (new, `src/memory/session.ts`) pulls an 8 KB / 10-message recency window via `session.getRecentHistory` and maps it to chat messages.
- `executeApolloTurn` (`src/agents/runtime.ts`) fetches that window and threads it through to `runDeskTurn`, which splices it into the message list ahead of the current utterance.
- Fixed the mock-voice test adapter, which located the user message with `.find` — now `.findLast`, since history messages carry the same `role`.
- Updated `documentation/capabilities/memory.md`, which previously documented session storage as write-only.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (490 pass)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds bounded recent-session context to voice replies so follow-up utterances can refer to prior turns.
- Reads and maps an 8 KB recency window of user and assistant messages.
- Places mapped history before the current utterance in the LLM conversation.
- Adds direct mapping, filtering, ordering, and placement coverage.
- Updates the mock voice adapter and memory documentation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previous history-sequencing coverage concern is addressed by direct mapping and final message-order tests.
</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover buildRecentTurnHistoryMessag..."](https://github.com/galfrevn/apollo/commit/3de398181a1db14bdf4eadfa6ccc626ad1323e2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52701450)</sub>

<!-- /greptile_comment -->