### PR TITLE
ci: collapse the quality gate into one job and speed up local checks

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: coverage/lcov.info
   path-prefix:
-    description: Prefix to prepend to lcov SF: paths so they match repo-root-relative PR file paths
+    description: 'Prefix to prepend to lcov SF: paths so they match repo-root-relative PR file paths'
     required: false
     default: ''
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,15 +1,22 @@
 name: Setup
 description: Install Bun, restore caches, and install workspace dependencies
+
+inputs:
+  worker-types:
+    description: Generate worker-configuration.d.ts. Only typecheck and test read it.
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: 1.3.13
 
     - name: Cache Bun install
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.bun/install/cache
         key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -17,11 +24,12 @@ runs:
           bun-${{ runner.os }}-
 
     - name: Cache Turborepo
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: .turbo
-        key: turbo-${{ runner.os }}-${{ github.sha }}
+        key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
         restore-keys: |
+          turbo-${{ runner.os }}-${{ github.job }}-
           turbo-${{ runner.os }}-
 
     - name: Install dependencies
@@ -29,5 +37,6 @@ runs:
       run: bun install --frozen-lockfile
 
     - name: Generate Worker types
+      if: inputs.worker-types == 'true'
       shell: bash
       run: bun run types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Detect code changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
         with:
           filters: |
             code:
@@ -43,12 +43,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,69 +5,42 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  lint:
-    name: Lint
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup
+        id: setup
         uses: ./.github/actions/setup
 
       - name: Run oxlint
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: bun run lint
 
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
       - name: Check formatting
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: bun run format:check
 
-  types:
-    name: Types
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
       - name: Typecheck
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: bun run typecheck
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
       - name: Run tests with coverage
+        id: test
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: bun run test:coverage
 
       - name: Patch coverage
