### PR TITLE
feat: manage the agent end to end from the console

### DIFF
--- a/apps/agent/src/agents/apollo.ts
+++ b/apps/agent/src/agents/apollo.ts
@@ -33,13 +33,33 @@ import {
 } from '@/auth/role';
 import { isDeviceSharedSecretValid } from '@/auth/token';
 import {
+  mapSessionMessagesToConsoleHistory,
+  type ConsoleHistoryTurn,
+} from '@/console/history';
+import {
+  listConsoleJobDocuments,
+  readConsoleJobDocument,
+  type ConsoleJobDocument,
+} from '@/console/jobs';
+import {
   browseConsoleMemory as browseConsoleMemoryRecords,
+  deleteConsoleMemory as deleteConsoleMemoryRecord,
   type ConsoleMemoryBrowseResult,
 } from '@/console/memory';
 import {
+  consoleAddListItemInputSchema,
+  consoleAddMemoryInputSchema,
   consoleCancelReminderInputSchema,
+  consoleCreateReminderInputSchema,
+  consoleDeleteMemoryInputSchema,
+  consoleDeviceBrightnessInputSchema,
+  consoleDeviceVolumeInputSchema,
+  consoleDocumentInputSchema,
+  consoleHistoryInputSchema,
   consoleMemoryBrowseInputSchema,
+  consoleRemoveListItemInputSchema,
   consoleSecretInputSchema,
+  consoleWeatherInputSchema,
 } from '@/console/rpc';
 import { buildConsoleStatusSnapshot, type ConsoleStatusSnapshot } from '@/console/status';
 import {
@@ -60,7 +80,12 @@ import {
   type InitiativeDeliveryOutcome,
   type InitiativeUtteranceInput,
 } from '@/initiative/logic';
-import { listListItemRecords, type ListItemRecord } from '@/lists/store';
+import {
+  addListItemRecord,
+  listListItemRecords,
+  removeListItemRecordById,
+  type ListItemRecord,
+} from '@/lists/store';
 import { resolveDiscoveredMcpToolSafety } from '@/mcp/adapter';
 import {
   buildDeviceToolCallPayload,
@@ -90,13 +115,15 @@ import {
 import { OWNER_MEMORY_CONSOLIDATION_CRON } from '@/memory/consolidate';
 import { runOwnerMemoryConsolidation } from '@/memory/nightly';
 import { deletePendingDeviceMessage, listPendingDeviceMessages } from '@/memory/pending';
-import { createApolloSession } from '@/memory/session';
+import { createApolloSession, rememberFactInSession } from '@/memory/session';
 import {
+  addMemoryRecord,
   getSessionPreference,
   setSessionPreference,
   type MemorySqlExecutor,
 } from '@/memory/store';
 import { PUBLIC_ORIGIN_PREFERENCE_KEY, runFirmwareLifecycle } from '@/ota/lifecycle';
+import { enqueueMemoryIndexJob } from '@/queues/consume';
 import { cycleDeskSpeechMode, resolveDeskSpeechMode } from '@/persona/catalog';
 import { resolveDeskFaceEmotion } from '@/persona/face';
 import { APOLLO_TTS_VOICE } from '@/persona/soul';
@@ -131,6 +158,7 @@ import type {
   ToolDefinition,
   ToolExecutionResult,
 } from '@/tools/types';
+import { geocodeDeskWeatherLocation, type DeskWeatherLocation } from '@/weather/geocode';
 import type { DeskWeatherSnapshot } from '@/weather/fetch';
 import {
   resolveDeskWeatherLocationFromPreferences,
@@ -649,6 +677,152 @@ export class Apollo extends Agent<Env, ApolloState> {
     return mapAgentScheduleListToReminderList(
       mapUnknownScheduleListToAgentScheduleLikeList(await this.listSchedules()),
     );
+  }
+
+  @callable()
+  async createConsoleReminder(
+    rawInput: unknown,
+  ): Promise<readonly ScheduledReminderRow[]> {
+    const input = consoleCreateReminderInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    // Timers are recognized downstream by the "Timer" message prefix plus a
+    // numeric delay, so the console reuses the voice tool's message shape.
+    const message =
+      input.isTimer === true ? `Timer terminado: ${input.message}.` : input.message;
+    await this.schedule(input.delaySeconds, 'deliverReminder', { message });
+    if (input.isTimer === true) {
+      this.#broadcastTimerArc({
+        endsAtEpochSeconds: Math.floor(Date.now() / 1000) + input.delaySeconds,
+        durationSeconds: input.delaySeconds,
+      });
+    }
+    return this.#listConsoleReminderRowList();
+  }
+
+  @callable()
+  async setConsoleDeviceVolume(rawInput: unknown): Promise<ToolExecutionResult> {
+    const input = consoleDeviceVolumeInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    return this.#callDeviceTool('self.audio_speaker.set_volume', {
+      volume: input.volume,
+    });
+  }
+
+  @callable()
+  async setConsoleDeviceBrightness(rawInput: unknown): Promise<ToolExecutionResult> {
+    const input = consoleDeviceBrightnessInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    return this.#callDeviceTool('self.screen.set_brightness', {
+      brightness: input.brightness,
+    });
+  }
+
+  @callable()
+  async getConsoleDeviceStatus(rawInput: unknown): Promise<ToolExecutionResult> {
+    const input = consoleSecretInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    return this.#callDeviceTool('self.get_device_status', {});
+  }
+
+  @callable()
+  async addConsoleMemory(rawInput: unknown): Promise<ConsoleMemoryBrowseResult> {
+    const input = consoleAddMemoryInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const memoryRecord = await addMemoryRecord(this.#sqlExecutor(), input.content);
+    await rememberFactInSession(this.session, input.content);
+    await enqueueMemoryIndexJob(this.env, {
+      memoryId: memoryRecord.id,
+      content: input.content,
+      deviceId: this.name ?? 'default',
+    });
+    return browseConsoleMemoryRecords(this.#sqlExecutor(), {});
+  }
+
+  @callable()
+  async deleteConsoleMemory(rawInput: unknown): Promise<ConsoleMemoryBrowseResult> {
+    const input = consoleDeleteMemoryInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    await deleteConsoleMemoryRecord(
+      this.#sqlExecutor(),
+      this.env.VECTORIZE,
+      input.memoryId,
+    );
+    return browseConsoleMemoryRecords(this.#sqlExecutor(), {});
+  }
+
+  @callable()
+  async addConsoleListItem(rawInput: unknown): Promise<readonly ListItemRecord[]> {
+    const input = consoleAddListItemInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    await addListItemRecord(this.#sqlExecutor(), {
+      listName: input.listName,
+      content: input.content,
+    });
+    return listListItemRecords(this.#sqlExecutor());
+  }
+
+  @callable()
+  async removeConsoleListItem(rawInput: unknown): Promise<readonly ListItemRecord[]> {
+    const input = consoleRemoveListItemInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    await removeListItemRecordById(this.#sqlExecutor(), input.itemId);
+    return listListItemRecords(this.#sqlExecutor());
+  }
+
+  @callable()
+  async getConsoleWeather(rawInput: unknown): Promise<DeskWeatherLocation> {
+    const input = consoleSecretInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    return this.#resolveWeatherLocation();
+  }
+
+  @callable()
+  async setConsoleWeather(rawInput: unknown): Promise<DeskWeatherLocation> {
+    const input = consoleWeatherInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const location = await geocodeDeskWeatherLocation({
+      locationQuery: input.locationQuery,
+    });
+    await setSessionPreference(
+      this.#sqlExecutor(),
+      WEATHER_LOCATION_PREFERENCE_KEY,
+      serializeWeatherLocation(location),
+    );
+    await this.refreshDashboardWeather();
+    return location;
+  }
+
+  @callable()
+  async listConsoleHistory(rawInput: unknown): Promise<readonly ConsoleHistoryTurn[]> {
+    const input = consoleHistoryInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const recentHistory = await this.session.getRecentHistory(
+      input.maxContentBytes ?? 24_000,
+      10,
+    );
+    return mapSessionMessagesToConsoleHistory(recentHistory.messages);
+  }
+
+  @callable()
+  async listConsoleJobs(rawInput: unknown): Promise<readonly ConsoleJobDocument[]> {
+    const input = consoleSecretInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    return listConsoleJobDocuments(this.env.MEDIA, this.name ?? 'default');
+  }
+
+  @callable()
+  async getConsoleDocument(rawInput: unknown): Promise<{
+    readonly documentKey: string;
+    readonly content: string | null;
+  }> {
+    const input = consoleDocumentInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const content = await readConsoleJobDocument(
+      this.env.MEDIA,
+      this.name ?? 'default',
+      input.documentKey,
+    );
+    return { documentKey: input.documentKey, content };
   }
 
   @callable()

--- a/apps/agent/src/console/__tests__/history.spec.ts
+++ b/apps/agent/src/console/__tests__/history.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+
+import { mapSessionMessagesToConsoleHistory } from '@/console/history';
+
+describe('console history mapping', () => {
+  it('joins text parts and keeps roles in order', () => {
+    const turnList = mapSessionMessagesToConsoleHistory([
+      { id: 'a', role: 'user', parts: [{ type: 'text', text: 'poné un timer' }] },
+      {
+        id: 'b',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Listo,' },
+          { type: 'text', text: 'timer de 5 minutos.' },
+        ],
+      },
+    ]);
+
+    expect(turnList).toEqual([
+      { id: 'a', role: 'user', text: 'poné un timer' },
+      { id: 'b', role: 'assistant', text: 'Listo,\ntimer de 5 minutos.' },
+    ]);
+  });
+
+  it('drops non-text parts and empty messages', () => {
+    const turnList = mapSessionMessagesToConsoleHistory([
+      { id: 'a', role: 'assistant', parts: [{ type: 'reasoning' }] },
+      { id: 'b', role: 'user', parts: [{ type: 'text', text: '   ' }] },
+      { id: 'c', role: 'user', parts: [{ type: 'text', text: 'hola' }] },
+    ]);
+
+    expect(turnList).toEqual([{ id: 'c', role: 'user', text: 'hola' }]);
+  });
+});

--- a/apps/agent/src/console/__tests__/jobs.spec.ts
+++ b/apps/agent/src/console/__tests__/jobs.spec.ts
@@ -9,17 +9,25 @@ import type { ConsoleDocumentBucket } from '@/console/jobs';
 
 function createFakeDocumentBucket(
   objectMap: Record<string, { uploaded: Date; content: string }>,
+  pageSize?: number,
 ): ConsoleDocumentBucket {
   return {
-    async list({ prefix }) {
+    async list({ prefix, cursor }) {
+      const matchingObjectList = Object.entries(objectMap)
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => ({
+          key,
+          uploaded: value.uploaded,
+          size: value.content.length,
+        }));
+      const startIndex = cursor === undefined ? 0 : Number(cursor);
+      const endIndex =
+        pageSize === undefined ? matchingObjectList.length : startIndex + pageSize;
+      const isTruncated = endIndex < matchingObjectList.length;
       return {
-        objects: Object.entries(objectMap)
-          .filter(([key]) => key.startsWith(prefix))
-          .map(([key, value]) => ({
-            key,
-            uploaded: value.uploaded,
-            size: value.content.length,
-          })),
+        objects: matchingObjectList.slice(startIndex, endIndex),
+        truncated: isTruncated,
+        ...(isTruncated ? { cursor: String(endIndex) } : {}),
       };
     },
     async get(key) {
@@ -59,6 +67,22 @@ describe('console job documents', () => {
     await expect(
       readConsoleJobDocument(bucket, 'desk', 'firmware/latest.json'),
     ).resolves.toBeNull();
+  });
+
+  it('follows the listing cursor across pages', async () => {
+    const paginatedBucket = createFakeDocumentBucket(
+      {
+        'research/desk/a.md': { uploaded: new Date('2026-08-01'), content: 'a' },
+        'research/desk/b.md': { uploaded: new Date('2026-08-02'), content: 'b' },
+        'research/desk/c.md': { uploaded: new Date('2026-08-03'), content: 'c' },
+      },
+      1,
+    );
+
+    const documentList = await listConsoleJobDocuments(paginatedBucket, 'desk');
+
+    expect(documentList).toHaveLength(3);
+    expect(documentList[0]?.documentKey).toBe('research/desk/c.md');
   });
 
   it('guards key prefixes strictly', () => {

--- a/apps/agent/src/console/__tests__/jobs.spec.ts
+++ b/apps/agent/src/console/__tests__/jobs.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  isConsoleReadableDocumentKey,
+  listConsoleJobDocuments,
+  readConsoleJobDocument,
+} from '@/console/jobs';
+import type { ConsoleDocumentBucket } from '@/console/jobs';
+
+function createFakeDocumentBucket(
+  objectMap: Record<string, { uploaded: Date; content: string }>,
+): ConsoleDocumentBucket {
+  return {
+    async list({ prefix }) {
+      return {
+        objects: Object.entries(objectMap)
+          .filter(([key]) => key.startsWith(prefix))
+          .map(([key, value]) => ({
+            key,
+            uploaded: value.uploaded,
+            size: value.content.length,
+          })),
+      };
+    },
+    async get(key) {
+      const object = objectMap[key];
+      return object === undefined ? null : { text: async () => object.content };
+    },
+  };
+}
+
+describe('console job documents', () => {
+  const bucket = createFakeDocumentBucket({
+    'research/desk/run-1.md': { uploaded: new Date('2026-08-01'), content: '# uno' },
+    'research/desk/run-2.md': { uploaded: new Date('2026-08-10'), content: '# dos' },
+    'coding/desk/run-3.md': { uploaded: new Date('2026-08-05'), content: '# tres' },
+    'research/other/run-4.md': { uploaded: new Date('2026-08-11'), content: '# ajeno' },
+    'firmware/latest.json': { uploaded: new Date('2026-08-11'), content: '{}' },
+  });
+
+  it('lists research and coding documents for the device, newest first', async () => {
+    const documentList = await listConsoleJobDocuments(bucket, 'desk');
+    expect(documentList.map((document) => document.documentKey)).toEqual([
+      'research/desk/run-2.md',
+      'coding/desk/run-3.md',
+      'research/desk/run-1.md',
+    ]);
+    expect(documentList[0]?.kind).toBe('research');
+    expect(documentList[1]?.kind).toBe('coding');
+  });
+
+  it('reads a document only inside the device prefixes', async () => {
+    await expect(
+      readConsoleJobDocument(bucket, 'desk', 'coding/desk/run-3.md'),
+    ).resolves.toBe('# tres');
+    await expect(
+      readConsoleJobDocument(bucket, 'desk', 'research/other/run-4.md'),
+    ).resolves.toBeNull();
+    await expect(
+      readConsoleJobDocument(bucket, 'desk', 'firmware/latest.json'),
+    ).resolves.toBeNull();
+  });
+
+  it('guards key prefixes strictly', () => {
+    expect(isConsoleReadableDocumentKey('research/desk/x.md', 'desk')).toBe(true);
+    expect(isConsoleReadableDocumentKey('research/desk2/x.md', 'desk')).toBe(false);
+    expect(isConsoleReadableDocumentKey('skills/desk/x.md', 'desk')).toBe(false);
+  });
+});

--- a/apps/agent/src/console/__tests__/memory.spec.ts
+++ b/apps/agent/src/console/__tests__/memory.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { browseConsoleMemory } from '@/console/memory';
+import { browseConsoleMemory, deleteConsoleMemory } from '@/console/memory';
 import { addMemoryRecord, setSessionPreference } from '@/memory/store';
 import type { MemorySqlExecutor } from '@/memory/store';
 
@@ -18,6 +18,14 @@ function createInMemoryConsoleSqlExecutor(): MemorySqlExecutor {
           content: String(bindValues[1]),
           created_at: Number(bindValues[2]),
         });
+        return [];
+      }
+      if (query.startsWith('DELETE FROM memories')) {
+        const targetId = String(bindValues[0]);
+        const targetIndex = memoryRowList.findIndex((row) => row.id === targetId);
+        if (targetIndex >= 0) {
+          memoryRowList.splice(targetIndex, 1);
+        }
         return [];
       }
       if (query.startsWith('INSERT INTO session_prefs')) {
@@ -98,6 +106,22 @@ describe('console memory browse', () => {
     expect(browseResult.ownerFactList).toHaveLength(1);
     expect(browseResult.ownerFactList[0]?.content).toBe('lives in Buenos Aires');
     expect(browseResult.lastConsolidatedAtMilliseconds).toBe(99);
+  });
+
+  it('deletes a memory from sql and its vector together', async () => {
+    const sqlExecutor = createInMemoryConsoleSqlExecutor();
+    const addedRecord = await addMemoryRecord(sqlExecutor, 'fact to forget', 1);
+    const deletedVectorIdList: string[] = [];
+
+    await deleteConsoleMemory(
+      sqlExecutor,
+      { deleteByIds: async (idList) => deletedVectorIdList.push(...idList) },
+      addedRecord.id,
+    );
+
+    const browseResult = await browseConsoleMemory(sqlExecutor, {});
+    expect(browseResult.memoryList).toEqual([]);
+    expect(deletedVectorIdList).toEqual([addedRecord.id]);
   });
 
   it('treats a corrupt stored owner-memory state as absent', async () => {

--- a/apps/agent/src/console/history.ts
+++ b/apps/agent/src/console/history.ts
@@ -1,0 +1,29 @@
+export type ConsoleHistoryTurn = {
+  readonly id: string;
+  readonly role: string;
+  readonly text: string;
+};
+
+type SessionMessageLike = {
+  readonly id: string;
+  readonly role: string;
+  readonly parts: readonly { readonly type: string; readonly text?: string }[];
+};
+
+export function mapSessionMessagesToConsoleHistory(
+  messageList: readonly SessionMessageLike[],
+): readonly ConsoleHistoryTurn[] {
+  const turnList: ConsoleHistoryTurn[] = [];
+  for (const message of messageList) {
+    const text = message.parts
+      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .map((part) => part.text)
+      .join('\n')
+      .trim();
+    if (text.length === 0) {
+      continue;
+    }
+    turnList.push({ id: message.id, role: message.role, text });
+  }
+  return turnList;
+}

--- a/apps/agent/src/console/jobs.ts
+++ b/apps/agent/src/console/jobs.ts
@@ -1,0 +1,70 @@
+export type ConsoleJobDocument = {
+  readonly documentKey: string;
+  readonly kind: 'research' | 'coding';
+  readonly uploadedAtIso: string;
+  readonly sizeBytes: number;
+};
+
+type BucketListingLike = {
+  readonly objects: readonly {
+    readonly key: string;
+    readonly uploaded: Date;
+    readonly size: number;
+  }[];
+};
+
+export type ConsoleDocumentBucket = {
+  list(options: { prefix: string; limit?: number }): Promise<BucketListingLike>;
+  get(key: string): Promise<{ text(): Promise<string> } | null>;
+};
+
+const JOB_KIND_PREFIX_LIST = ['research', 'coding'] as const;
+const JOB_LISTING_LIMIT_PER_KIND = 50;
+
+export async function listConsoleJobDocuments(
+  bucket: ConsoleDocumentBucket,
+  deviceId: string,
+): Promise<readonly ConsoleJobDocument[]> {
+  const documentList: ConsoleJobDocument[] = [];
+  for (const kind of JOB_KIND_PREFIX_LIST) {
+    const listing = await bucket.list({
+      prefix: `${kind}/${deviceId}/`,
+      limit: JOB_LISTING_LIMIT_PER_KIND,
+    });
+    for (const object of listing.objects) {
+      documentList.push({
+        documentKey: object.key,
+        kind,
+        uploadedAtIso: object.uploaded.toISOString(),
+        sizeBytes: object.size,
+      });
+    }
+  }
+  return documentList.toSorted((left, right) =>
+    right.uploadedAtIso.localeCompare(left.uploadedAtIso),
+  );
+}
+
+export function isConsoleReadableDocumentKey(
+  documentKey: string,
+  deviceId: string,
+): boolean {
+  return JOB_KIND_PREFIX_LIST.some((kind) =>
+    documentKey.startsWith(`${kind}/${deviceId}/`),
+  );
+}
+
+export async function readConsoleJobDocument(
+  bucket: ConsoleDocumentBucket,
+  deviceId: string,
+  documentKey: string,
+): Promise<string | null> {
+  if (!isConsoleReadableDocumentKey(documentKey, deviceId)) {
+    return null;
+  }
+  const object = await bucket.get(documentKey);
+  if (object === null) {
+    return null;
+  }
+  return object.text();
+}

--- a/apps/agent/src/console/jobs.ts
+++ b/apps/agent/src/console/jobs.ts
@@ -11,15 +11,22 @@ type BucketListingLike = {
     readonly uploaded: Date;
     readonly size: number;
   }[];
+  readonly truncated: boolean;
+  readonly cursor?: string;
 };
 
 export type ConsoleDocumentBucket = {
-  list(options: { prefix: string; limit?: number }): Promise<BucketListingLike>;
+  list(options: {
+    prefix: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<BucketListingLike>;
   get(key: string): Promise<{ text(): Promise<string> } | null>;
 };
 
 const JOB_KIND_PREFIX_LIST = ['research', 'coding'] as const;
-const JOB_LISTING_LIMIT_PER_KIND = 50;
+const JOB_LISTING_PAGE_SIZE = 500;
+const JOB_LISTING_MAX_DOCUMENTS_PER_KIND = 2_000;
 
 export async function listConsoleJobDocuments(
   bucket: ConsoleDocumentBucket,
@@ -27,18 +34,25 @@ export async function listConsoleJobDocuments(
 ): Promise<readonly ConsoleJobDocument[]> {
   const documentList: ConsoleJobDocument[] = [];
   for (const kind of JOB_KIND_PREFIX_LIST) {
-    const listing = await bucket.list({
-      prefix: `${kind}/${deviceId}/`,
-      limit: JOB_LISTING_LIMIT_PER_KIND,
-    });
-    for (const object of listing.objects) {
-      documentList.push({
-        documentKey: object.key,
-        kind,
-        uploadedAtIso: object.uploaded.toISOString(),
-        sizeBytes: object.size,
+    let cursor: string | undefined;
+    let collectedCount = 0;
+    do {
+      const listing = await bucket.list({
+        prefix: `${kind}/${deviceId}/`,
+        limit: JOB_LISTING_PAGE_SIZE,
+        ...(cursor === undefined ? {} : { cursor }),
       });
-    }
+      for (const object of listing.objects) {
+        documentList.push({
+          documentKey: object.key,
+          kind,
+          uploadedAtIso: object.uploaded.toISOString(),
+          sizeBytes: object.size,
+        });
+      }
+      collectedCount += listing.objects.length;
+      cursor = listing.truncated ? listing.cursor : undefined;
+    } while (cursor !== undefined && collectedCount < JOB_LISTING_MAX_DOCUMENTS_PER_KIND);
   }
   return documentList.toSorted((left, right) =>
     right.uploadedAtIso.localeCompare(left.uploadedAtIso),

--- a/apps/agent/src/console/memory.ts
+++ b/apps/agent/src/console/memory.ts
@@ -16,6 +16,24 @@ export type ConsoleMemoryBrowseResult = {
   readonly lastConsolidatedAtMilliseconds: number | null;
 };
 
+type MemoryVectorIndexLike = {
+  deleteByIds(idList: string[]): Promise<unknown>;
+};
+
+// The Vectorize entry shares the memory record's UUID, so both stores are
+// cleared together — vector first, so a failed vector delete leaves the SQL
+// row intact instead of orphaning an embedding that voice recall would still
+// surface. The consolidated owner-fact list is left untouched: the next
+// nightly run may re-derive a fact whose source memory still reads true.
+export async function deleteConsoleMemory(
+  sqlExecutor: MemorySqlExecutor,
+  vectorIndex: MemoryVectorIndexLike,
+  memoryId: string,
+): Promise<void> {
+  await vectorIndex.deleteByIds([memoryId]);
+  sqlExecutor.execute('DELETE FROM memories WHERE id = ?', memoryId);
+}
+
 export async function browseConsoleMemory(
   sqlExecutor: MemorySqlExecutor,
   input: { readonly query?: string; readonly limit?: number },

--- a/apps/agent/src/console/rpc.ts
+++ b/apps/agent/src/console/rpc.ts
@@ -12,3 +12,46 @@ export const consoleMemoryBrowseInputSchema = consoleSecretInputSchema.extend({
 export const consoleCancelReminderInputSchema = consoleSecretInputSchema.extend({
   reminderId: z.string().min(1),
 });
+
+export const consoleCreateReminderInputSchema = consoleSecretInputSchema.extend({
+  message: z.string().min(1).max(200),
+  delaySeconds: z.number().int().min(5).max(86_400),
+  isTimer: z.boolean().optional(),
+});
+
+export const consoleDeviceVolumeInputSchema = consoleSecretInputSchema.extend({
+  volume: z.number().int().min(0).max(100),
+});
+
+export const consoleDeviceBrightnessInputSchema = consoleSecretInputSchema.extend({
+  brightness: z.number().int().min(0).max(100),
+});
+
+export const consoleAddMemoryInputSchema = consoleSecretInputSchema.extend({
+  content: z.string().min(1).max(500),
+});
+
+export const consoleDeleteMemoryInputSchema = consoleSecretInputSchema.extend({
+  memoryId: z.string().min(1),
+});
+
+export const consoleAddListItemInputSchema = consoleSecretInputSchema.extend({
+  listName: z.string().min(1).max(60),
+  content: z.string().min(1).max(200),
+});
+
+export const consoleRemoveListItemInputSchema = consoleSecretInputSchema.extend({
+  itemId: z.string().min(1),
+});
+
+export const consoleWeatherInputSchema = consoleSecretInputSchema.extend({
+  locationQuery: z.string().min(1).max(100),
+});
+
+export const consoleHistoryInputSchema = consoleSecretInputSchema.extend({
+  maxContentBytes: z.number().int().min(1_000).max(100_000).optional(),
+});
+
+export const consoleDocumentInputSchema = consoleSecretInputSchema.extend({
+  documentKey: z.string().min(1).max(300),
+});

--- a/apps/agent/src/lists/__tests__/store.spec.ts
+++ b/apps/agent/src/lists/__tests__/store.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   addListItemRecord,
   listListItemRecords,
+  removeListItemRecordById,
   removeListItemRecords,
 } from '@/lists/store';
 import type { MemorySqlExecutor } from '@/memory/store';
@@ -88,6 +89,25 @@ describe('list store', () => {
     });
     expect(clearRemoval.removedCount).toBe(1);
     expect(await listListItemRecords(sqlExecutor, 'super')).toEqual([]);
+  });
+
+  it('removes a single item by id', async () => {
+    const sqlExecutor = createInMemoryListSqlExecutor();
+    const keptItem = await addListItemRecord(
+      sqlExecutor,
+      { listName: 'super', content: 'yerba' },
+      1,
+    );
+    const removedItem = await addListItemRecord(
+      sqlExecutor,
+      { listName: 'super', content: 'pan' },
+      2,
+    );
+
+    await removeListItemRecordById(sqlExecutor, removedItem.id);
+
+    const remainingItemList = await listListItemRecords(sqlExecutor, 'super');
+    expect(remainingItemList.map((item) => item.id)).toEqual([keptItem.id]);
   });
 
   it('never wipes a list when the content query is blank and clearAll is off', async () => {

--- a/apps/agent/src/lists/store.ts
+++ b/apps/agent/src/lists/store.ts
@@ -65,6 +65,13 @@ export async function listListItemRecords(
   return rowList.map(toListItemRecord);
 }
 
+export async function removeListItemRecordById(
+  sqlExecutor: MemorySqlExecutor,
+  itemId: string,
+): Promise<void> {
+  sqlExecutor.execute('DELETE FROM list_items WHERE id = ?', itemId);
+}
+
 export async function removeListItemRecords(
   sqlExecutor: MemorySqlExecutor,
   input: {

--- a/apps/console/src/agent/rpc.ts
+++ b/apps/console/src/agent/rpc.ts
@@ -1,12 +1,18 @@
 import { z } from 'zod';
 
 import {
+  apolloStateSchema,
   consoleStatusSchema,
+  deviceCommandResultSchema,
+  historyTurnListSchema,
+  jobDocumentContentSchema,
+  jobDocumentListSchema,
   listItemListSchema,
   mcpInstallResultSchema,
   mcpServerListSchema,
   memoryBrowseResultSchema,
   reminderListSchema,
+  weatherLocationSchema,
 } from '@/agent/schema';
 
 type AgentCall = (method: string, args?: unknown[]) => Promise<unknown>;
@@ -22,6 +28,10 @@ export function createConsoleRpc(call: AgentCall, secret: string) {
   };
 
   return {
+    // confirmAction predates the console-rpc pattern: it takes a bare boolean
+    // and is gated at connect time only, so it bypasses invoke().
+    confirmPendingAction: async (isApproved: boolean) =>
+      apolloStateSchema.parse(await call('confirmAction', [isApproved])),
     getStatus: () => invoke('getConsoleStatus', consoleStatusSchema),
     browseMemory: (query?: string) =>
       invoke('browseConsoleMemory', memoryBrowseResultSchema, { query }),
@@ -29,6 +39,31 @@ export function createConsoleRpc(call: AgentCall, secret: string) {
     listReminders: () => invoke('listConsoleReminders', reminderListSchema),
     cancelReminder: (reminderId: string) =>
       invoke('cancelConsoleReminder', reminderListSchema, { reminderId }),
+    createReminder: (message: string, delaySeconds: number, isTimer: boolean) =>
+      invoke('createConsoleReminder', reminderListSchema, {
+        message,
+        delaySeconds,
+        isTimer,
+      }),
+    setDeviceVolume: (volume: number) =>
+      invoke('setConsoleDeviceVolume', deviceCommandResultSchema, { volume }),
+    setDeviceBrightness: (brightness: number) =>
+      invoke('setConsoleDeviceBrightness', deviceCommandResultSchema, { brightness }),
+    addMemory: (content: string) =>
+      invoke('addConsoleMemory', memoryBrowseResultSchema, { content }),
+    deleteMemory: (memoryId: string) =>
+      invoke('deleteConsoleMemory', memoryBrowseResultSchema, { memoryId }),
+    addListItem: (listName: string, content: string) =>
+      invoke('addConsoleListItem', listItemListSchema, { listName, content }),
+    removeListItem: (itemId: string) =>
+      invoke('removeConsoleListItem', listItemListSchema, { itemId }),
+    getWeather: () => invoke('getConsoleWeather', weatherLocationSchema),
+    setWeather: (locationQuery: string) =>
+      invoke('setConsoleWeather', weatherLocationSchema, { locationQuery }),
+    listHistory: () => invoke('listConsoleHistory', historyTurnListSchema),
+    listJobs: () => invoke('listConsoleJobs', jobDocumentListSchema),
+    getDocument: (documentKey: string) =>
+      invoke('getConsoleDocument', jobDocumentContentSchema, { documentKey }),
     listMcpServers: () => invoke('listMcpServers', mcpServerListSchema),
     installMcpServer: (name: string, url: string) =>
       invoke('installMcpServer', mcpInstallResultSchema, { name, url }),

--- a/apps/console/src/agent/schema.ts
+++ b/apps/console/src/agent/schema.ts
@@ -114,3 +114,48 @@ export const mcpInstallResultSchema = z.object({
 });
 
 export type McpInstallResult = z.infer<typeof mcpInstallResultSchema>;
+
+export const deviceCommandResultSchema = z.object({
+  ok: z.boolean(),
+  summary: z.string(),
+  data: z.unknown().optional(),
+});
+
+export type DeviceCommandResult = z.infer<typeof deviceCommandResultSchema>;
+
+export const weatherLocationSchema = z.object({
+  locationLabel: z.string(),
+  latitude: z.number(),
+  longitude: z.number(),
+  timezone: z.string(),
+});
+
+export type WeatherLocation = z.infer<typeof weatherLocationSchema>;
+
+export const historyTurnSchema = z.object({
+  id: z.string(),
+  role: z.string(),
+  text: z.string(),
+});
+
+export const historyTurnListSchema = z.array(historyTurnSchema);
+
+export type HistoryTurn = z.infer<typeof historyTurnSchema>;
+
+export const jobDocumentSchema = z.object({
+  documentKey: z.string(),
+  kind: z.enum(['research', 'coding']),
+  uploadedAtIso: z.string(),
+  sizeBytes: z.number(),
+});
+
+export const jobDocumentListSchema = z.array(jobDocumentSchema);
+
+export type JobDocument = z.infer<typeof jobDocumentSchema>;
+
+export const jobDocumentContentSchema = z.object({
+  documentKey: z.string(),
+  content: z.string().nullable(),
+});
+
+export type JobDocumentContent = z.infer<typeof jobDocumentContentSchema>;

--- a/apps/console/src/history/page.tsx
+++ b/apps/console/src/history/page.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { Empty } from '@/blueprint/empty';
+import { Heading } from '@/blueprint/heading';
+import { Panel } from '@/blueprint/panel';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/components/utility';
+import type { ConsoleRpc } from '@/agent/rpc';
+import type { HistoryTurn } from '@/agent/schema';
+
+export function HistoryPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) {
+  const [turnList, setTurnList] = useState<readonly HistoryTurn[] | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const refreshHistory = useCallback(async () => {
+    setErrorMessage(null);
+    try {
+      setTurnList(await consoleRpc.listHistory());
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Could not load the history.',
+      );
+    }
+  }, [consoleRpc]);
+
+  useEffect(() => {
+    void refreshHistory();
+  }, [refreshHistory]);
+
+  return (
+    <div className="settle space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <Heading description="Recent voice turns between the owner and the agent">
+          History
+        </Heading>
+        <Button variant="outline" size="sm" onClick={() => void refreshHistory()}>
+          Refresh
+        </Button>
+      </div>
+
+      {errorMessage !== null && (
+        <p
+          role="alert"
+          className="rounded-lg border border-danger/40 bg-dangerdim px-3 py-2 text-xs text-danger"
+        >
+          {errorMessage}
+        </p>
+      )}
+
+      <Panel
+        title="Conversation"
+        meta={
+          turnList !== null ? (
+            <span className="text-xs text-faint">{turnList.length} turns</span>
+          ) : undefined
+        }
+      >
+        {turnList === null ? (
+          <p className="p-4 text-sm text-muted">Loading…</p>
+        ) : turnList.length === 0 ? (
+          <Empty message="No conversation yet — talk to the desk" className="m-4" />
+        ) : (
+          <ol className="space-y-3 p-4">
+            {turnList.map((turn) => (
+              <li
+                key={turn.id}
+                className={cn(
+                  'flex',
+                  turn.role === 'assistant' ? 'justify-start' : 'justify-end',
+                )}
+              >
+                <div
+                  className={cn(
+                    'max-w-[85%] rounded-lg border px-3 py-2 sm:max-w-[70%]',
+                    turn.role === 'assistant'
+                      ? 'border-line bg-raised'
+                      : 'border-amber/30 bg-amberdim',
+                  )}
+                >
+                  <p className="label-soft mb-1 text-faint">
+                    {turn.role === 'assistant' ? 'Apollo' : 'Owner'}
+                  </p>
+                  <p className="text-sm whitespace-pre-wrap">{turn.text}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </Panel>
+
+      <p className="text-xs text-faint">
+        Voice turns only — tool calls are not recorded in the session today.
+      </p>
+    </div>
+  );
+}

--- a/apps/console/src/jobs/page.tsx
+++ b/apps/console/src/jobs/page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Empty } from '@/blueprint/empty';
 import { Heading } from '@/blueprint/heading';
@@ -20,6 +20,7 @@ export function JobsPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) {
   const [openDocumentKey, setOpenDocumentKey] = useState<string | null>(null);
   const [openDocumentContent, setOpenDocumentContent] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const openDocumentKeyRef = useRef<string | null>(null);
 
   const refreshDocumentList = useCallback(async () => {
     setErrorMessage(null);
@@ -36,17 +37,23 @@ export function JobsPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) {
 
   async function handleOpenDocument(documentKey: string) {
     if (openDocumentKey === documentKey) {
+      openDocumentKeyRef.current = null;
       setOpenDocumentKey(null);
       setOpenDocumentContent(null);
       return;
     }
+    openDocumentKeyRef.current = documentKey;
     setOpenDocumentKey(documentKey);
     setOpenDocumentContent(null);
+    let loadedContent: string;
     try {
       const documentResult = await consoleRpc.getDocument(documentKey);
-      setOpenDocumentContent(documentResult.content ?? 'Document not found.');
+      loadedContent = documentResult.content ?? 'Document not found.';
     } catch {
-      setOpenDocumentContent('Could not load the document.');
+      loadedContent = 'Could not load the document.';
+    }
+    if (openDocumentKeyRef.current === documentKey) {
+      setOpenDocumentContent(loadedContent);
     }
   }
 

--- a/apps/console/src/jobs/page.tsx
+++ b/apps/console/src/jobs/page.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { Empty } from '@/blueprint/empty';
+import { Heading } from '@/blueprint/heading';
+import { Panel } from '@/blueprint/panel';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { ConsoleRpc } from '@/agent/rpc';
+import type { JobDocument } from '@/agent/schema';
+
+function formatSizeLabel(sizeBytes: number): string {
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+  return `${(sizeBytes / 1024).toFixed(1)} kB`;
+}
+
+export function JobsPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) {
+  const [documentList, setDocumentList] = useState<readonly JobDocument[] | null>(null);
+  const [openDocumentKey, setOpenDocumentKey] = useState<string | null>(null);
+  const [openDocumentContent, setOpenDocumentContent] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const refreshDocumentList = useCallback(async () => {
+    setErrorMessage(null);
+    try {
+      setDocumentList(await consoleRpc.listJobs());
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Could not list jobs.');
+    }
+  }, [consoleRpc]);
+
+  useEffect(() => {
+    void refreshDocumentList();
+  }, [refreshDocumentList]);
+
+  async function handleOpenDocument(documentKey: string) {
+    if (openDocumentKey === documentKey) {
+      setOpenDocumentKey(null);
+      setOpenDocumentContent(null);
+      return;
+    }
+    setOpenDocumentKey(documentKey);
+    setOpenDocumentContent(null);
+    try {
+      const documentResult = await consoleRpc.getDocument(documentKey);
+      setOpenDocumentContent(documentResult.content ?? 'Document not found.');
+    } catch {
+      setOpenDocumentContent('Could not load the document.');
+    }
+  }
+
+  return (
+    <div className="settle space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <Heading description="Documents produced by research and coding runs">
+          Jobs
+        </Heading>
+        <Button variant="outline" size="sm" onClick={() => void refreshDocumentList()}>
+          Refresh
+        </Button>
+      </div>
+
+      {errorMessage !== null && (
+        <p
+          role="alert"
+          className="rounded-lg border border-danger/40 bg-dangerdim px-3 py-2 text-xs text-danger"
+        >
+          {errorMessage}
+        </p>
+      )}
+
+      <Panel
+        title="Run documents"
+        meta={
+          documentList !== null ? (
+            <span className="text-xs text-faint">{documentList.length} documents</span>
+          ) : undefined
+        }
+      >
+        {documentList === null ? (
+          <p className="p-4 text-sm text-muted">Loading…</p>
+        ) : documentList.length === 0 ? (
+          <Empty
+            message="No run documents yet — ask the desk to research something"
+            className="m-4"
+          />
+        ) : (
+          <ul>
+            {documentList.map((jobDocument) => (
+              <li
+                key={jobDocument.documentKey}
+                className="border-b border-line last:border-b-0"
+              >
+                <button
+                  type="button"
+                  onClick={() => void handleOpenDocument(jobDocument.documentKey)}
+                  aria-expanded={openDocumentKey === jobDocument.documentKey}
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors duration-150 hover:bg-raised"
+                >
+                  <Badge variant={jobDocument.kind === 'coding' ? 'amber' : 'outline'}>
+                    {jobDocument.kind}
+                  </Badge>
+                  <span className="min-w-0 flex-1 truncate font-mono text-xs">
+                    {jobDocument.documentKey.split('/').at(-1)}
+                  </span>
+                  <span className="shrink-0 text-xs whitespace-nowrap text-faint">
+                    {new Date(jobDocument.uploadedAtIso).toLocaleString()} ·{' '}
+                    {formatSizeLabel(jobDocument.sizeBytes)}
+                  </span>
+                </button>
+                {openDocumentKey === jobDocument.documentKey && (
+                  <div className="border-t border-line bg-ground px-4 py-3">
+                    {openDocumentContent === null ? (
+                      <p className="text-sm text-muted">Loading document…</p>
+                    ) : (
+                      <pre className="max-h-96 overflow-auto font-mono text-xs leading-relaxed whitespace-pre-wrap">
+                        {openDocumentContent}
+                      </pre>
+                    )}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </div>
+  );
+}

--- a/apps/console/src/layout/nav.tsx
+++ b/apps/console/src/layout/nav.tsx
@@ -7,6 +7,8 @@ const ROUTE_LABEL_MAP: Record<ConsoleRoute, string> = {
   mcp: 'MCP',
   memory: 'Memory',
   schedules: 'Schedules',
+  history: 'History',
+  jobs: 'Jobs',
 };
 
 export function Nav() {

--- a/apps/console/src/layout/shell.tsx
+++ b/apps/console/src/layout/shell.tsx
@@ -5,6 +5,8 @@ import { createConsoleRpc } from '@/agent/rpc';
 import { Chip } from '@/blueprint/chip';
 import { Button } from '@/components/ui/button';
 import { useConnection } from '@/connection/context';
+import { HistoryPage } from '@/history/page';
+import { JobsPage } from '@/jobs/page';
 import { Nav } from '@/layout/nav';
 import { McpPage } from '@/mcp/page';
 import { MemoryPage } from '@/memory/page';
@@ -87,6 +89,8 @@ export function Shell({ connection }: { readonly connection: ConsoleConnection }
           {activeRoute === 'mcp' && <McpPage consoleRpc={consoleRpc} />}
           {activeRoute === 'memory' && <MemoryPage consoleRpc={consoleRpc} />}
           {activeRoute === 'schedules' && <SchedulesPage consoleRpc={consoleRpc} />}
+          {activeRoute === 'history' && <HistoryPage consoleRpc={consoleRpc} />}
+          {activeRoute === 'jobs' && <JobsPage consoleRpc={consoleRpc} />}
         </main>
       </div>
     </div>

--- a/apps/console/src/memory/lists.tsx
+++ b/apps/console/src/memory/lists.tsx
@@ -1,36 +1,129 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+
+import { XIcon } from 'lucide-react';
+
 import { Empty } from '@/blueprint/empty';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import type { ListItem } from '@/agent/schema';
 
-export function ListsBlock({ itemList }: { readonly itemList: readonly ListItem[] }) {
-  if (itemList.length === 0) {
-    return <Empty message="No lists yet — ask the desk to note something" />;
+function AddItemForm({
+  onAdd,
+}: {
+  readonly onAdd: (listName: string, content: string) => Promise<void>;
+}) {
+  const [listName, setListName] = useState('');
+  const [content, setContent] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (listName.trim().length === 0 || content.trim().length === 0) {
+      return;
+    }
+    setIsAdding(true);
+    try {
+      await onAdd(listName.trim(), content.trim());
+      setContent('');
+    } finally {
+      setIsAdding(false);
+    }
   }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-wrap gap-2 border-b border-line p-3"
+      aria-busy={isAdding}
+    >
+      <Input
+        value={listName}
+        onChange={(event) => setListName(event.target.value)}
+        placeholder="List (e.g. super)"
+        aria-label="List name"
+        className="h-8 w-36 text-xs"
+      />
+      <Input
+        value={content}
+        onChange={(event) => setContent(event.target.value)}
+        placeholder="New item…"
+        aria-label="Item content"
+        className="h-8 min-w-40 flex-1 text-xs"
+      />
+      <Button type="submit" variant="outline" size="sm" disabled={isAdding}>
+        Add
+      </Button>
+    </form>
+  );
+}
+
+export function ListsBlock({
+  itemList,
+  onAdd,
+  onRemove,
+}: {
+  readonly itemList: readonly ListItem[];
+  readonly onAdd: (listName: string, content: string) => Promise<void>;
+  readonly onRemove: (itemId: string) => Promise<void>;
+}) {
+  const [busyItemId, setBusyItemId] = useState<string | null>(null);
+
+  async function handleRemove(itemId: string) {
+    setBusyItemId(itemId);
+    try {
+      await onRemove(itemId);
+    } finally {
+      setBusyItemId(null);
+    }
+  }
+
   const groupedListMap = new Map<string, ListItem[]>();
   for (const item of itemList) {
-    const groupList = groupedListMap.get(item.listName) ?? [];
-    groupList.push(item);
-    groupedListMap.set(item.listName, groupList);
+    const listGroupItemList = groupedListMap.get(item.listName) ?? [];
+    listGroupItemList.push(item);
+    groupedListMap.set(item.listName, listGroupItemList);
   }
+
   return (
-    <div className="grid gap-px bg-line sm:grid-cols-2">
-      {[...groupedListMap.entries()].map(([listName, groupItemList]) => (
-        <section key={listName} className="bg-panel p-4">
-          <h3 className="label-soft flex items-baseline justify-between text-muted">
-            {listName}
-            <span className="text-faint">{groupItemList.length}</span>
-          </h3>
-          <ul className="mt-3 space-y-1.5">
-            {groupItemList.map((item) => (
-              <li key={item.id} className="flex gap-2 text-sm">
-                <span aria-hidden className="mt-[0.5em] size-1 shrink-0 bg-faint" />
-                {item.content}
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
-      {groupedListMap.size % 2 === 1 && (
-        <div aria-hidden className="hidden bg-panel sm:block" />
+    <div>
+      <AddItemForm onAdd={onAdd} />
+      {itemList.length === 0 ? (
+        <Empty
+          message="No lists yet — add an item above or ask the desk"
+          className="m-3"
+        />
+      ) : (
+        <div className="grid gap-px bg-line sm:grid-cols-2">
+          {[...groupedListMap.entries()].map(([listName, listGroupItemList]) => (
+            <section key={listName} className="bg-panel p-4">
+              <h3 className="label-soft flex items-baseline justify-between text-muted">
+                {listName}
+                <span className="text-faint">{listGroupItemList.length}</span>
+              </h3>
+              <ul className="mt-3 space-y-1">
+                {listGroupItemList.map((item) => (
+                  <li key={item.id} className="group flex items-center gap-2 text-sm">
+                    <span aria-hidden className="size-1 shrink-0 bg-faint" />
+                    <span className="min-w-0 flex-1">{item.content}</span>
+                    <button
+                      type="button"
+                      onClick={() => void handleRemove(item.id)}
+                      disabled={busyItemId === item.id}
+                      aria-label={`Remove ${item.content}`}
+                      className="text-faint opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:text-danger focus-visible:opacity-100 disabled:opacity-40"
+                    >
+                      <XIcon className="size-3.5" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+          {groupedListMap.size % 2 === 1 && (
+            <div aria-hidden className="hidden bg-panel sm:block" />
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/console/src/memory/page.tsx
+++ b/apps/console/src/memory/page.tsx
@@ -15,7 +15,42 @@ export function MemoryPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) 
   const [browseResult, setBrowseResult] = useState<MemoryBrowseResult | null>(null);
   const [itemList, setItemList] = useState<readonly ListItem[] | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const [newMemoryContent, setNewMemoryContent] = useState('');
+  const [isAddingMemory, setIsAddingMemory] = useState(false);
+  const [busyMemoryId, setBusyMemoryId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleAddMemory(event: FormEvent) {
+    event.preventDefault();
+    const trimmedContent = newMemoryContent.trim();
+    if (trimmedContent.length === 0) {
+      return;
+    }
+    setIsAddingMemory(true);
+    setErrorMessage(null);
+    try {
+      setBrowseResult(await consoleRpc.addMemory(trimmedContent));
+      setNewMemoryContent('');
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Could not add memory.');
+    } finally {
+      setIsAddingMemory(false);
+    }
+  }
+
+  async function handleDeleteMemory(memoryId: string) {
+    setBusyMemoryId(memoryId);
+    setErrorMessage(null);
+    try {
+      setBrowseResult(await consoleRpc.deleteMemory(memoryId));
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Could not delete memory.',
+      );
+    } finally {
+      setBusyMemoryId(null);
+    }
+  }
 
   const browseMemory = useCallback(
     async (query?: string) => {
@@ -86,6 +121,22 @@ export function MemoryPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) 
           </form>
         }
       >
+        <form
+          onSubmit={handleAddMemory}
+          className="flex gap-2 border-b border-line p-3"
+          aria-busy={isAddingMemory}
+        >
+          <Input
+            value={newMemoryContent}
+            onChange={(event) => setNewMemoryContent(event.target.value)}
+            placeholder="Remember that…"
+            aria-label="New memory"
+            className="h-8 flex-1 text-xs"
+          />
+          <Button type="submit" variant="outline" size="sm" disabled={isAddingMemory}>
+            {isAddingMemory ? 'Saving…' : 'Remember'}
+          </Button>
+        </form>
         {browseResult === null ? (
           <p className="p-4 text-sm text-muted">Loading…</p>
         ) : browseResult.memoryList.length === 0 ? (
@@ -95,12 +146,21 @@ export function MemoryPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) 
             {browseResult.memoryList.map((memoryRecord) => (
               <li
                 key={memoryRecord.id}
-                className="flex items-baseline gap-4 border-b border-line px-4 py-2.5 last:border-b-0"
+                className="group flex items-baseline gap-4 border-b border-line px-4 py-2.5 last:border-b-0"
               >
                 <span className="shrink-0 text-xs text-faint">
                   {new Date(memoryRecord.createdAt).toLocaleDateString()}
                 </span>
                 <p className="min-w-0 flex-1 text-sm">{memoryRecord.content}</p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={busyMemoryId === memoryRecord.id}
+                  onClick={() => void handleDeleteMemory(memoryRecord.id)}
+                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-danger"
+                >
+                  Forget
+                </Button>
               </li>
             ))}
           </ul>
@@ -111,9 +171,15 @@ export function MemoryPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) 
         {itemList === null ? (
           <p className="p-4 text-sm text-muted">Loading…</p>
         ) : (
-          <div className="p-px">
-            <ListsBlock itemList={itemList} />
-          </div>
+          <ListsBlock
+            itemList={itemList}
+            onAdd={async (listName, content) => {
+              setItemList(await consoleRpc.addListItem(listName, content));
+            }}
+            onRemove={async (itemId) => {
+              setItemList(await consoleRpc.removeListItem(itemId));
+            }}
+          />
         )}
       </Panel>
     </div>

--- a/apps/console/src/router/hash.ts
+++ b/apps/console/src/router/hash.ts
@@ -1,12 +1,14 @@
 import { useSyncExternalStore } from 'react';
 
-export type ConsoleRoute = 'status' | 'mcp' | 'memory' | 'schedules';
+export type ConsoleRoute = 'status' | 'mcp' | 'memory' | 'schedules' | 'history' | 'jobs';
 
 export const CONSOLE_ROUTE_LIST: readonly ConsoleRoute[] = [
   'status',
   'mcp',
   'memory',
   'schedules',
+  'history',
+  'jobs',
 ];
 
 export function parseRouteFromHash(hash: string): ConsoleRoute {

--- a/apps/console/src/schedules/create.tsx
+++ b/apps/console/src/schedules/create.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+
+const MAX_DELAY_MINUTES = 1_440;
+
+export function CreateReminderForm({
+  onCreate,
+}: {
+  readonly onCreate: (
+    message: string,
+    delaySeconds: number,
+    isTimer: boolean,
+  ) => Promise<void>;
+}) {
+  const [message, setMessage] = useState('');
+  const [delayMinutes, setDelayMinutes] = useState('');
+  const [isTimer, setIsTimer] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    const trimmedMessage = message.trim();
+    const parsedMinutes = Number(delayMinutes);
+    if (trimmedMessage.length === 0) {
+      setErrorMessage(
+        isTimer ? 'Give the timer a label.' : 'Write the reminder message.',
+      );
+      return;
+    }
+    if (
+      !Number.isFinite(parsedMinutes) ||
+      parsedMinutes < 1 ||
+      parsedMinutes > MAX_DELAY_MINUTES
+    ) {
+      setErrorMessage(`Minutes must be between 1 and ${MAX_DELAY_MINUTES}.`);
+      return;
+    }
+    setIsCreating(true);
+    setErrorMessage(null);
+    try {
+      await onCreate(trimmedMessage, Math.round(parsedMinutes * 60), isTimer);
+      setMessage('');
+      setDelayMinutes('');
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Scheduling failed.');
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4" aria-busy={isCreating}>
+      <div className="grid gap-4 sm:grid-cols-[2fr_8rem_auto_auto] sm:items-end">
+        <div className="space-y-2">
+          <Label htmlFor="reminder-message">{isTimer ? 'Timer label' : 'Message'}</Label>
+          <Input
+            id="reminder-message"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder={isTimer ? 'pasta' : 'Sacar la pizza del horno'}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="reminder-minutes">In minutes</Label>
+          <Input
+            id="reminder-minutes"
+            type="number"
+            min={1}
+            max={MAX_DELAY_MINUTES}
+            value={delayMinutes}
+            onChange={(event) => setDelayMinutes(event.target.value)}
+            placeholder="15"
+            className="font-mono"
+          />
+        </div>
+        <div className="flex items-center gap-2 pb-2.5">
+          <Switch
+            id="reminder-timer"
+            checked={isTimer}
+            onCheckedChange={setIsTimer}
+            aria-label="Schedule as a timer"
+          />
+          <Label htmlFor="reminder-timer" className="cursor-pointer">
+            Timer
+          </Label>
+        </div>
+        <Button type="submit" disabled={isCreating}>
+          {isCreating ? 'Scheduling…' : 'Schedule'}
+        </Button>
+      </div>
+      <p className="text-xs text-faint">
+        {isTimer
+          ? 'Timers show a countdown arc on the desk and announce when done.'
+          : 'The desk speaks the reminder when it fires.'}
+      </p>
+      {errorMessage !== null && (
+        <p role="alert" className="text-xs text-danger">
+          {errorMessage}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/apps/console/src/schedules/page.tsx
+++ b/apps/console/src/schedules/page.tsx
@@ -13,11 +13,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { CreateReminderForm } from '@/schedules/create';
 import type { ConsoleRpc } from '@/agent/rpc';
 import type { Reminder } from '@/agent/schema';
 
+// Mirrors the worker's own timer convention: the "Timer" message prefix plus a
+// numeric delay, both required (apps/agent/src/agents/apollo.ts).
 function isTimerReminder(reminder: Reminder): boolean {
-  return reminder.delayInSeconds !== undefined;
+  return reminder.message.startsWith('Timer') && reminder.delayInSeconds !== undefined;
 }
 
 function formatRemainingLabel(firesAtIso: string, nowMilliseconds: number): string {
@@ -93,6 +96,16 @@ export function SchedulesPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
           {errorMessage}
         </p>
       )}
+
+      <Panel title="Schedule something">
+        <CreateReminderForm
+          onCreate={async (message, delaySeconds, isTimer) => {
+            setReminderList(
+              await consoleRpc.createReminder(message, delaySeconds, isTimer),
+            );
+          }}
+        />
+      </Panel>
 
       <Panel
         title="Reminders & timers"

--- a/apps/console/src/status/device.tsx
+++ b/apps/console/src/status/device.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConsoleRpc } from '@/agent/rpc';
+
+function CommandRow({
+  label,
+  inputId,
+  onApply,
+}: {
+  readonly label: string;
+  readonly inputId: string;
+  readonly onApply: (value: number) => Promise<string>;
+}) {
+  const [value, setValue] = useState('');
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isApplying, setIsApplying] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    const parsedValue = Number(value);
+    if (!Number.isInteger(parsedValue) || parsedValue < 0 || parsedValue > 100) {
+      setFeedback('Use a whole number from 0 to 100.');
+      return;
+    }
+    setIsApplying(true);
+    setFeedback(null);
+    try {
+      setFeedback(await onApply(parsedValue));
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : 'Command failed.');
+    } finally {
+      setIsApplying(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-end gap-2" aria-busy={isApplying}>
+      <div className="flex-1 space-y-1.5">
+        <Label htmlFor={inputId}>{label}</Label>
+        <Input
+          id={inputId}
+          type="number"
+          min={0}
+          max={100}
+          placeholder="0–100"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          className="font-mono"
+        />
+        {feedback !== null && <p className="text-xs text-muted">{feedback}</p>}
+      </div>
+      <Button type="submit" variant="outline" size="sm" disabled={isApplying}>
+        Apply
+      </Button>
+    </form>
+  );
+}
+
+export function DeviceControls({
+  consoleRpc,
+  isDeviceConnected,
+}: {
+  readonly consoleRpc: ConsoleRpc;
+  readonly isDeviceConnected: boolean;
+}) {
+  if (!isDeviceConnected) {
+    return (
+      <p className="px-4 pb-4 text-xs text-faint">
+        Controls appear when the desk is online.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-4 px-4 pb-4">
+      <CommandRow
+        label="Volume"
+        inputId="device-volume"
+        onApply={async (volume) => (await consoleRpc.setDeviceVolume(volume)).summary}
+      />
+      <CommandRow
+        label="Brightness"
+        inputId="device-brightness"
+        onApply={async (brightness) =>
+          (await consoleRpc.setDeviceBrightness(brightness)).summary
+        }
+      />
+    </div>
+  );
+}

--- a/apps/console/src/status/page.tsx
+++ b/apps/console/src/status/page.tsx
@@ -3,8 +3,11 @@ import { useEffect, useState } from 'react';
 import { Chip } from '@/blueprint/chip';
 import { Heading } from '@/blueprint/heading';
 import { Panel } from '@/blueprint/panel';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/components/utility';
+import { DeviceControls } from '@/status/device';
 import { TelemetryGrid } from '@/status/telemetry';
+import { WeatherPanel } from '@/status/weather';
 import type { ApolloAgentHandle } from '@/agent/hook';
 import type { ApolloAgentState, ConsoleStatus } from '@/agent/schema';
 import type { ConsoleRpc } from '@/agent/rpc';
@@ -31,6 +34,16 @@ export function StatusPage({
 }) {
   const [status, setStatus] = useState<ConsoleStatus | null>(null);
   const [didPollFail, setDidPollFail] = useState(false);
+  const [isResolvingConfirm, setIsResolvingConfirm] = useState(false);
+
+  async function handleResolveConfirm(isApproved: boolean) {
+    setIsResolvingConfirm(true);
+    try {
+      await consoleRpc.confirmPendingAction(isApproved);
+    } finally {
+      setIsResolvingConfirm(false);
+    }
+  }
 
   useEffect(() => {
     let isDisposed = false;
@@ -109,6 +122,7 @@ export function StatusPage({
               </p>
             )}
           </div>
+          <DeviceControls consoleRpc={consoleRpc} isDeviceConnected={isDeviceConnected} />
         </Panel>
 
         <Panel
@@ -154,12 +168,33 @@ export function StatusPage({
                 <div className="col-span-full bg-panel p-4">
                   <dt className="label-soft text-amber">Awaiting confirmation</dt>
                   <dd className="mt-1.5 text-sm">{agentState.pendingConfirmSummary}</dd>
+                  <dd className="mt-3 flex gap-2">
+                    <Button
+                      size="sm"
+                      disabled={isResolvingConfirm}
+                      onClick={() => void handleResolveConfirm(true)}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={isResolvingConfirm}
+                      onClick={() => void handleResolveConfirm(false)}
+                    >
+                      Reject
+                    </Button>
+                  </dd>
                 </div>
               )}
             </dl>
           )}
         </Panel>
       </div>
+
+      <Panel title="Weather location">
+        <WeatherPanel consoleRpc={consoleRpc} />
+      </Panel>
 
       <Panel title="Telemetry">
         <div className="p-4">

--- a/apps/console/src/status/weather.tsx
+++ b/apps/console/src/status/weather.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { ConsoleRpc } from '@/agent/rpc';
+import type { WeatherLocation } from '@/agent/schema';
+
+export function WeatherPanel({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) {
+  const [location, setLocation] = useState<WeatherLocation | null>(null);
+  const [locationQuery, setLocationQuery] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    void consoleRpc
+      .getWeather()
+      .then(setLocation)
+      .catch(() => setErrorMessage('Could not load the weather location.'));
+  }, [consoleRpc]);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    const trimmedQuery = locationQuery.trim();
+    if (trimmedQuery.length === 0) {
+      return;
+    }
+    setIsSaving(true);
+    setErrorMessage(null);
+    try {
+      setLocation(await consoleRpc.setWeather(trimmedQuery));
+      setLocationQuery('');
+    } catch {
+      setErrorMessage(`No location found for “${trimmedQuery}”.`);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 p-4">
+      <div>
+        <p className="text-sm">
+          {location === null ? 'Loading…' : location.locationLabel}
+        </p>
+        {location !== null && (
+          <p className="mt-0.5 font-mono text-xs text-faint">
+            {location.latitude.toFixed(2)}, {location.longitude.toFixed(2)} ·{' '}
+            {location.timezone}
+          </p>
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2" aria-busy={isSaving}>
+        <Input
+          value={locationQuery}
+          onChange={(event) => setLocationQuery(event.target.value)}
+          placeholder="Change city…"
+          aria-label="New weather location"
+        />
+        <Button type="submit" variant="outline" disabled={isSaving}>
+          {isSaving ? 'Saving…' : 'Set'}
+        </Button>
+      </form>
+      {errorMessage !== null && (
+        <p role="alert" className="text-xs text-danger">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "bun@1.3.13",
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
-    "dev": "turbo run dev --filter=@apollo/agent",
+    "dev": "turbo run dev",
+    "dev:agent": "turbo run dev --filter=@apollo/agent",
     "dev:console": "turbo run dev --filter=@apollo/console",
     "build": "turbo run build",
     "deploy": "turbo run deploy",


### PR DESCRIPTION
## Summary

Turns the console from a viewer into a remote control, per the confirmed scope: confirmations, device volume/brightness, lists & memories management, reminder/timer creation, weather location, conversation history, and background jobs.

**Console (apps/console):**
- Status: Approve/Reject buttons for pending tool confirmations; device volume/brightness controls (shown only while the desk is online); weather location panel with city search.
- Memory: add memories ("Remember"), delete memories ("Forget"), add/remove list items inline.
- Schedules: create reminders and timers (timer mode broadcasts the countdown arc to the desk); fixed the timer badge to use the worker's real convention (Timer prefix **and** numeric delay).
- New **History** page: recent voice turns from the session (text only — tool calls aren't persisted in the session today, noted in the UI).
- New **Jobs** page: research/coding run documents listed from R2, newest first, with inline document reading.

**Agent (apps/agent):** thirteen new secret-gated `@callable()`s delegating to three new `src/console/` modules:
- `history.ts` — session messages → console turns (pure, tested)
- `jobs.ts` — R2 listing under `research/<deviceId>/` + `coding/<deviceId>/` with strict prefix guards on reads (tested)
- `memory.ts` — deletion clears Vectorize **first**, then SQL, so a failed vector delete never orphans an embedding that voice recall would resurface (tested)
- `lists/store.ts` gains `removeListItemRecordById` (tested)
- Device commands reuse the existing `#callDeviceTool` bridge (`self.audio_speaker.set_volume`, `self.screen.set_brightness`); weather reuses the voice tool's geocoding + triggers an immediate dashboard refresh.

**DX:** root `bun run dev` now starts agent + console together (`dev:agent` kept for the worker alone).

## Verification

- `bun run check` green: 513 agent tests + 15 console tests
- Live e2e against `wrangler dev` + device simulator: volume command full round trip (device ack rendered), memory add, list add, reminder creation, weather location read, history/jobs pages with real empty states, job document seeded in local R2 listed and read inline
- Local-dev caveat surfaced correctly: Vectorize can't run locally; memory deletion now fails clean (nothing deleted) instead of half-deleting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KU8mRmhLmvkpBGPgYoXXxU

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands the console with end-to-end controls for device settings, confirmations, memories, lists, schedules, weather, history, and background-job documents. The pagination and stale-response fixes remain incomplete in edge cases.

- Adds secret-gated agent RPC operations and corresponding console controls.
- Adds conversation-history and job-document pages.
- Adds paginated R2 job listing and guarded document loading.
- Extends memory, list, reminder, timer, weather, volume, and brightness management.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because job pagination remains incomplete and same-document reopen sequences can still render stale responses.

The listing loop silently stops after 2,000 objects per job kind, while the document-loading guard can accept an obsolete request after the same key is closed and reopened.

**Files Needing Attention:** apps/agent/src/console/jobs.ts; apps/console/src/jobs/page.tsx
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fagent%2Fsrc%2Fconsole%2Fjobs.ts%3A55%0A**Pagination%20still%20truncates%20job%20history**%0A%0AWhen%20a%20device%20accumulates%20more%20than%202%2C000%20research%20or%20coding%20documents%2C%20this%20loop%20stops%20while%20R2%20still%20has%20another%20page.%20The%20console%20silently%20omits%20the%20remaining%20documents%20and%20can%20omit%20recent%20runs%20because%20it%20sorts%20only%20the%20capped%20subset.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fconsole%2Fsrc%2Fjobs%2Fpage.tsx%3A55-57%0A**Same-key%20requests%20remain%20stale**%0A%0AIf%20the%20operator%20opens%20a%20document%2C%20closes%20it%20while%20loading%2C%20and%20reopens%20the%20same%20document%20before%20the%20first%20request%20completes%2C%20the%20old%20request%20passes%20this%20key-only%20guard.%20Its%20stale%20content%2C%20not-found%20result%2C%20or%20transient%20error%20then%20replaces%20the%20reopened%20row's%20current%20result.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=galfrevn%2Fapollo&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: paginate job listings and drop stal..."](https://github.com/galfrevn/apollo/commit/1bf2abb602bf0b274a0970952fae525f85d1fefd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52773664)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->