### PR TITLE
fix(ci): pass Cloudflare credentials through turbo to wrangler

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,10 +20,12 @@
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "passThroughEnv": ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN"]
     },
     "deploy": {
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN"]
     }
   }
 }


### PR DESCRIPTION
The Deploy workflow has failed on every push since the Turborepo restructure.

## Cause

Turbo 2 runs tasks in **strict env mode**: a task only receives the environment variables it declares. `deploy` now runs as `turbo run deploy --filter=@apollo/agent`, so the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` the workflow sets on the step were filtered out before `wrangler` was invoked:

```
✘ [ERROR] In a non-interactive environment, it's necessary to set a
CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

The workflow and the `production` environment secrets are correct — nothing was missing on the GitHub side.

## Fix

Declare both variables as `passThroughEnv` on the `deploy` task, which forwards them without folding secret values into the task hash. `dev` gets the same treatment, since `wrangler dev` hits the identical trap when authenticating by token rather than `wrangler login`.

## Verification

- `turbo run deploy --dry-run json` now reports both under `passThroughEnv` (previously `null`)
- `bun run check` passes — 496 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qkhh3MjuGKELFYTkBLrXw

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR forwards existing Cloudflare credentials through Turborepo’s strict environment boundary so Wrangler can authenticate during development and deployment.

- Adds `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` to the `dev` task’s `passThroughEnv`.
- Adds the same credentials to the uncached `deploy` task’s `passThroughEnv`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The changed task configuration forwards the credentials required by the existing Wrangler scripts, while both affected tasks remain uncached and no unintended repository call path or rule violation was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pass Cloudflare credentials thr..."](https://github.com/galfrevn/apollo/commit/688b314c301f16b86539bf250f7864c4b4b277d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52726897)</sub>

<!-- /greptile_comment -->