-        if: github.event_name == 'pull_request'
+        if: ${{ !cancelled() && steps.test.outcome == 'success' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/coverage
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
       - reopened
 
 concurrency:
@@ -23,10 +22,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          worker-types: 'false'
 
       - name: Validate pull request title
         env:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Assign author
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pullRequestAuthorLogin = context.payload.pull_request.user.login;
@@ -46,13 +46,13 @@ jobs:
             }
 
       - name: Label by path
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true
 
       - name: Label by size
-        uses: codelytv/pr-size-labeler@v1
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: size/xs
@@ -69,7 +69,7 @@ jobs:
 
       - name: Comment quote
         if: github.event.action == 'opened' || github.event.action == 'ready_for_review'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('node:fs');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,19 @@ A personal desk agent for an ESP32 device: a Cloudflare Worker (`apps/agent/`) t
 
 ## Commands
 
-Root scripts proxy through turbo; target a single app directly with `turbo run <task> --filter=@apollo/agent`.
+Root scripts proxy through turbo across every workspace; target a single app with `turbo run <task> --filter=@apollo/agent`.
 
 ```bash
+bun run check        # the full quality gate, ~2s cold
 bun run dev          # turbo run dev --filter=@apollo/agent (wrangler dev, preview R2 bucket)
-bun run test         # turbo run test --filter=@apollo/agent
-bun run typecheck    # turbo run typecheck --filter=@apollo/agent
+bun run test         # turbo run test
+bun run typecheck    # turbo run typecheck
 bun run lint         # oxlint --deny-warnings (repo-wide)
 bun run format       # oxfmt --write (repo-wide)
-bun run types        # turbo run types --filter=@apollo/agent, regenerates worker-configuration.d.ts
+bun run types        # turbo run types, regenerates worker-configuration.d.ts
 ```
 
-**Quality gate — all three must pass before a change is done:** `bun run typecheck`, `bun run lint`, `bun run test`.
+**Quality gate — must pass before a change is done:** `bun run check`, which runs lint, format, typecheck, and test. The pre-push hook runs typecheck and test as a backstop.
 
 Formatting is oxfmt's job; never hand-format. Note that oxfmt does *not* sort or group imports — the Import Grouping rules below are enforced by review only.
 

--- a/documentation/operations/setup.md
+++ b/documentation/operations/setup.md
@@ -33,6 +33,7 @@ From `package.json`:
 
 | Script | Purpose |
 |--------|---------|
+| `bun run check` | Full quality gate: lint, format, typecheck, test |
 | `bun run dev` | Local Worker via Wrangler |
 | `bun run deploy` | Deploy Worker to Cloudflare |
 | `bun run typecheck` | TypeScript `--noEmit` |

--- a/documentation/operations/testing.md
+++ b/documentation/operations/testing.md
@@ -17,7 +17,7 @@ bun run test:coverage
 
 ## Quality gates
 
-Before considering a change done: `bun run typecheck`, `bun run lint`, and `bun test` should pass.
+Before considering a change done, `bun run check` should pass — it runs lint, format, typecheck, and test in one go. The pre-push hook runs typecheck and test as a backstop.
 
 ## Navigation
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,3 +31,8 @@ commit-msg:
   jobs:
     - name: commitlint
       run: bunx commitlint --edit {1}
+
+pre-push:
+  jobs:
+    - name: gate
+      run: bunx turbo run typecheck test

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
   "scripts": {
     "dev": "turbo run dev --filter=@apollo/agent",
     "deploy": "turbo run deploy --filter=@apollo/agent",
-    "types": "turbo run types --filter=@apollo/agent",
-    "typecheck": "turbo run typecheck --filter=@apollo/agent",
+    "types": "turbo run types",
+    "typecheck": "turbo run typecheck",
     "lint": "oxlint --deny-warnings",
     "format": "oxfmt --write",
     "format:check": "oxfmt --check",
-    "test": "turbo run test --filter=@apollo/agent",
-    "test:coverage": "turbo run test:coverage --filter=@apollo/agent"
+    "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage",
+    "check": "bun run lint && bun run format:check && turbo run typecheck test"
   },
   "devDependencies": {
     "turbo": "^2.5.0",

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "types": {
       "cache": true,
+      "inputs": ["wrangler.jsonc"],
       "outputs": ["worker-configuration.d.ts"]
     },
     "typecheck": {


### PR DESCRIPTION
## Why

The quality gate is about **two seconds of real work**, but it ran as four CI jobs that each paid a ~40s checkout → install → generate-types setup. Measured locally, cold, with the turbo cache wiped:

| task | real work |
|---|---|
| `lint` (oxlint, 165 files) | 0.10s |
| `format:check` | ~0.3s |
| `typecheck` (incl. `wrangler types`) | 2.0s |
| `test` (496 tests, 68 files) | 0.71s |

## CI

- **Merge lint / format / typecheck / test into one `Quality` job.** Each check is guarded with `!cancelled() && steps.setup.outcome == 'success'`, so every check still runs when an earlier one fails and a red build reports all broken checks at once, the way the split jobs did. Patch coverage is guarded on the test step specifically, so it does not fire against a missing lcov.
- **Skip Worker type generation where nothing reads it.** The setup action ran `bun run types` unconditionally; `title.yml` was installing the whole workspace and invoking wrangler to lint one line of text. Now a `worker-types` input, default on.
- **Stop validating PR titles on `synchronize`** — pushing a commit never changes the title.
- **Scope the Turborepo cache key by job.** `turbo-${{ runner.os }}-${{ github.sha }}` had every concurrent job racing to reserve one key; all but the first logged a reserve failure.
- **Drop `fetch-depth: 0` from the test job.** The coverage action reads changed files via `github.rest.pulls.listFiles`, not git, so full history was cloned for nothing.
- **Pin every external action to a commit SHA**, matching what `deploy.yml` already did. Pins are to each action's *current major*; no version upgrades here.
- **Narrow `pull-requests: write`** to the job that posts the coverage comment.

## Turborepo

The `types` task had no `inputs`, so it defaulted to every file in the package and editing any `src/**.ts` re-invoked wrangler. It only depends on `wrangler.jsonc`. Verified: after touching `apps/agent/src/index.ts`, `types` is now a cache hit while `typecheck` correctly re-runs.

## Local DX

- Root `typecheck` / `test` / `test:coverage` / `types` no longer pin `--filter=@apollo/agent`, so `apps/console/` is covered the day it gets a `package.json` instead of being silently skipped. `dev` and `deploy` keep the filter, where targeting one app is the point.
- **`bun run check`** runs the whole gate in one command — ~2s cold.
- **Pre-push hook** runs `turbo run typecheck test`. Previously those failures only surfaced ~10 minutes later in CI. It fired on the push for this PR and passed in 0.09s cached.

## Found along the way

`.github/actions/coverage/action.yml` had an unquoted `SF: ` in a description, which strict YAML parsers read as a mapping. **Not a live failure** — GitHub's parser tolerates it and CI is green today — but it breaks `actionlint` and any strict YAML tooling. Quoted it.

## Verification

- `bun run check` passes cold (1.9s)
- `actionlint` passes clean across all workflows
- All 7 workflow/action YAML files parse under strict `js-yaml`; before this, `coverage/action.yml` did not
- Confirmed the repo ruleset has no `required_status_checks`, so renaming the four checks to one strands no branch-protection rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVctoxCjZeooJz2edQqazG

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consolidates CI quality checks into one reusable-workflow job and reduces unnecessary setup work while preserving individual check execution after failures.

- Pins external GitHub Actions and narrows pull-request write permissions.
- Adds opt-out Worker type generation and job-scoped Turbo caches.
- Expands root quality scripts across workspaces and adds a pre-push typecheck/test gate.
- Narrows the Turbo `types` task inputs and updates operational documentation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The consolidated workflow preserves check execution and coverage gating, current workspaces remain compatible with the expanded Turbo commands, and relevant dependency changes still invalidate generated Worker type caches.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: collapse the quality gate into one j..."](https://github.com/galfrevn/apollo/commit/89cbaac69f032ec4f7a8d78aebfa91931ba5a097) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52717859)</sub>

<!-- /greptile_comment -->