### PR TITLE
feat(agent): conversation threads, live mode push, and MCP install auth

### DIFF
--- a/apps/agent/src/agents/apollo.ts
+++ b/apps/agent/src/agents/apollo.ts
@@ -5,7 +5,7 @@ import {
   type ConnectionContext,
   type WSMessage,
 } from 'agents';
-import type { Session } from 'agents/experimental/memory/session';
+import type { Session, SessionManager } from 'agents/experimental/memory/session';
 
 import {
   buildDeskDashboardPayload,
@@ -34,7 +34,9 @@ import {
 import { isDeviceSharedSecretValid } from '@/auth/token';
 import {
   mapSessionMessagesToConsoleHistory,
+  mapThreadCatalogToConsoleThreadList,
   type ConsoleHistoryTurn,
+  type ConsoleThreadSummary,
 } from '@/console/history';
 import {
   listConsoleJobDocuments,
@@ -55,10 +57,12 @@ import {
   consoleDeviceBrightnessInputSchema,
   consoleDeviceVolumeInputSchema,
   consoleDocumentInputSchema,
-  consoleHistoryInputSchema,
   consoleMemoryBrowseInputSchema,
   consoleRemoveListItemInputSchema,
   consoleSecretInputSchema,
+  consoleSpeechModeInputSchema,
+  consoleThreadInputSchema,
+  consoleThreadListInputSchema,
   consoleWeatherInputSchema,
 } from '@/console/rpc';
 import { buildConsoleStatusSnapshot, type ConsoleStatusSnapshot } from '@/console/status';
@@ -93,6 +97,7 @@ import {
   DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS,
   summarizeDeviceToolResult,
 } from '@/mcp/bridge';
+import { buildMcpOauthLandingResponse } from '@/mcp/landing';
 import { buildNamespacedMcpToolName } from '@/mcp/naming';
 import {
   buildInstalledMcpServerSummaryList,
@@ -112,16 +117,24 @@ import {
   listMcpToolSettings,
   saveMcpToolSetting,
 } from '@/mcp/settings';
-import { OWNER_MEMORY_CONSOLIDATION_CRON } from '@/memory/consolidate';
+import {
+  flattenRecentHistoryToTranscript,
+  OWNER_MEMORY_CONSOLIDATION_CRON,
+} from '@/memory/consolidate';
 import { runOwnerMemoryConsolidation } from '@/memory/nightly';
 import { deletePendingDeviceMessage, listPendingDeviceMessages } from '@/memory/pending';
-import { createApolloSession, rememberFactInSession } from '@/memory/session';
+import {
+  createApolloSessionManager,
+  LEGACY_THREAD_SESSION_ID,
+  rememberFactInSession,
+} from '@/memory/session';
 import {
   addMemoryRecord,
   getSessionPreference,
   setSessionPreference,
   type MemorySqlExecutor,
 } from '@/memory/store';
+import { embedTextWithOpenRouter, queryMemoryVectors } from '@/memory/vector';
 import { PUBLIC_ORIGIN_PREFERENCE_KEY, runFirmwareLifecycle } from '@/ota/lifecycle';
 import { enqueueMemoryIndexJob } from '@/queues/consume';
 import { cycleDeskSpeechMode, resolveDeskSpeechMode } from '@/persona/catalog';
@@ -147,6 +160,39 @@ import {
   type DeskTelemetrySnapshot,
 } from '@/telemetry/logic';
 import {
+  buildThreadDigestMessageList,
+  finalizeThreadPayloadSchema,
+  parseThreadDigestResult,
+  runThreadFinalization,
+  THREAD_FINALIZATION_TRANSCRIPT_BYTE_BUDGET,
+} from '@/threads/finalize';
+import { buildThreadHandoffNote, THREAD_HANDOFF_BYTE_BUDGET } from '@/threads/handoff';
+import {
+  ACTIVE_THREAD_LAST_TURN_PREFERENCE_KEY,
+  ACTIVE_THREAD_SESSION_PREFERENCE_KEY,
+  buildDefaultThreadTitle,
+  COMMAND_THREAD_RETENTION_DAYS,
+  decideThreadRotation,
+  parseStoredLastTurnAt,
+  PREVIOUS_THREAD_SESSION_PREFERENCE_KEY,
+  THREAD_INACTIVITY_CUTOFF_MILLISECONDS,
+} from '@/threads/lifecycle';
+import {
+  mapVectorMemoryIdToThreadSessionId,
+  selectThreadForResume,
+  THREAD_VECTOR_MEMORY_ID_PREFIX,
+} from '@/threads/resume';
+import {
+  deleteThreadMeta,
+  getThreadMeta,
+  listExpiredCommandThreadSessionIds,
+  listThreadMeta,
+  listThreadSessionIdsActiveSince,
+  markThreadFinalized,
+  recordThreadActivity,
+  reopenThreadMeta,
+} from '@/threads/store';
+import {
   deletePendingToolConfirmations,
   isPendingConfirmationOrphaned,
   readPendingToolConfirmation,
@@ -158,6 +204,7 @@ import type {
   ToolDefinition,
   ToolExecutionResult,
 } from '@/tools/types';
+import { chatWithOpenRouter } from '@/voice/llm';
 import { geocodeDeskWeatherLocation, type DeskWeatherLocation } from '@/weather/geocode';
 import type { DeskWeatherSnapshot } from '@/weather/fetch';
 import {
@@ -231,7 +278,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   #pendingConfirmation: PendingToolConfirmation | undefined;
   #didLoadPreferences = false;
   #isSpeechAborted = false;
-  #session: Session | undefined;
+  #sessionManager: SessionManager | undefined;
+  #activeThreadSessionId: string | undefined;
+  #idleThreadCheckScheduleId: string | undefined;
   #lastKnownWeatherSnapshot: DeskWeatherSnapshot | undefined;
   #lastTelemetrySnapshot: DeskTelemetrySnapshot | undefined;
   #isAnnouncingLowBattery = false;
@@ -245,14 +294,27 @@ export class Apollo extends Agent<Env, ApolloState> {
     readonly receivedAtMilliseconds: number;
   } | null = null;
 
-  get session(): Session {
-    if (this.#session === undefined) {
-      this.#session = createApolloSession(this, this.env.MEDIA);
+  get sessionManager(): SessionManager {
+    if (this.#sessionManager === undefined) {
+      this.#sessionManager = createApolloSessionManager(this, this.env);
     }
-    return this.#session;
+    return this.#sessionManager;
+  }
+
+  // The active thread session; before the first post-migration turn it falls
+  // back to the legacy fixed session, whose shared memory block is the same.
+  get session(): Session {
+    return this.sessionManager.getSession(
+      this.#activeThreadSessionId ?? LEGACY_THREAD_SESSION_ID,
+    );
   }
 
   async onStart(): Promise<void> {
+    // Held in memory only, so every DO start must re-register it; without it a
+    // successful OAuth callback strands the owner's browser on a bare 404.
+    this.mcp.configureOAuthCallback({
+      customHandler: (callbackResult) => buildMcpOauthLandingResponse(callbackResult),
+    });
     void this.sql`
       CREATE TABLE IF NOT EXISTS memories (
         id TEXT PRIMARY KEY,
@@ -304,13 +366,57 @@ export class Apollo extends Agent<Env, ApolloState> {
         safety TEXT NOT NULL
       )
     `;
-    this.#session = createApolloSession(this, this.env.MEDIA);
+    // Thread classification and summaries live outside the SDK's session
+    // tables so the SDK schema stays untouched by Apollo concerns.
+    void this.sql`
+      CREATE TABLE IF NOT EXISTS thread_meta (
+        session_id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        summary TEXT,
+        last_turn_at INTEGER NOT NULL
+      )
+    `;
+    this.#sessionManager = createApolloSessionManager(this, this.env);
+    const storedActiveThreadSessionId = await getSessionPreference(
+      this.#sqlExecutor(),
+      ACTIVE_THREAD_SESSION_PREFERENCE_KEY,
+    );
+    if (storedActiveThreadSessionId !== null && storedActiveThreadSessionId.length > 0) {
+      this.#activeThreadSessionId = storedActiveThreadSessionId;
+    }
     await this.#ensurePreferencesLoaded();
     await this.scheduleEvery(
       DESK_DASHBOARD_REFRESH_INTERVAL_SECONDS,
       'refreshDashboardWeather',
     );
     await this.schedule(OWNER_MEMORY_CONSOLIDATION_CRON, 'consolidateOwnerMemory');
+    await this.scheduleEvery(86_400, 'purgeExpiredCommandThreads');
+  }
+
+  async purgeExpiredCommandThreads(): Promise<void> {
+    const sqlExecutor = this.#sqlExecutor();
+    const retentionCutoffMilliseconds =
+      Date.now() - COMMAND_THREAD_RETENTION_DAYS * 86_400_000;
+    const expiredSessionIdList = listExpiredCommandThreadSessionIds(
+      sqlExecutor,
+      retentionCutoffMilliseconds,
+    );
+    for (const expiredSessionId of expiredSessionIdList) {
+      if (expiredSessionId === this.#activeThreadSessionId) {
+        continue;
+      }
+      await this.sessionManager.delete(expiredSessionId);
+      deleteThreadMeta(sqlExecutor, expiredSessionId);
+    }
+    if (expiredSessionIdList.length > 0) {
+      console.log(
+        JSON.stringify({
+          level: 'info',
+          message: 'command_threads_purged',
+          purgedCount: expiredSessionIdList.length,
+        }),
+      );
+    }
   }
 
   async #resolveWeatherLocation() {
@@ -558,7 +664,17 @@ export class Apollo extends Agent<Env, ApolloState> {
   }> {
     const input = installMcpServerInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
-    const installResult = await this.addMcpServer(input.name, input.url);
+    // Without an explicit callbackHost the SDK derives it from this very
+    // connection's host, which is the worker origin the console dialed.
+    const installResult = await this.addMcpServer(
+      input.name,
+      input.url,
+      input.authToken === undefined
+        ? undefined
+        : {
+            transport: { headers: { Authorization: `Bearer ${input.authToken}` } },
+          },
+    );
     return {
       serverId: installResult.id,
       state: installResult.state,
@@ -793,13 +909,28 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async listConsoleHistory(rawInput: unknown): Promise<readonly ConsoleHistoryTurn[]> {
-    const input = consoleHistoryInputSchema.parse(rawInput);
+  async listConsoleThreads(rawInput: unknown): Promise<readonly ConsoleThreadSummary[]> {
+    const input = consoleThreadListInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
-    const recentHistory = await this.session.getRecentHistory(
-      input.maxContentBytes ?? 24_000,
-      10,
+    const legacyMessageCount = await this.sessionManager.getMessageCount(
+      LEGACY_THREAD_SESSION_ID,
     );
+    return mapThreadCatalogToConsoleThreadList({
+      sessionInfoList: this.sessionManager.list(),
+      threadMetaList: listThreadMeta(this.#sqlExecutor()),
+      activeThreadSessionId: this.#activeThreadSessionId ?? null,
+      hasLegacyHistory: legacyMessageCount > 0,
+      legacySessionId: LEGACY_THREAD_SESSION_ID,
+    });
+  }
+
+  @callable()
+  async getConsoleThread(rawInput: unknown): Promise<readonly ConsoleHistoryTurn[]> {
+    const input = consoleThreadInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const recentHistory = await this.sessionManager
+      .getSession(input.threadId)
+      .getRecentHistory(input.maxContentBytes ?? 48_000, 10);
     return mapSessionMessagesToConsoleHistory(recentHistory.messages);
   }
 
@@ -826,6 +957,13 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
+  async setConsoleSpeechMode(rawInput: unknown): Promise<ApolloState> {
+    const input = consoleSpeechModeInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    return this.setSpeechMode(input.speechModeId);
+  }
+
+  @callable()
   async setSpeechMode(speechModeId: string): Promise<ApolloState> {
     const speechMode = resolveDeskSpeechMode(speechModeId);
     await setSessionPreference(this.#sqlExecutor(), 'speechMode', speechMode.id);
@@ -834,6 +972,11 @@ export class Apollo extends Agent<Env, ApolloState> {
       speechMode: speechMode.id,
       caption: null,
     });
+    // The desk only learns the new accent from a ui_state push; without it the
+    // ring keeps the old mode color until an unrelated event redraws it.
+    for (const connection of this.getConnections(DEVICE_CONNECTION_TAG)) {
+      this.#pushUiState(connection);
+    }
     return this.state;
   }
 
@@ -1072,10 +1215,305 @@ export class Apollo extends Agent<Env, ApolloState> {
         deviceId: this.name ?? 'default',
         nowMilliseconds: Date.now(),
         createIdentifier: () => crypto.randomUUID(),
+        gatherTranscriptSince: async (sinceMilliseconds, transcriptByteBudget) =>
+          this.#gatherThreadTranscriptSince(sinceMilliseconds, transcriptByteBudget),
       });
     } finally {
       this.#isConsolidatingMemory = false;
     }
+  }
+
+  async #gatherThreadTranscriptSince(
+    sinceMilliseconds: number,
+    transcriptByteBudget: number,
+  ): Promise<{ readonly transcriptText: string; readonly hasNewActivity: boolean }> {
+    const activeThreadSessionIdList = listThreadSessionIdsActiveSince(
+      this.#sqlExecutor(),
+      sinceMilliseconds,
+    );
+    if (activeThreadSessionIdList.length === 0) {
+      return { transcriptText: '', hasNewActivity: false };
+    }
+    const transcriptPartList: string[] = [];
+    let remainingByteBudget = transcriptByteBudget;
+    for (const threadSessionId of activeThreadSessionIdList) {
+      if (remainingByteBudget <= 0) {
+        break;
+      }
+      const recentHistory = await this.sessionManager
+        .getSession(threadSessionId)
+        .getRecentHistory(remainingByteBudget, 1);
+      const transcriptText = flattenRecentHistoryToTranscript(recentHistory.messages);
+      if (transcriptText.length === 0) {
+        continue;
+      }
+      transcriptPartList.push(transcriptText);
+      remainingByteBudget -= transcriptText.length;
+    }
+    return {
+      transcriptText: transcriptPartList.join('\n\n'),
+      hasNewActivity: true,
+    };
+  }
+
+  async #rotateThreadForTurn(): Promise<void> {
+    const sqlExecutor = this.#sqlExecutor();
+    const nowMilliseconds = Date.now();
+    const storedLastTurnAt = await getSessionPreference(
+      sqlExecutor,
+      ACTIVE_THREAD_LAST_TURN_PREFERENCE_KEY,
+    );
+    const rotationDecision = decideThreadRotation({
+      activeSessionId: this.#activeThreadSessionId ?? null,
+      lastTurnAtMilliseconds: parseStoredLastTurnAt(storedLastTurnAt),
+      nowMilliseconds,
+    });
+    let activeThreadSessionId: string;
+    if (rotationDecision.action === 'start') {
+      // A thread the idle check already closed still hands its tail to the
+      // next thread; its id survives in the previous-thread preference.
+      const storedPreviousThreadSessionId = await getSessionPreference(
+        sqlExecutor,
+        PREVIOUS_THREAD_SESSION_PREFERENCE_KEY,
+      );
+      const handoffSourceSessionId =
+        rotationDecision.previousSessionId ??
+        (storedPreviousThreadSessionId !== null &&
+        storedPreviousThreadSessionId.length > 0
+          ? storedPreviousThreadSessionId
+          : null);
+      const threadInfo = this.sessionManager.create(
+        buildDefaultThreadTitle(nowMilliseconds),
+        { source: 'voice' },
+      );
+      activeThreadSessionId = threadInfo.id;
+      this.#activeThreadSessionId = threadInfo.id;
+      await setSessionPreference(
+        sqlExecutor,
+        ACTIVE_THREAD_SESSION_PREFERENCE_KEY,
+        threadInfo.id,
+      );
+      await setSessionPreference(sqlExecutor, PREVIOUS_THREAD_SESSION_PREFERENCE_KEY, '');
+      if (handoffSourceSessionId !== null) {
+        await this.#writeThreadHandoffNote(handoffSourceSessionId, threadInfo.id);
+      }
+      if (rotationDecision.previousSessionId !== null) {
+        await this.schedule(1, 'finalizeThread', {
+          sessionId: rotationDecision.previousSessionId,
+        });
+      }
+    } else {
+      activeThreadSessionId = rotationDecision.sessionId;
+    }
+    await setSessionPreference(
+      sqlExecutor,
+      ACTIVE_THREAD_LAST_TURN_PREFERENCE_KEY,
+      String(nowMilliseconds),
+    );
+    recordThreadActivity(sqlExecutor, activeThreadSessionId, nowMilliseconds);
+    await this.#scheduleIdleThreadCheck();
+  }
+
+  // Best effort: the id lives in memory only, so a hibernation between turns
+  // leaks at most one extra check, and maybeFinalizeIdleThread is idempotent.
+  async #scheduleIdleThreadCheck(): Promise<void> {
+    if (this.#idleThreadCheckScheduleId !== undefined) {
+      await this.cancelSchedule(this.#idleThreadCheckScheduleId);
+    }
+    const idleCheckDelaySeconds =
+      Math.ceil(THREAD_INACTIVITY_CUTOFF_MILLISECONDS / 1000) + 60;
+    const idleCheckSchedule = await this.schedule(
+      idleCheckDelaySeconds,
+      'maybeFinalizeIdleThread',
+      {},
+    );
+    this.#idleThreadCheckScheduleId = idleCheckSchedule.id;
+  }
+
+  async maybeFinalizeIdleThread(): Promise<void> {
+    const sqlExecutor = this.#sqlExecutor();
+    const activeThreadSessionId = this.#activeThreadSessionId;
+    if (activeThreadSessionId === undefined) {
+      return;
+    }
+    const lastTurnAtMilliseconds = parseStoredLastTurnAt(
+      await getSessionPreference(sqlExecutor, ACTIVE_THREAD_LAST_TURN_PREFERENCE_KEY),
+    );
+    if (
+      lastTurnAtMilliseconds === null ||
+      Date.now() - lastTurnAtMilliseconds < THREAD_INACTIVITY_CUTOFF_MILLISECONDS
+    ) {
+      return;
+    }
+    this.#activeThreadSessionId = undefined;
+    await setSessionPreference(sqlExecutor, ACTIVE_THREAD_SESSION_PREFERENCE_KEY, '');
+    await setSessionPreference(
+      sqlExecutor,
+      PREVIOUS_THREAD_SESSION_PREFERENCE_KEY,
+      activeThreadSessionId,
+    );
+    await this.finalizeThread({ sessionId: activeThreadSessionId });
+  }
+
+  // Reopening makes the found thread active again: its recency window feeds
+  // the next turn, and its meta drops back to pending so the next close
+  // regenerates a digest that covers the new turns. The turn that triggered
+  // the resume still lands in the thread it started in.
+  async #resumeConversationThread(
+    query: string,
+  ): Promise<{ readonly title: string; readonly summary: string | null } | undefined> {
+    const sqlExecutor = this.#sqlExecutor();
+    const resolvedSessionId =
+      (await this.#findThreadByVector(query)) ?? this.#findThreadByKeyword(query);
+    if (resolvedSessionId === undefined) {
+      return undefined;
+    }
+    const threadInfo = this.sessionManager.get(resolvedSessionId);
+    if (threadInfo === null) {
+      return undefined;
+    }
+    const threadMeta = getThreadMeta(sqlExecutor, resolvedSessionId);
+    const nowMilliseconds = Date.now();
+    this.#activeThreadSessionId = resolvedSessionId;
+    await setSessionPreference(
+      sqlExecutor,
+      ACTIVE_THREAD_SESSION_PREFERENCE_KEY,
+      resolvedSessionId,
+    );
+    await setSessionPreference(
+      sqlExecutor,
+      ACTIVE_THREAD_LAST_TURN_PREFERENCE_KEY,
+      String(nowMilliseconds),
+    );
+    await setSessionPreference(sqlExecutor, PREVIOUS_THREAD_SESSION_PREFERENCE_KEY, '');
+    recordThreadActivity(sqlExecutor, resolvedSessionId, nowMilliseconds);
+    reopenThreadMeta(sqlExecutor, resolvedSessionId);
+    await this.#scheduleIdleThreadCheck();
+    return { title: threadInfo.name, summary: threadMeta?.summary ?? null };
+  }
+
+  async #findThreadByVector(query: string): Promise<string | undefined> {
+    // Mock mode has no embeddings; the keyword fallback still works.
+    if (this.env.MOCK_VOICE === '1') {
+      return undefined;
+    }
+    try {
+      const values = await embedTextWithOpenRouter({
+        openRouterApiKey: this.env.OPENROUTER_API_KEY,
+        modelId: this.env.OPENROUTER_EMBEDDING_MODEL,
+        text: query,
+      });
+      const matchList = await queryMemoryVectors({
+        vectorizeIndex: this.env.VECTORIZE,
+        values,
+        deviceId: this.name ?? 'default',
+        topK: 8,
+      });
+      for (const match of matchList) {
+        const sessionId = mapVectorMemoryIdToThreadSessionId(match.id);
+        if (
+          sessionId !== undefined &&
+          sessionId !== this.#activeThreadSessionId &&
+          this.sessionManager.get(sessionId) !== null
+        ) {
+          return sessionId;
+        }
+      }
+    } catch {
+      // Resume must never fail the turn; the keyword fallback runs next.
+    }
+    return undefined;
+  }
+
+  #findThreadByKeyword(query: string): string | undefined {
+    const metaBySessionId = new Map(
+      listThreadMeta(this.#sqlExecutor()).map((meta) => [meta.sessionId, meta]),
+    );
+    const candidateList = this.sessionManager
+      .list()
+      .filter((sessionInfo) => sessionInfo.id !== this.#activeThreadSessionId)
+      .map((sessionInfo) => ({
+        sessionId: sessionInfo.id,
+        title: sessionInfo.name,
+        summary: metaBySessionId.get(sessionInfo.id)?.summary ?? null,
+        lastTurnAtMilliseconds:
+          metaBySessionId.get(sessionInfo.id)?.lastTurnAtMilliseconds ?? 0,
+      }))
+      .toSorted(
+        (left, right) => right.lastTurnAtMilliseconds - left.lastTurnAtMilliseconds,
+      );
+    return selectThreadForResume(candidateList, query)?.sessionId;
+  }
+
+  async #writeThreadHandoffNote(
+    sourceSessionId: string,
+    targetSessionId: string,
+  ): Promise<void> {
+    const sourceHistory = await this.sessionManager
+      .getSession(sourceSessionId)
+      .getRecentHistory(THREAD_HANDOFF_BYTE_BUDGET, 2);
+    const handoffNote = buildThreadHandoffNote({
+      previousThreadTitle: this.sessionManager.get(sourceSessionId)?.name ?? '',
+      messageList: sourceHistory.messages,
+    });
+    if (handoffNote === undefined) {
+      return;
+    }
+    const targetSession = this.sessionManager.getSession(targetSessionId);
+    await targetSession.replaceContextBlock('handoff', handoffNote);
+    await targetSession.refreshSystemPrompt();
+  }
+
+  async finalizeThread(rawPayload: unknown): Promise<void> {
+    const payload = finalizeThreadPayloadSchema.parse(rawPayload);
+    const sqlExecutor = this.#sqlExecutor();
+    const existingMeta = getThreadMeta(sqlExecutor, payload.sessionId);
+    if (existingMeta !== undefined && existingMeta.kind !== 'pending') {
+      return;
+    }
+    await runThreadFinalization({
+      getThreadMessages: async () => {
+        const recentHistory = await this.sessionManager
+          .getSession(payload.sessionId)
+          .getRecentHistory(THREAD_FINALIZATION_TRANSCRIPT_BYTE_BUDGET, 10);
+        return recentHistory.messages;
+      },
+      generateThreadDigest: async (transcriptText) => {
+        // Mock mode has no LLM to call; a dev session must not burn tokens.
+        if (this.env.MOCK_VOICE === '1' || transcriptText.length === 0) {
+          return undefined;
+        }
+        const chatResult = await chatWithOpenRouter({
+          openRouterApiKey: this.env.OPENROUTER_API_KEY,
+          modelId: this.env.OPENROUTER_MODEL,
+          messageList: buildThreadDigestMessageList(transcriptText),
+        });
+        return parseThreadDigestResult(chatResult.text);
+      },
+      renameThread: async (title) => {
+        this.sessionManager.rename(payload.sessionId, title);
+      },
+      persistOutcome: async (outcome) => {
+        markThreadFinalized(sqlExecutor, {
+          sessionId: payload.sessionId,
+          kind: outcome.kind,
+          summary: outcome.summary,
+        });
+        // The summary rides the same embedding pipeline as owner facts; the
+        // thread- prefix is what resume_conversation later maps back to a
+        // session id.
+        if (outcome.kind === 'conversation' && outcome.summary !== null) {
+          await enqueueMemoryIndexJob(this.env, {
+            memoryId: `${THREAD_VECTOR_MEMORY_ID_PREFIX}${payload.sessionId}`,
+            content:
+              outcome.title !== null
+                ? `${outcome.title}: ${outcome.summary}`
+                : outcome.summary,
+            deviceId: this.name ?? 'default',
+          });
+        }
+      },
+    });
   }
 
   #currentFocusState(): DeskFocusState {
@@ -1537,6 +1975,7 @@ export class Apollo extends Agent<Env, ApolloState> {
     const deviceId = this.name ?? 'default';
     this.#isSpeechAborted = false;
     await this.#ensureTelemetrySnapshotLoaded();
+    await this.#rotateThreadForTurn();
     const deskToolEffects = createDeskToolEffects({
       sqlExecutor: this.#sqlExecutor(),
       environment: this.env,
@@ -1607,6 +2046,14 @@ export class Apollo extends Agent<Env, ApolloState> {
           serializeWeatherLocation(location),
         );
       },
+      searchThreadHistory: async ({ query, limit }) =>
+        this.sessionManager.search(query, { limit }).map((match) => ({
+          id: match.id,
+          role: match.role,
+          content: match.content,
+        })),
+      resumeConversationThread: async ({ query }) =>
+        this.#resumeConversationThread(query),
       callDeviceTool: async ({ deviceToolName, argumentRecord }) =>
         this.#callDeviceTool(deviceToolName, argumentRecord),
       callInstalledMcpTool: async (call) => callInstalledMcpTool(this.mcp, call),

--- a/apps/agent/src/agents/apollo.ts
+++ b/apps/agent/src/agents/apollo.ts
@@ -1467,6 +1467,15 @@ export class Apollo extends Agent<Env, ApolloState> {
   async finalizeThread(rawPayload: unknown): Promise<void> {
     const payload = finalizeThreadPayloadSchema.parse(rawPayload);
     const sqlExecutor = this.#sqlExecutor();
+    // A resumed thread is active again by the time a delayed finalizer fires;
+    // digesting it now would freeze the old transcript and pin it, because
+    // later closes skip non-pending meta. Rotation away reschedules this.
+    const activeThreadSessionId =
+      this.#activeThreadSessionId ??
+      (await getSessionPreference(sqlExecutor, ACTIVE_THREAD_SESSION_PREFERENCE_KEY));
+    if (payload.sessionId === activeThreadSessionId) {
+      return;
+    }
     const existingMeta = getThreadMeta(sqlExecutor, payload.sessionId);
     if (existingMeta !== undefined && existingMeta.kind !== 'pending') {
       return;

--- a/apps/agent/src/agents/effects.ts
+++ b/apps/agent/src/agents/effects.ts
@@ -30,6 +30,8 @@ export function createDeskToolEffects(input: {
   readonly cancelReminders: DeskToolEffects['cancelReminders'];
   readonly resolveWeatherLocation: DeskToolEffects['resolveWeatherLocation'];
   readonly persistWeatherLocation: DeskToolEffects['persistWeatherLocation'];
+  readonly searchThreadHistory: DeskToolEffects['searchThreadHistory'];
+  readonly resumeConversationThread: DeskToolEffects['resumeConversationThread'];
   readonly callDeviceTool: DeskToolEffects['callDeviceTool'];
   readonly callInstalledMcpTool: DeskToolEffects['callInstalledMcpTool'];
 }): DeskToolEffects {
@@ -65,6 +67,8 @@ export function createDeskToolEffects(input: {
     cancelReminders: input.cancelReminders,
     resolveWeatherLocation: input.resolveWeatherLocation,
     persistWeatherLocation: input.persistWeatherLocation,
+    searchThreadHistory: input.searchThreadHistory,
+    resumeConversationThread: input.resumeConversationThread,
     callDeviceTool: input.callDeviceTool,
     callInstalledMcpTool: input.callInstalledMcpTool,
     addListItem: async (item) => addListItemRecord(input.sqlExecutor, item),

--- a/apps/agent/src/agents/runtime.ts
+++ b/apps/agent/src/agents/runtime.ts
@@ -334,11 +334,20 @@ export async function executeApolloTurn(
       id: crypto.randomUUID(),
       role: 'user',
       parts: [{ type: 'text', text: turnOutput.transcript }],
+      createdAt: new Date(),
     });
     await dependencies.session.appendMessage({
       id: crypto.randomUUID(),
       role: 'assistant',
-      parts: [{ type: 'text', text: turnOutput.spokenText }],
+      parts: [
+        { type: 'text', text: turnOutput.spokenText },
+        ...turnOutput.executedToolCallList.map((executedToolCall) => ({
+          type: 'tool-call',
+          toolName: executedToolCall.name,
+          output: executedToolCall.summary,
+        })),
+      ],
+      createdAt: new Date(),
     });
   }
 }

--- a/apps/agent/src/configuration/testing.ts
+++ b/apps/agent/src/configuration/testing.ts
@@ -191,6 +191,8 @@ export function createStubDeskToolEffects(
       timezone: 'America/Argentina/Buenos_Aires',
     }),
     persistWeatherLocation: async () => {},
+    searchThreadHistory: async () => [],
+    resumeConversationThread: async () => undefined,
     addListItem: async ({ listName, content }) => ({
       id: 'stub-item',
       listName,

--- a/apps/agent/src/console/__tests__/history.spec.ts
+++ b/apps/agent/src/console/__tests__/history.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'bun:test';
 
-import { mapSessionMessagesToConsoleHistory } from '@/console/history';
+import {
+  mapSessionMessagesToConsoleHistory,
+  mapThreadCatalogToConsoleThreadList,
+} from '@/console/history';
 
 describe('console history mapping', () => {
   it('joins text parts and keeps roles in order', () => {
@@ -17,8 +20,57 @@ describe('console history mapping', () => {
     ]);
 
     expect(turnList).toEqual([
-      { id: 'a', role: 'user', text: 'poné un timer' },
-      { id: 'b', role: 'assistant', text: 'Listo,\ntimer de 5 minutos.' },
+      {
+        id: 'a',
+        role: 'user',
+        text: 'poné un timer',
+        createdAtIso: null,
+        toolNameList: [],
+      },
+      {
+        id: 'b',
+        role: 'assistant',
+        text: 'Listo,\ntimer de 5 minutos.',
+        createdAtIso: null,
+        toolNameList: [],
+      },
+    ]);
+  });
+
+  it('collects tool-call parts into the turn tool list', () => {
+    const turnList = mapSessionMessagesToConsoleHistory([
+      {
+        id: 'a',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Listo, timer de 5 minutos.' },
+          { type: 'tool-call', toolName: 'set_timer' },
+        ],
+      },
+    ]);
+
+    expect(turnList[0]?.toolNameList).toEqual(['set_timer']);
+  });
+
+  it('normalizes createdAt into an ISO string when present', () => {
+    const turnList = mapSessionMessagesToConsoleHistory([
+      {
+        id: 'a',
+        role: 'user',
+        parts: [{ type: 'text', text: 'hola' }],
+        createdAt: '2026-08-12T10:00:00.000Z',
+      },
+      {
+        id: 'b',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'buenas' }],
+        createdAt: new Date('2026-08-12T10:00:05.000Z'),
+      },
+    ]);
+
+    expect(turnList.map((turn) => turn.createdAtIso)).toEqual([
+      '2026-08-12T10:00:00.000Z',
+      '2026-08-12T10:00:05.000Z',
     ]);
   });
 
@@ -29,6 +81,81 @@ describe('console history mapping', () => {
       { id: 'c', role: 'user', parts: [{ type: 'text', text: 'hola' }] },
     ]);
 
-    expect(turnList).toEqual([{ id: 'c', role: 'user', text: 'hola' }]);
+    expect(turnList).toEqual([
+      { id: 'c', role: 'user', text: 'hola', createdAtIso: null, toolNameList: [] },
+    ]);
+  });
+});
+
+describe('mapThreadCatalogToConsoleThreadList', () => {
+  it('merges session info with thread meta and sorts active first, then recency', () => {
+    const threadList = mapThreadCatalogToConsoleThreadList({
+      sessionInfoList: [
+        { id: 't1', name: 'Viaje a Salta' },
+        { id: 't2', name: 'Conversación del 2026-08-12' },
+        { id: 't3', name: 'poné un timer' },
+      ],
+      threadMetaList: [
+        {
+          sessionId: 't1',
+          kind: 'conversation',
+          summary: 'Viaje en auto en octubre.',
+          lastTurnAtMilliseconds: 1_000,
+        },
+        {
+          sessionId: 't2',
+          kind: 'pending',
+          summary: null,
+          lastTurnAtMilliseconds: 3_000,
+        },
+        {
+          sessionId: 't3',
+          kind: 'command',
+          summary: null,
+          lastTurnAtMilliseconds: 2_000,
+        },
+      ],
+      activeThreadSessionId: 't2',
+      hasLegacyHistory: false,
+      legacySessionId: 'desk-main',
+    });
+
+    expect(threadList.map((thread) => thread.id)).toEqual(['t2', 't3', 't1']);
+    expect(threadList[0]?.isActive).toBe(true);
+    expect(threadList[2]?.summary).toBe('Viaje en auto en octubre.');
+  });
+
+  it('appends the legacy session as a closed conversation when it has history', () => {
+    const threadList = mapThreadCatalogToConsoleThreadList({
+      sessionInfoList: [],
+      threadMetaList: [],
+      activeThreadSessionId: null,
+      hasLegacyHistory: true,
+      legacySessionId: 'desk-main',
+    });
+
+    expect(threadList).toEqual([
+      {
+        id: 'desk-main',
+        title: 'Historial previo a los hilos',
+        kind: 'conversation',
+        isActive: false,
+        summary: null,
+        lastTurnAtIso: null,
+      },
+    ]);
+  });
+
+  it('marks sessions without meta as pending', () => {
+    const threadList = mapThreadCatalogToConsoleThreadList({
+      sessionInfoList: [{ id: 't1', name: 'Conversación del 2026-08-12' }],
+      threadMetaList: [],
+      activeThreadSessionId: null,
+      hasLegacyHistory: false,
+      legacySessionId: 'desk-main',
+    });
+
+    expect(threadList[0]?.kind).toBe('pending');
+    expect(threadList[0]?.lastTurnAtIso).toBeNull();
   });
 });

--- a/apps/agent/src/console/history.ts
+++ b/apps/agent/src/console/history.ts
@@ -2,13 +2,51 @@ export type ConsoleHistoryTurn = {
   readonly id: string;
   readonly role: string;
   readonly text: string;
+  readonly createdAtIso: string | null;
+  readonly toolNameList: readonly string[];
+};
+
+export type ConsoleThreadSummary = {
+  readonly id: string;
+  readonly title: string;
+  readonly kind: 'pending' | 'command' | 'conversation';
+  readonly isActive: boolean;
+  readonly summary: string | null;
+  readonly lastTurnAtIso: string | null;
 };
 
 type SessionMessageLike = {
   readonly id: string;
   readonly role: string;
-  readonly parts: readonly { readonly type: string; readonly text?: string }[];
+  readonly parts: readonly {
+    readonly type: string;
+    readonly text?: string;
+    readonly toolName?: string;
+  }[];
+  readonly createdAt?: unknown;
 };
+
+type SessionInfoLike = {
+  readonly id: string;
+  readonly name: string;
+};
+
+type ThreadMetaLike = {
+  readonly sessionId: string;
+  readonly kind: 'pending' | 'command' | 'conversation';
+  readonly summary: string | null;
+  readonly lastTurnAtMilliseconds: number;
+};
+
+function normalizeMessageCreatedAt(rawCreatedAt: unknown): string | null {
+  if (rawCreatedAt instanceof Date) {
+    return rawCreatedAt.toISOString();
+  }
+  if (typeof rawCreatedAt === 'string' && rawCreatedAt.length > 0) {
+    return rawCreatedAt;
+  }
+  return null;
+}
 
 export function mapSessionMessagesToConsoleHistory(
   messageList: readonly SessionMessageLike[],
@@ -20,10 +58,62 @@ export function mapSessionMessagesToConsoleHistory(
       .map((part) => part.text)
       .join('\n')
       .trim();
-    if (text.length === 0) {
+    const toolNameList = message.parts
+      .filter((part) => part.type === 'tool-call' && typeof part.toolName === 'string')
+      .map((part) => part.toolName)
+      .filter((toolName): toolName is string => toolName !== undefined);
+    if (text.length === 0 && toolNameList.length === 0) {
       continue;
     }
-    turnList.push({ id: message.id, role: message.role, text });
+    turnList.push({
+      id: message.id,
+      role: message.role,
+      text,
+      createdAtIso: normalizeMessageCreatedAt(message.createdAt),
+      toolNameList,
+    });
   }
   return turnList;
+}
+
+export function mapThreadCatalogToConsoleThreadList(input: {
+  readonly sessionInfoList: readonly SessionInfoLike[];
+  readonly threadMetaList: readonly ThreadMetaLike[];
+  readonly activeThreadSessionId: string | null;
+  readonly hasLegacyHistory: boolean;
+  readonly legacySessionId: string;
+}): readonly ConsoleThreadSummary[] {
+  const metaBySessionId = new Map(
+    input.threadMetaList.map((meta) => [meta.sessionId, meta]),
+  );
+  const summaryList: ConsoleThreadSummary[] = input.sessionInfoList.map((sessionInfo) => {
+    const meta = metaBySessionId.get(sessionInfo.id);
+    return {
+      id: sessionInfo.id,
+      title: sessionInfo.name,
+      kind: meta?.kind ?? 'pending',
+      isActive: sessionInfo.id === input.activeThreadSessionId,
+      summary: meta?.summary ?? null,
+      lastTurnAtIso:
+        meta === undefined || meta.lastTurnAtMilliseconds === 0
+          ? null
+          : new Date(meta.lastTurnAtMilliseconds).toISOString(),
+    };
+  });
+  if (input.hasLegacyHistory) {
+    summaryList.push({
+      id: input.legacySessionId,
+      title: 'Historial previo a los hilos',
+      kind: 'conversation',
+      isActive: false,
+      summary: null,
+      lastTurnAtIso: null,
+    });
+  }
+  return summaryList.toSorted((left, right) => {
+    if (left.isActive !== right.isActive) {
+      return left.isActive ? -1 : 1;
+    }
+    return (right.lastTurnAtIso ?? '').localeCompare(left.lastTurnAtIso ?? '');
+  });
 }

--- a/apps/agent/src/console/rpc.ts
+++ b/apps/agent/src/console/rpc.ts
@@ -27,6 +27,10 @@ export const consoleDeviceBrightnessInputSchema = consoleSecretInputSchema.exten
   brightness: z.number().int().min(0).max(100),
 });
 
+export const consoleSpeechModeInputSchema = consoleSecretInputSchema.extend({
+  speechModeId: z.string().min(1).max(30),
+});
+
 export const consoleAddMemoryInputSchema = consoleSecretInputSchema.extend({
   content: z.string().min(1).max(500),
 });
@@ -48,7 +52,10 @@ export const consoleWeatherInputSchema = consoleSecretInputSchema.extend({
   locationQuery: z.string().min(1).max(100),
 });
 
-export const consoleHistoryInputSchema = consoleSecretInputSchema.extend({
+export const consoleThreadListInputSchema = consoleSecretInputSchema;
+
+export const consoleThreadInputSchema = consoleSecretInputSchema.extend({
+  threadId: z.string().min(1).max(100),
   maxContentBytes: z.number().int().min(1_000).max(100_000).optional(),
 });
 

--- a/apps/agent/src/mcp/__tests__/landing.spec.ts
+++ b/apps/agent/src/mcp/__tests__/landing.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildMcpOauthLandingResponse } from '@/mcp/landing';
+
+describe('mcp oauth landing page', () => {
+  it('renders a success page with a 200 status', async () => {
+    const response = buildMcpOauthLandingResponse({ authSuccess: true });
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/html');
+    expect(html).toContain('Server authorized');
+    expect(html).toContain('refresh the MCP page');
+  });
+
+  it('renders the provider error with a 400 status', async () => {
+    const response = buildMcpOauthLandingResponse({
+      authSuccess: false,
+      authError: 'access_denied',
+    });
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).toContain('Authorization failed');
+    expect(html).toContain('access_denied');
+  });
+
+  it('escapes markup in provider errors', async () => {
+    const response = buildMcpOauthLandingResponse({
+      authSuccess: false,
+      authError: '<script>alert("x")</script>',
+    });
+    const html = await response.text();
+
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('falls back to an unknown error label', async () => {
+    const response = buildMcpOauthLandingResponse({ authSuccess: false });
+    const html = await response.text();
+
+    expect(html).toContain('unknown error');
+  });
+});

--- a/apps/agent/src/mcp/landing.ts
+++ b/apps/agent/src/mcp/landing.ts
@@ -1,0 +1,44 @@
+export type McpOauthCallbackResult = {
+  readonly authSuccess: boolean;
+  readonly authError?: string;
+};
+
+function escapeHtml(rawText: string): string {
+  return rawText
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+export function buildMcpOauthLandingResponse(result: McpOauthCallbackResult): Response {
+  const headline = result.authSuccess ? 'Server authorized' : 'Authorization failed';
+  const detail = result.authSuccess
+    ? 'You can close this tab and refresh the MCP page in the console. If the server still says authenticating, use Retry connection in its panel.'
+    : `The server refused the authorization: ${escapeHtml(result.authError ?? 'unknown error')}. Close this tab and install it again from the console.`;
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
+    <title>Apollo — ${headline}</title>
+  </head>
+  <body style="margin:0;min-height:100dvh;display:grid;place-items:center;background:#0d0d0d;color:#fafafa;font-family:system-ui,sans-serif;">
+    <main style="max-width:26rem;padding:2rem;text-align:center;">
+      <svg width="26" height="26" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <rect x="1" y="1" width="8.5" height="8.5" />
+        <rect x="10.5" y="1" width="8.5" height="8.5" opacity="0.45" />
+        <rect x="1" y="10.5" width="8.5" height="8.5" opacity="0.45" />
+        <rect x="10.5" y="10.5" width="8.5" height="8.5" opacity="0.18" />
+      </svg>
+      <h1 style="margin:1.25rem 0 0;font-family:Georgia,serif;font-weight:400;font-size:2rem;">${headline}</h1>
+      <p style="margin:0.75rem 0 0;font-size:0.875rem;line-height:1.6;color:#878787;">${detail}</p>
+    </main>
+  </body>
+</html>`;
+  return new Response(html, {
+    status: result.authSuccess ? 200 : 400,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}

--- a/apps/agent/src/mcp/servers.ts
+++ b/apps/agent/src/mcp/servers.ts
@@ -23,6 +23,7 @@ export const installMcpServerInputSchema = z.object({
   secret: z.string().min(1),
   name: z.string().min(1).max(64),
   url: mcpServerUrlSchema,
+  authToken: z.string().min(1).max(4096).optional(),
 });
 
 export type InstallMcpServerInput = z.infer<typeof installMcpServerInputSchema>;

--- a/apps/agent/src/memory/__tests__/compaction.spec.ts
+++ b/apps/agent/src/memory/__tests__/compaction.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'bun:test';
+import type { SessionMessage } from 'agents/experimental/memory/session';
+
+import { createFakeApolloEnvironment } from '@/configuration/testing';
+import {
+  compactThreadMessageList,
+  mapRecentHistoryToChatMessageList,
+} from '@/memory/session';
+
+function buildMessage(
+  id: string,
+  role: 'user' | 'assistant',
+  text: string,
+): SessionMessage {
+  return { id, role, parts: [{ type: 'text', text }] };
+}
+
+function buildLongMessageList(messageCount: number): SessionMessage[] {
+  return Array.from({ length: messageCount }, (unused, messageIndex) =>
+    buildMessage(
+      `m${messageIndex}`,
+      messageIndex % 2 === 0 ? 'user' : 'assistant',
+      `mensaje número ${messageIndex}`,
+    ),
+  );
+}
+
+function createFakeOpenRouterFetch(summaryText: string): typeof fetch {
+  const fetchLike = async () =>
+    new Response(JSON.stringify({ choices: [{ message: { content: summaryText } }] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  return Object.assign(fetchLike, { preconnect: () => {} });
+}
+
+describe('compactThreadMessageList', () => {
+  it('skips compaction entirely in mock voice mode', async () => {
+    const environment = createFakeApolloEnvironment({ MOCK_VOICE: '1' });
+    const compactionResult = await compactThreadMessageList(
+      environment,
+      buildLongMessageList(30),
+    );
+    expect(compactionResult).toBeNull();
+  });
+
+  it('leaves short threads untouched', async () => {
+    const environment = createFakeApolloEnvironment({ MOCK_VOICE: '0' });
+    const compactionResult = await compactThreadMessageList(
+      environment,
+      buildLongMessageList(12),
+    );
+    expect(compactionResult).toBeNull();
+  });
+
+  it('returns null when the compactable stretch has no spoken text', async () => {
+    const environment = createFakeApolloEnvironment({ MOCK_VOICE: '0' });
+    const silentMessageList = Array.from({ length: 30 }, (unused, messageIndex) => ({
+      id: `m${messageIndex}`,
+      role: 'user' as const,
+      parts: [],
+    }));
+    const compactionResult = await compactThreadMessageList(
+      environment,
+      silentMessageList,
+    );
+    expect(compactionResult).toBeNull();
+  });
+
+  it('summarizes the old stretch and keeps the recent tail out of it', async () => {
+    const environment = createFakeApolloEnvironment({ MOCK_VOICE: '0' });
+    const messageList = buildLongMessageList(30);
+    const compactionResult = await compactThreadMessageList(
+      environment,
+      messageList,
+      createFakeOpenRouterFetch('Hablaron del viaje a Salta y quedó pendiente el auto.'),
+    );
+
+    expect(compactionResult).not.toBeNull();
+    expect(compactionResult?.fromMessageId).toBe('m0');
+    expect(compactionResult?.toMessageId).toBe('m19');
+    expect(compactionResult?.summary).toContain('viaje a Salta');
+  });
+
+  it('returns null when the model produces an empty summary', async () => {
+    const environment = createFakeApolloEnvironment({ MOCK_VOICE: '0' });
+    const compactionResult = await compactThreadMessageList(
+      environment,
+      buildLongMessageList(30),
+      createFakeOpenRouterFetch('   '),
+    );
+    expect(compactionResult).toBeNull();
+  });
+});
+
+describe('mapRecentHistoryToChatMessageList', () => {
+  it('keeps only spoken user and assistant turns', () => {
+    const messageList: SessionMessage[] = [
+      buildMessage('u1', 'user', 'hola'),
+      { id: 's1', role: 'system', parts: [{ type: 'text', text: 'interno' }] },
+      { id: 'u2', role: 'user', parts: [] },
+      buildMessage('a1', 'assistant', 'buenas'),
+    ];
+
+    expect(mapRecentHistoryToChatMessageList(messageList)).toEqual([
+      { role: 'user', content: 'hola' },
+      { role: 'assistant', content: 'buenas' },
+    ]);
+  });
+});

--- a/apps/agent/src/memory/nightly.ts
+++ b/apps/agent/src/memory/nightly.ts
@@ -3,7 +3,6 @@ import type { Session } from 'agents/experimental/memory/session';
 import {
   buildExtractionRetryMessageList,
   buildMemoryExtractionMessageList,
-  flattenRecentHistoryToTranscript,
   mergeOwnerFacts,
   OWNER_MEMORY_MIN_RUN_INTERVAL_MS,
   OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
@@ -78,6 +77,13 @@ export type OwnerMemoryConsolidationDependencies = {
   readonly deviceId: string;
   readonly nowMilliseconds: number;
   readonly createIdentifier: () => string;
+  readonly gatherTranscriptSince: (
+    sinceMilliseconds: number,
+    transcriptByteBudget: number,
+  ) => Promise<{
+    readonly transcriptText: string;
+    readonly hasNewActivity: boolean;
+  }>;
 };
 
 // Roadmap item 18: the nightly cron owns the previously append-only memory
@@ -101,15 +107,17 @@ export async function runOwnerMemoryConsolidation(
   ) {
     return;
   }
-  const latestLeaf = await session.getLatestLeaf();
-  if (latestLeaf === null || latestLeaf.id === state?.lastProcessedLeafId) {
+  // Turns spread across every thread that was active since the last run, so
+  // the transcript is gathered thread by thread instead of from one session.
+  const gatheredTranscript = await dependencies.gatherTranscriptSince(
+    state?.lastConsolidatedAtMilliseconds ?? 0,
+    OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
+  );
+  if (!gatheredTranscript.hasNewActivity) {
     // An idle day: nothing new happened, so the run costs zero LLM calls.
     const idleState: OwnerMemoryState = {
       factList: state?.factList ?? [],
       lastConsolidatedAtMilliseconds: nowMilliseconds,
-      ...(state?.lastProcessedLeafId !== undefined
-        ? { lastProcessedLeafId: state.lastProcessedLeafId }
-        : {}),
     };
     await setSessionPreference(
       sqlExecutor,
@@ -118,9 +126,6 @@ export async function runOwnerMemoryConsolidation(
     );
     return;
   }
-  const recentHistory = await session.getRecentHistory(
-    OWNER_MEMORY_TRANSCRIPT_BYTE_BUDGET,
-  );
   const seededFactList = seedOwnerFactsFromMemoryBlock({
     blockContent: session.getContextBlock('memory')?.content ?? '',
     knownFactList: state?.factList ?? [],
@@ -128,7 +133,7 @@ export async function runOwnerMemoryConsolidation(
     createIdentifier: dependencies.createIdentifier,
   });
   const extractionMessageList = buildMemoryExtractionMessageList({
-    transcriptText: flattenRecentHistoryToTranscript(recentHistory.messages),
+    transcriptText: gatheredTranscript.transcriptText,
     existingFactList: seededFactList,
     nowIso: new Date(nowMilliseconds).toISOString(),
   });
@@ -206,13 +211,12 @@ export async function runOwnerMemoryConsolidation(
     );
   }
   // The checkpoint is written only after every durable output above succeeded:
-  // a failure mid-run leaves lastProcessedLeafId untouched, so the next night
-  // reprocesses the same window (the content dedupe makes that idempotent)
-  // instead of silently skipping it.
+  // a failure mid-run leaves lastConsolidatedAtMilliseconds untouched, so the
+  // next night reprocesses the same window (the content dedupe makes that
+  // idempotent) instead of silently skipping it.
   const nextState: OwnerMemoryState = {
     factList: merge.nextFactList,
     lastConsolidatedAtMilliseconds: nowMilliseconds,
-    lastProcessedLeafId: latestLeaf.id,
   };
   await setSessionPreference(
     sqlExecutor,
@@ -225,7 +229,6 @@ export async function runOwnerMemoryConsolidation(
       message: 'owner_memory_consolidated',
       factCount: merge.nextFactList.length,
       newFactCount: merge.genuinelyNewFactList.length,
-      transcriptTruncated: recentHistory.truncated,
     }),
   );
 }

--- a/apps/agent/src/memory/session.ts
+++ b/apps/agent/src/memory/session.ts
@@ -1,40 +1,140 @@
 import {
+  AgentContextProvider,
   AgentSearchProvider,
   R2SkillProvider,
-  Session,
+  SessionManager,
+  type Session,
   type SessionMessage,
 } from 'agents/experimental/memory/session';
 
 import type { Apollo } from '@/agents/apollo';
 import { buildApolloSoulPrompt } from '@/persona/soul';
-import type { OpenRouterChatMessage } from '@/voice/llm';
+import { chatWithOpenRouter, type OpenRouterChatMessage } from '@/voice/llm';
 
 const RECENT_TURN_HISTORY_BYTE_BUDGET = 8_000;
 const RECENT_TURN_HISTORY_MIN_MESSAGE_COUNT = 10;
 
-export function createApolloSession(agent: Apollo, mediaBucket: R2Bucket): Session {
-  return Session.create(agent)
-    .forSession('desk-main')
-    .withContext('soul', {
-      provider: {
-        get: async () => {
-          return buildApolloSoulPrompt(agent.state.speechMode);
+const THREAD_COMPACTION_TOKEN_THRESHOLD = 20_000;
+const COMPACTION_KEEP_RECENT_MESSAGE_COUNT = 10;
+const COMPACTION_TRANSCRIPT_CHARACTER_BUDGET = 30_000;
+
+export const LEGACY_THREAD_SESSION_ID = 'desk-main';
+
+// Learned facts predate threads: the old fixed session auto-derived this key
+// ('memory' + '_desk-main'), so every thread session must keep pointing at it
+// or the owner memory block would silently fragment per thread.
+export const SHARED_MEMORY_CONTEXT_KEY = 'memory_desk-main';
+
+// The SDK declares CompactResult without exporting it; this structural twin
+// keeps the compaction function typed without reaching into SDK internals.
+type ThreadCompactionResult = {
+  readonly fromMessageId: string;
+  readonly toMessageId: string;
+  readonly summary: string;
+};
+
+export function createApolloSessionManager(
+  agent: Apollo,
+  environment: Env,
+): SessionManager {
+  return (
+    SessionManager.create(agent)
+      .withContext('soul', {
+        provider: {
+          get: async () => {
+            return buildApolloSoulPrompt(agent.state.speechMode);
+          },
         },
+      })
+      .withContext('memory', {
+        description: 'Hechos y preferencias aprendidas del usuario',
+        maxTokens: 1100,
+        provider: new AgentContextProvider(agent, SHARED_MEMORY_CONTEXT_KEY),
+      })
+      // Deliberately without a provider: the SDK namespaces it per session, so
+      // each thread carries only its own handoff note.
+      .withContext('handoff', {
+        description: 'Cierre del hilo anterior',
+        maxTokens: 400,
+      })
+      .withContext('knowledge', {
+        description: 'Base de conocimiento buscable (FTS)',
+        provider: new AgentSearchProvider(agent),
+      })
+      .withContext('skills', {
+        description: 'Documentos largos en R2 (load on demand)',
+        provider: new R2SkillProvider(environment.MEDIA, { prefix: 'skills/' }),
+      })
+      .withCachedPrompt()
+      .onCompaction(async (messageList) =>
+        compactThreadMessageList(environment, messageList),
+      )
+      .compactAfter(THREAD_COMPACTION_TOKEN_THRESHOLD)
+  );
+}
+
+// A marathon thread (or a repeatedly resumed one) can outgrow its token
+// budget; compaction folds everything but the recent tail into a summary
+// overlay. Originals stay in SQLite, so the console still shows full turns.
+async function compactThreadMessageList(
+  environment: Env,
+  messageList: SessionMessage[],
+): Promise<ThreadCompactionResult | null> {
+  // Mock mode has no LLM to call; a dev session must not burn tokens.
+  if (environment.MOCK_VOICE === '1') {
+    return null;
+  }
+  if (messageList.length <= COMPACTION_KEEP_RECENT_MESSAGE_COUNT + 4) {
+    return null;
+  }
+  const compactableMessageList = messageList.slice(
+    0,
+    messageList.length - COMPACTION_KEEP_RECENT_MESSAGE_COUNT,
+  );
+  const firstMessage = compactableMessageList[0];
+  const lastMessage = compactableMessageList[compactableMessageList.length - 1];
+  if (firstMessage === undefined || lastMessage === undefined) {
+    return null;
+  }
+  const transcriptText = compactableMessageList
+    .map((message) => {
+      const spokenText = message.parts
+        .filter((part) => part.type === 'text' && typeof part.text === 'string')
+        .map((part) => part.text)
+        .join(' ')
+        .trim();
+      if (spokenText.length === 0) {
+        return undefined;
+      }
+      return `${message.role === 'user' ? 'Usuario' : 'Apollo'}: ${spokenText}`;
+    })
+    .filter((line): line is string => line !== undefined)
+    .join('\n')
+    .slice(-COMPACTION_TRANSCRIPT_CHARACTER_BUDGET);
+  if (transcriptText.length === 0) {
+    return null;
+  }
+  const chatResult = await chatWithOpenRouter({
+    openRouterApiKey: environment.OPENROUTER_API_KEY,
+    modelId: environment.OPENROUTER_MODEL,
+    messageList: [
+      {
+        role: 'system',
+        content:
+          'Resumí esta parte vieja de una conversación entre el dueño y su asistente de escritorio en un párrafo en español. Conservá decisiones, datos concretos y pendientes; descartá saludos y relleno.',
       },
-    })
-    .withContext('memory', {
-      description: 'Hechos y preferencias aprendidas del usuario',
-      maxTokens: 1100,
-    })
-    .withContext('knowledge', {
-      description: 'Base de conocimiento buscable (FTS)',
-      provider: new AgentSearchProvider(agent),
-    })
-    .withContext('skills', {
-      description: 'Documentos largos en R2 (load on demand)',
-      provider: new R2SkillProvider(mediaBucket, { prefix: 'skills/' }),
-    })
-    .withCachedPrompt();
+      { role: 'user', content: transcriptText },
+    ],
+  });
+  const summaryText = chatResult.text.trim();
+  if (summaryText.length === 0) {
+    return null;
+  }
+  return {
+    fromMessageId: firstMessage.id,
+    toMessageId: lastMessage.id,
+    summary: `Resumen de la parte anterior de la conversación: ${summaryText}`,
+  };
 }
 
 export async function rememberFactInSession(

--- a/apps/agent/src/memory/session.ts
+++ b/apps/agent/src/memory/session.ts
@@ -76,9 +76,10 @@ export function createApolloSessionManager(
 // A marathon thread (or a repeatedly resumed one) can outgrow its token
 // budget; compaction folds everything but the recent tail into a summary
 // overlay. Originals stay in SQLite, so the console still shows full turns.
-async function compactThreadMessageList(
+export async function compactThreadMessageList(
   environment: Env,
   messageList: SessionMessage[],
+  fetchImplementation?: typeof fetch,
 ): Promise<ThreadCompactionResult | null> {
   // Mock mode has no LLM to call; a dev session must not burn tokens.
   if (environment.MOCK_VOICE === '1') {
@@ -117,6 +118,7 @@ async function compactThreadMessageList(
   const chatResult = await chatWithOpenRouter({
     openRouterApiKey: environment.OPENROUTER_API_KEY,
     modelId: environment.OPENROUTER_MODEL,
+    ...(fetchImplementation === undefined ? {} : { fetchImplementation }),
     messageList: [
       {
         role: 'system',

--- a/apps/agent/src/threads/__tests__/finalize.spec.ts
+++ b/apps/agent/src/threads/__tests__/finalize.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { SessionMessage } from 'agents/experimental/memory/session';
+
+import {
+  buildFallbackThreadTitle,
+  classifyThreadMessages,
+  flattenThreadMessagesToTranscript,
+  parseThreadDigestResult,
+  runThreadFinalization,
+} from '@/threads/finalize';
+
+function buildUserMessage(id: string, text: string): SessionMessage {
+  return { id, role: 'user', parts: [{ type: 'text', text }] };
+}
+
+function buildAssistantMessage(id: string, text: string): SessionMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }] };
+}
+
+const commandExchange: SessionMessage[] = [
+  buildUserMessage('u1', 'poné un timer de diez minutos'),
+  buildAssistantMessage('a1', 'Listo, timer de diez minutos.'),
+];
+
+const conversationExchange: SessionMessage[] = [
+  buildUserMessage('u1', 'quiero planear el viaje a Salta'),
+  buildAssistantMessage('a1', '¿Para qué fechas?'),
+  buildUserMessage('u2', 'la primera semana de octubre'),
+  buildAssistantMessage('a2', 'Anotado, ¿en auto o en avión?'),
+  buildUserMessage('u3', 'en auto, quiero parar en Tucumán'),
+  buildAssistantMessage('a3', 'Buena ruta, te armo un borrador.'),
+];
+
+describe('classifyThreadMessages', () => {
+  it('marks short exchanges as commands', () => {
+    expect(classifyThreadMessages(commandExchange)).toBe('command');
+  });
+
+  it('marks longer exchanges as conversations', () => {
+    expect(classifyThreadMessages(conversationExchange)).toBe('conversation');
+  });
+
+  it('ignores user messages without spoken text', () => {
+    const messageList: SessionMessage[] = [
+      ...commandExchange,
+      { id: 'u2', role: 'user', parts: [{ type: 'tool-call' }] },
+      { id: 'u3', role: 'user', parts: [{ type: 'text', text: '   ' }] },
+    ];
+
+    expect(classifyThreadMessages(messageList)).toBe('command');
+  });
+});
+
+describe('buildFallbackThreadTitle', () => {
+  it('uses the first spoken user turn', () => {
+    expect(buildFallbackThreadTitle(conversationExchange)).toBe(
+      'quiero planear el viaje a Salta',
+    );
+  });
+
+  it('truncates long first turns with an ellipsis', () => {
+    const longText = 'a'.repeat(80);
+    const title = buildFallbackThreadTitle([buildUserMessage('u1', longText)]);
+
+    expect(title).toBe(`${'a'.repeat(59)}…`);
+    expect(title?.length).toBe(60);
+  });
+
+  it('returns undefined when no user turn has text', () => {
+    expect(buildFallbackThreadTitle([buildAssistantMessage('a1', 'hola')])).toBe(
+      undefined,
+    );
+  });
+});
+
+describe('parseThreadDigestResult', () => {
+  it('parses a fenced JSON reply', () => {
+    const digest = parseThreadDigestResult(
+      '```json\n{"title": "Viaje a Salta", "summary": "Planeamos el viaje en auto."}\n```',
+    );
+
+    expect(digest).toEqual({
+      title: 'Viaje a Salta',
+      summary: 'Planeamos el viaje en auto.',
+    });
+  });
+
+  it('rejects replies without a usable JSON object', () => {
+    expect(parseThreadDigestResult('no pude resumir')).toBeUndefined();
+    expect(parseThreadDigestResult('{"title": ""}')).toBeUndefined();
+  });
+});
+
+describe('runThreadFinalization', () => {
+  it('titles commands from the first turn without calling the LLM', async () => {
+    let digestCallCount = 0;
+    let renamedTitle: string | undefined;
+    let persistedOutcome:
+      | { kind: string; title: string | null; summary: string | null }
+      | undefined;
+
+    await runThreadFinalization({
+      getThreadMessages: async () => commandExchange,
+      generateThreadDigest: async () => {
+        digestCallCount += 1;
+        return undefined;
+      },
+      renameThread: async (title) => {
+        renamedTitle = title;
+      },
+      persistOutcome: async (outcome) => {
+        persistedOutcome = outcome;
+      },
+    });
+
+    expect(digestCallCount).toBe(0);
+    expect(renamedTitle).toBe('poné un timer de diez minutos');
+    expect(persistedOutcome).toEqual({
+      kind: 'command',
+      title: 'poné un timer de diez minutos',
+      summary: null,
+    });
+  });
+
+  it('titles and summarizes conversations from the digest', async () => {
+    let receivedTranscript: string | undefined;
+    let renamedTitle: string | undefined;
+    let persistedOutcome:
+      | { kind: string; title: string | null; summary: string | null }
+      | undefined;
+
+    await runThreadFinalization({
+      getThreadMessages: async () => conversationExchange,
+      generateThreadDigest: async (transcriptText) => {
+        receivedTranscript = transcriptText;
+        return { title: 'Viaje a Salta', summary: 'Viaje en auto en octubre.' };
+      },
+      renameThread: async (title) => {
+        renamedTitle = title;
+      },
+      persistOutcome: async (outcome) => {
+        persistedOutcome = outcome;
+      },
+    });
+
+    expect(receivedTranscript).toBe(
+      flattenThreadMessagesToTranscript(conversationExchange),
+    );
+    expect(renamedTitle).toBe('Viaje a Salta');
+    expect(persistedOutcome).toEqual({
+      kind: 'conversation',
+      title: 'Viaje a Salta',
+      summary: 'Viaje en auto en octubre.',
+    });
+  });
+
+  it('falls back to the first turn when the digest is unusable', async () => {
+    let renamedTitle: string | undefined;
+    let persistedOutcome:
+      | { kind: string; title: string | null; summary: string | null }
+      | undefined;
+
+    await runThreadFinalization({
+      getThreadMessages: async () => conversationExchange,
+      generateThreadDigest: async () => undefined,
+      renameThread: async (title) => {
+        renamedTitle = title;
+      },
+      persistOutcome: async (outcome) => {
+        persistedOutcome = outcome;
+      },
+    });
+
+    expect(renamedTitle).toBe('quiero planear el viaje a Salta');
+    expect(persistedOutcome).toEqual({
+      kind: 'conversation',
+      title: 'quiero planear el viaje a Salta',
+      summary: null,
+    });
+  });
+});

--- a/apps/agent/src/threads/__tests__/handoff.spec.ts
+++ b/apps/agent/src/threads/__tests__/handoff.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import type { SessionMessage } from 'agents/experimental/memory/session';
+
+import { buildThreadHandoffNote, THREAD_HANDOFF_BYTE_BUDGET } from '@/threads/handoff';
+
+function buildUserMessage(id: string, text: string): SessionMessage {
+  return { id, role: 'user', parts: [{ type: 'text', text }] };
+}
+
+function buildAssistantMessage(id: string, text: string): SessionMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }] };
+}
+
+describe('buildThreadHandoffNote', () => {
+  it('returns undefined when the thread has no spoken text', () => {
+    expect(
+      buildThreadHandoffNote({ previousThreadTitle: 'Viaje a Salta', messageList: [] }),
+    ).toBeUndefined();
+  });
+
+  it('carries the previous title and the full short transcript', () => {
+    const handoffNote = buildThreadHandoffNote({
+      previousThreadTitle: 'Viaje a Salta',
+      messageList: [
+        buildUserMessage('u1', 'quiero planear el viaje'),
+        buildAssistantMessage('a1', '¿Para qué fechas?'),
+      ],
+    });
+
+    expect(handoffNote).toContain('("Viaje a Salta")');
+    expect(handoffNote).toContain('Usuario: quiero planear el viaje');
+    expect(handoffNote).toContain('Apollo: ¿Para qué fechas?');
+  });
+
+  it('omits the title fragment when the previous thread has no title', () => {
+    const handoffNote = buildThreadHandoffNote({
+      previousThreadTitle: '',
+      messageList: [buildUserMessage('u1', 'hola')],
+    });
+
+    expect(handoffNote).not.toContain('("');
+    expect(handoffNote).toContain('Usuario: hola');
+  });
+
+  it('keeps only the transcript tail when the budget is exceeded', () => {
+    const messageList = [
+      buildUserMessage('u1', 'primera línea que debería caerse'),
+      buildAssistantMessage('a1', 'x'.repeat(80)),
+      buildUserMessage('u2', 'última línea que debe quedar'),
+    ];
+    const handoffNote = buildThreadHandoffNote({
+      previousThreadTitle: 'Larga',
+      messageList,
+      byteBudget: 120,
+    });
+
+    expect(handoffNote).toBeDefined();
+    expect(handoffNote).toContain('Usuario: última línea que debe quedar');
+    expect(handoffNote).not.toContain('primera línea que debería caerse');
+  });
+
+  it('exposes a sane default budget', () => {
+    expect(THREAD_HANDOFF_BYTE_BUDGET).toBeGreaterThan(0);
+  });
+});

--- a/apps/agent/src/threads/__tests__/lifecycle.spec.ts
+++ b/apps/agent/src/threads/__tests__/lifecycle.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildDefaultThreadTitle,
+  decideThreadRotation,
+  parseStoredLastTurnAt,
+  THREAD_INACTIVITY_CUTOFF_MILLISECONDS,
+} from '@/threads/lifecycle';
+
+describe('decideThreadRotation', () => {
+  it('starts a first thread when none is active', () => {
+    const decision = decideThreadRotation({
+      activeSessionId: null,
+      lastTurnAtMilliseconds: null,
+      nowMilliseconds: 1_000,
+    });
+
+    expect(decision).toEqual({ action: 'start', previousSessionId: null });
+  });
+
+  it('reuses the active thread inside the inactivity window', () => {
+    const decision = decideThreadRotation({
+      activeSessionId: 'thread-1',
+      lastTurnAtMilliseconds: 1_000,
+      nowMilliseconds: 1_000 + THREAD_INACTIVITY_CUTOFF_MILLISECONDS - 1,
+    });
+
+    expect(decision).toEqual({ action: 'reuse', sessionId: 'thread-1' });
+  });
+
+  it('starts a new thread once the cutoff elapses, handing off the previous one', () => {
+    const decision = decideThreadRotation({
+      activeSessionId: 'thread-1',
+      lastTurnAtMilliseconds: 1_000,
+      nowMilliseconds: 1_000 + THREAD_INACTIVITY_CUTOFF_MILLISECONDS,
+    });
+
+    expect(decision).toEqual({ action: 'start', previousSessionId: 'thread-1' });
+  });
+
+  it('reuses the active thread when the last turn timestamp is unknown', () => {
+    const decision = decideThreadRotation({
+      activeSessionId: 'thread-1',
+      lastTurnAtMilliseconds: null,
+      nowMilliseconds: 999_999_999,
+    });
+
+    expect(decision).toEqual({ action: 'reuse', sessionId: 'thread-1' });
+  });
+
+  it('honors a custom cutoff', () => {
+    const decision = decideThreadRotation({
+      activeSessionId: 'thread-1',
+      lastTurnAtMilliseconds: 0,
+      nowMilliseconds: 5_000,
+      inactivityCutoffMilliseconds: 4_000,
+    });
+
+    expect(decision).toEqual({ action: 'start', previousSessionId: 'thread-1' });
+  });
+});
+
+describe('parseStoredLastTurnAt', () => {
+  it('parses a stored millisecond timestamp', () => {
+    expect(parseStoredLastTurnAt('1723459200000')).toBe(1_723_459_200_000);
+  });
+
+  it('treats null, empty, and garbage values as unknown', () => {
+    expect(parseStoredLastTurnAt(null)).toBeNull();
+    expect(parseStoredLastTurnAt('')).toBeNull();
+    expect(parseStoredLastTurnAt('ayer')).toBeNull();
+  });
+});
+
+describe('buildDefaultThreadTitle', () => {
+  it('names the thread after its calendar day', () => {
+    expect(buildDefaultThreadTitle(Date.UTC(2026, 7, 12, 15, 30))).toBe(
+      'Conversación del 2026-08-12',
+    );
+  });
+});

--- a/apps/agent/src/threads/__tests__/resume.spec.ts
+++ b/apps/agent/src/threads/__tests__/resume.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildThreadHandoffNote } from '@/threads/handoff';
+import {
+  mapVectorMemoryIdToThreadSessionId,
+  selectThreadForResume,
+} from '@/threads/resume';
+
+describe('mapVectorMemoryIdToThreadSessionId', () => {
+  it('extracts the session id from a thread vector id', () => {
+    expect(mapVectorMemoryIdToThreadSessionId('thread-abc-123')).toBe('abc-123');
+  });
+
+  it('ignores plain memory ids and empty suffixes', () => {
+    expect(mapVectorMemoryIdToThreadSessionId('memory-abc')).toBeUndefined();
+    expect(mapVectorMemoryIdToThreadSessionId('thread-')).toBeUndefined();
+  });
+});
+
+describe('selectThreadForResume', () => {
+  const candidateList = [
+    { sessionId: 't1', title: 'Viaje a Salta', summary: 'Ruta en auto por Tucumán.' },
+    { sessionId: 't2', title: 'Timer de pasta', summary: null },
+    { sessionId: 't3', title: 'Firmware del despertador', summary: 'Bug del wake word.' },
+  ];
+
+  it('matches query words against title and summary', () => {
+    expect(selectThreadForResume(candidateList, 'lo del viaje')?.sessionId).toBe('t1');
+    expect(selectThreadForResume(candidateList, 'el bug del firmware')?.sessionId).toBe(
+      't3',
+    );
+  });
+
+  it('prefers the candidate matching more query words', () => {
+    const matched = selectThreadForResume(candidateList, 'viaje en auto por salta');
+    expect(matched?.sessionId).toBe('t1');
+  });
+
+  it('returns undefined when nothing matches or the query is too short', () => {
+    expect(selectThreadForResume(candidateList, 'clima')).toBeUndefined();
+    expect(selectThreadForResume(candidateList, 'a')).toBeUndefined();
+  });
+});
+
+describe('buildThreadHandoffNote', () => {
+  it('wraps the transcript tail with the previous thread title', () => {
+    const note = buildThreadHandoffNote({
+      previousThreadTitle: 'Viaje a Salta',
+      messageList: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hola' }] },
+        { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'buenas' }] },
+      ],
+    });
+
+    expect(note).toContain('"Viaje a Salta"');
+    expect(note).toContain('Usuario: hola');
+    expect(note).toContain('Apollo: buenas');
+  });
+
+  it('keeps only the tail when the transcript exceeds the budget', () => {
+    const longMessageList = Array.from({ length: 50 }, (_, index) => ({
+      id: `m${index}`,
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      parts: [{ type: 'text', text: `mensaje número ${index} con relleno de texto` }],
+    }));
+    const note = buildThreadHandoffNote({
+      previousThreadTitle: '',
+      messageList: longMessageList,
+      byteBudget: 300,
+    });
+
+    expect(note).toBeDefined();
+    expect(note?.length).toBeLessThan(500);
+    expect(note).toContain('mensaje número 49');
+    expect(note).not.toContain('mensaje número 0 ');
+  });
+
+  it('returns undefined for a thread without spoken text', () => {
+    const note = buildThreadHandoffNote({
+      previousThreadTitle: 'x',
+      messageList: [{ id: 'a', role: 'assistant', parts: [{ type: 'reasoning' }] }],
+    });
+
+    expect(note).toBeUndefined();
+  });
+});

--- a/apps/agent/src/threads/__tests__/store.spec.ts
+++ b/apps/agent/src/threads/__tests__/store.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  deleteThreadMeta,
+  getThreadMeta,
+  listExpiredCommandThreadSessionIds,
+  listThreadMeta,
+  listThreadSessionIdsActiveSince,
+  markThreadFinalized,
+  recordThreadActivity,
+  reopenThreadMeta,
+} from '@/threads/store';
+import type { ThreadSqlExecutor } from '@/threads/store';
+
+type ThreadMetaRow = {
+  session_id: string;
+  kind: string;
+  summary: string | null;
+  last_turn_at: number;
+};
+
+function createInMemoryThreadSqlExecutor(): ThreadSqlExecutor {
+  const rowMap = new Map<string, ThreadMetaRow>();
+  return {
+    execute<Row extends Record<string, unknown>>(
+      query: string,
+      ...bindValues: unknown[]
+    ): readonly Row[] {
+      if (query.includes("VALUES (?, 'pending', NULL, ?)")) {
+        const sessionId = String(bindValues[0]);
+        const lastTurnAt = Number(bindValues[1]);
+        const existingRow = rowMap.get(sessionId);
+        if (existingRow === undefined) {
+          rowMap.set(sessionId, {
+            session_id: sessionId,
+            kind: 'pending',
+            summary: null,
+            last_turn_at: lastTurnAt,
+          });
+        } else {
+          existingRow.last_turn_at = lastTurnAt;
+        }
+        return [];
+      }
+      if (query.includes('VALUES (?, ?, ?, 0)')) {
+        const sessionId = String(bindValues[0]);
+        const kind = String(bindValues[1]);
+        const summary = bindValues[2] === null ? null : String(bindValues[2]);
+        const existingRow = rowMap.get(sessionId);
+        if (existingRow === undefined) {
+          rowMap.set(sessionId, {
+            session_id: sessionId,
+            kind,
+            summary,
+            last_turn_at: 0,
+          });
+        } else {
+          existingRow.kind = kind;
+          existingRow.summary = summary;
+        }
+        return [];
+      }
+      if (query.startsWith("UPDATE thread_meta SET kind = 'pending'")) {
+        const targetRow = rowMap.get(String(bindValues[0]));
+        if (targetRow !== undefined) {
+          targetRow.kind = 'pending';
+        }
+        return [];
+      }
+      if (query.startsWith('DELETE FROM thread_meta')) {
+        rowMap.delete(String(bindValues[0]));
+        return [];
+      }
+      if (query.includes("WHERE kind = 'command'")) {
+        const beforeMilliseconds = Number(bindValues[0]);
+        return [...rowMap.values()]
+          .filter(
+            (row) =>
+              row.kind === 'command' &&
+              row.last_turn_at > 0 &&
+              row.last_turn_at < beforeMilliseconds,
+          )
+          .map((row) => ({ session_id: row.session_id })) as unknown as readonly Row[];
+      }
+      if (query.includes('WHERE last_turn_at >=')) {
+        const sinceMilliseconds = Number(bindValues[0]);
+        return [...rowMap.values()]
+          .filter((row) => row.last_turn_at >= sinceMilliseconds)
+          .toSorted((left, right) => right.last_turn_at - left.last_turn_at)
+          .map((row) => ({ session_id: row.session_id })) as unknown as readonly Row[];
+      }
+      if (query.includes('WHERE session_id = ? LIMIT 1')) {
+        const targetRow = rowMap.get(String(bindValues[0]));
+        return (targetRow === undefined
+          ? []
+          : [{ ...targetRow }]) as unknown as readonly Row[];
+      }
+      return [...rowMap.values()]
+        .toSorted((left, right) => right.last_turn_at - left.last_turn_at)
+        .map((row) => ({ ...row })) as unknown as readonly Row[];
+    },
+  };
+}
+
+describe('thread meta store', () => {
+  it('records activity as pending and bumps last_turn_at on repeat turns', () => {
+    const sqlExecutor = createInMemoryThreadSqlExecutor();
+    recordThreadActivity(sqlExecutor, 'thread-1', 1_000);
+    recordThreadActivity(sqlExecutor, 'thread-1', 2_000);
+
+    expect(getThreadMeta(sqlExecutor, 'thread-1')).toEqual({
+      sessionId: 'thread-1',
+      kind: 'pending',
+      summary: null,
+      lastTurnAtMilliseconds: 2_000,
+    });
+  });
+
+  it('keeps the finalized kind and summary when later activity lands', () => {
+    const sqlExecutor = createInMemoryThreadSqlExecutor();
+    recordThreadActivity(sqlExecutor, 'thread-1', 1_000);
+    markThreadFinalized(sqlExecutor, {
+      sessionId: 'thread-1',
+      kind: 'conversation',
+      summary: 'trip planning',
+    });
+    recordThreadActivity(sqlExecutor, 'thread-1', 3_000);
+
+    expect(getThreadMeta(sqlExecutor, 'thread-1')).toEqual({
+      sessionId: 'thread-1',
+      kind: 'conversation',
+      summary: 'trip planning',
+      lastTurnAtMilliseconds: 3_000,
+    });
+  });
+
+  it('maps unknown kinds back to pending and misses to undefined', () => {
+    const sqlExecutor = createInMemoryThreadSqlExecutor();
+    sqlExecutor.execute(
+      'INSERT INTO thread_meta (session_id, kind, summary, last_turn_at) VALUES (?, ?, ?, 0)',
+      'thread-odd',
+      'archived',
+      null,
+    );
+
+    expect(getThreadMeta(sqlExecutor, 'thread-odd')?.kind).toBe('pending');
+    expect(getThreadMeta(sqlExecutor, 'thread-missing')).toBeUndefined();
+  });
+
+  it('lists meta newest-first and reopens finalized threads to pending', () => {
+    const sqlExecutor = createInMemoryThreadSqlExecutor();
+    recordThreadActivity(sqlExecutor, 'thread-old', 1_000);
+    recordThreadActivity(sqlExecutor, 'thread-new', 5_000);
+    markThreadFinalized(sqlExecutor, {
+      sessionId: 'thread-old',
+      kind: 'command',
+      summary: null,
+    });
+
+    expect(listThreadMeta(sqlExecutor).map((record) => record.sessionId)).toEqual([
+      'thread-new',
+      'thread-old',
+    ]);
+
+    reopenThreadMeta(sqlExecutor, 'thread-old');
+    expect(getThreadMeta(sqlExecutor, 'thread-old')?.kind).toBe('pending');
+  });
+
+  it('lists expired command threads and deletes their meta', () => {
+    const sqlExecutor = createInMemoryThreadSqlExecutor();
+    recordThreadActivity(sqlExecutor, 'thread-command', 1_000);
+    markThreadFinalized(sqlExecutor, {
+      sessionId: 'thread-command',
+      kind: 'command',
+      summary: null,
+    });
+    recordThreadActivity(sqlExecutor, 'thread-command', 1_500);
+    recordThreadActivity(sqlExecutor, 'thread-conversation', 1_500);
+
+    expect(listExpiredCommandThreadSessionIds(sqlExecutor, 2_000)).toEqual([
+      'thread-command',
+    ]);
+    expect(listExpiredCommandThreadSessionIds(sqlExecutor, 1_000)).toEqual([]);
+
+    deleteThreadMeta(sqlExecutor, 'thread-command');
+    expect(getThreadMeta(sqlExecutor, 'thread-command')).toBeUndefined();
+  });
+
+  it('lists sessions active since a cutoff, newest first', () => {
+    const sqlExecutor = createInMemoryThreadSqlExecutor();
+    recordThreadActivity(sqlExecutor, 'thread-a', 1_000);
+    recordThreadActivity(sqlExecutor, 'thread-b', 3_000);
+    recordThreadActivity(sqlExecutor, 'thread-c', 2_000);
+
+    expect(listThreadSessionIdsActiveSince(sqlExecutor, 2_000)).toEqual([
+      'thread-b',
+      'thread-c',
+    ]);
+  });
+});

--- a/apps/agent/src/threads/finalize.ts
+++ b/apps/agent/src/threads/finalize.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod';
+
+import type { SessionMessage } from 'agents/experimental/memory/session';
+
+import type { OpenRouterChatMessage } from '@/voice/llm';
+
+export const COMMAND_THREAD_MAX_USER_TURNS = 2;
+export const THREAD_FINALIZATION_TRANSCRIPT_BYTE_BUDGET = 24_000;
+const THREAD_TITLE_MAX_LENGTH = 60;
+
+export const finalizeThreadPayloadSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+const threadDigestResultSchema = z.object({
+  title: z.string().min(1).max(120),
+  summary: z.string().min(1).max(1_000),
+});
+
+export type ThreadDigestResult = z.infer<typeof threadDigestResultSchema>;
+
+function extractSpokenText(message: SessionMessage): string {
+  return message.parts
+    .filter((part) => part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join(' ')
+    .trim();
+}
+
+export function classifyThreadMessages(
+  messageList: readonly SessionMessage[],
+): 'command' | 'conversation' {
+  const spokenUserTurnCount = messageList.filter(
+    (message) => message.role === 'user' && extractSpokenText(message).length > 0,
+  ).length;
+  return spokenUserTurnCount <= COMMAND_THREAD_MAX_USER_TURNS
+    ? 'command'
+    : 'conversation';
+}
+
+export function buildFallbackThreadTitle(
+  messageList: readonly SessionMessage[],
+): string | undefined {
+  for (const message of messageList) {
+    if (message.role !== 'user') {
+      continue;
+    }
+    const spokenText = extractSpokenText(message);
+    if (spokenText.length === 0) {
+      continue;
+    }
+    return spokenText.length <= THREAD_TITLE_MAX_LENGTH
+      ? spokenText
+      : `${spokenText.slice(0, THREAD_TITLE_MAX_LENGTH - 1)}…`;
+  }
+  return undefined;
+}
+
+export function flattenThreadMessagesToTranscript(
+  messageList: readonly SessionMessage[],
+): string {
+  const lineList: string[] = [];
+  for (const message of messageList) {
+    const spokenText = extractSpokenText(message);
+    if (spokenText.length === 0) {
+      continue;
+    }
+    const speakerLabel = message.role === 'user' ? 'Usuario' : 'Apollo';
+    lineList.push(`${speakerLabel}: ${spokenText}`);
+  }
+  return lineList.join('\n');
+}
+
+export function buildThreadDigestMessageList(
+  transcriptText: string,
+): readonly OpenRouterChatMessage[] {
+  return [
+    {
+      role: 'system',
+      content:
+        'Sos el archivista de un asistente de escritorio por voz. Recibís la transcripción de una conversación ya cerrada entre el dueño y el asistente. Respondé SOLO con un objeto JSON con esta forma exacta: {"title": string, "summary": string}. El título: máximo 8 palabras, en español, sin comillas, describe el tema. El resumen: 2 a 4 oraciones en español con lo importante (decisiones, pendientes, datos concretos) para poder retomar la conversación más adelante.',
+    },
+    {
+      role: 'user',
+      content: transcriptText,
+    },
+  ];
+}
+
+export function parseThreadDigestResult(rawText: string): ThreadDigestResult | undefined {
+  // Models wrap JSON in fences or prose despite instructions; the outermost
+  // brace pair is the only part worth trying to parse.
+  const withoutFences = rawText.replace(/```(?:json)?/gi, '');
+  const firstBraceIndex = withoutFences.indexOf('{');
+  const lastBraceIndex = withoutFences.lastIndexOf('}');
+  if (firstBraceIndex === -1 || lastBraceIndex <= firstBraceIndex) {
+    return undefined;
+  }
+  try {
+    const parsedResult = threadDigestResultSchema.safeParse(
+      JSON.parse(withoutFences.slice(firstBraceIndex, lastBraceIndex + 1)),
+    );
+    return parsedResult.success ? parsedResult.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export type ThreadFinalizationDependencies = {
+  readonly getThreadMessages: () => Promise<readonly SessionMessage[]>;
+  readonly generateThreadDigest: (
+    transcriptText: string,
+  ) => Promise<ThreadDigestResult | undefined>;
+  readonly renameThread: (title: string) => Promise<void>;
+  readonly persistOutcome: (outcome: {
+    readonly kind: 'command' | 'conversation';
+    readonly title: string | null;
+    readonly summary: string | null;
+  }) => Promise<void>;
+};
+
+export async function runThreadFinalization(
+  dependencies: ThreadFinalizationDependencies,
+): Promise<void> {
+  const messageList = await dependencies.getThreadMessages();
+  const kind = classifyThreadMessages(messageList);
+  const fallbackTitle = buildFallbackThreadTitle(messageList);
+
+  if (kind === 'command') {
+    if (fallbackTitle !== undefined) {
+      await dependencies.renameThread(fallbackTitle);
+    }
+    await dependencies.persistOutcome({
+      kind,
+      title: fallbackTitle ?? null,
+      summary: null,
+    });
+    return;
+  }
+
+  const digest = await dependencies.generateThreadDigest(
+    flattenThreadMessagesToTranscript(messageList),
+  );
+  if (digest === undefined) {
+    if (fallbackTitle !== undefined) {
+      await dependencies.renameThread(fallbackTitle);
+    }
+    await dependencies.persistOutcome({
+      kind,
+      title: fallbackTitle ?? null,
+      summary: null,
+    });
+    return;
+  }
+  await dependencies.renameThread(digest.title);
+  await dependencies.persistOutcome({
+    kind,
+    title: digest.title,
+    summary: digest.summary,
+  });
+}

--- a/apps/agent/src/threads/handoff.ts
+++ b/apps/agent/src/threads/handoff.ts
@@ -1,0 +1,27 @@
+import type { SessionMessage } from 'agents/experimental/memory/session';
+
+import { flattenThreadMessagesToTranscript } from '@/threads/finalize';
+
+export const THREAD_HANDOFF_BYTE_BUDGET = 1_200;
+
+export function buildThreadHandoffNote(input: {
+  readonly previousThreadTitle: string;
+  readonly messageList: readonly SessionMessage[];
+  readonly byteBudget?: number;
+}): string | undefined {
+  const byteBudget = input.byteBudget ?? THREAD_HANDOFF_BYTE_BUDGET;
+  const transcriptText = flattenThreadMessagesToTranscript(input.messageList);
+  if (transcriptText.length === 0) {
+    return undefined;
+  }
+  let transcriptTail = transcriptText;
+  if (transcriptTail.length > byteBudget) {
+    const truncated = transcriptTail.slice(-byteBudget);
+    const firstLineBreakIndex = truncated.indexOf('\n');
+    transcriptTail =
+      firstLineBreakIndex === -1 ? truncated : truncated.slice(firstLineBreakIndex + 1);
+  }
+  const titleFragment =
+    input.previousThreadTitle.length > 0 ? ` ("${input.previousThreadTitle}")` : '';
+  return `La conversación anterior${titleFragment} se cerró por inactividad. Últimos intercambios, por si el usuario retoma el tema:\n${transcriptTail}`;
+}

--- a/apps/agent/src/threads/lifecycle.ts
+++ b/apps/agent/src/threads/lifecycle.ts
@@ -1,0 +1,44 @@
+export const THREAD_INACTIVITY_CUTOFF_MILLISECONDS = 30 * 60_000;
+
+export const ACTIVE_THREAD_SESSION_PREFERENCE_KEY = 'activeThreadSessionId';
+export const ACTIVE_THREAD_LAST_TURN_PREFERENCE_KEY = 'activeThreadLastTurnAt';
+export const PREVIOUS_THREAD_SESSION_PREFERENCE_KEY = 'previousThreadSessionId';
+
+export const COMMAND_THREAD_RETENTION_DAYS = 30;
+
+export type ThreadRotationDecision =
+  | { readonly action: 'reuse'; readonly sessionId: string }
+  | { readonly action: 'start'; readonly previousSessionId: string | null };
+
+export function decideThreadRotation(input: {
+  readonly activeSessionId: string | null;
+  readonly lastTurnAtMilliseconds: number | null;
+  readonly nowMilliseconds: number;
+  readonly inactivityCutoffMilliseconds?: number;
+}): ThreadRotationDecision {
+  const inactivityCutoffMilliseconds =
+    input.inactivityCutoffMilliseconds ?? THREAD_INACTIVITY_CUTOFF_MILLISECONDS;
+  if (input.activeSessionId === null) {
+    return { action: 'start', previousSessionId: null };
+  }
+  if (input.lastTurnAtMilliseconds === null) {
+    return { action: 'reuse', sessionId: input.activeSessionId };
+  }
+  const idleMilliseconds = input.nowMilliseconds - input.lastTurnAtMilliseconds;
+  if (idleMilliseconds >= inactivityCutoffMilliseconds) {
+    return { action: 'start', previousSessionId: input.activeSessionId };
+  }
+  return { action: 'reuse', sessionId: input.activeSessionId };
+}
+
+export function parseStoredLastTurnAt(storedValue: string | null): number | null {
+  if (storedValue === null || storedValue.length === 0) {
+    return null;
+  }
+  const parsedMilliseconds = Number(storedValue);
+  return Number.isFinite(parsedMilliseconds) ? parsedMilliseconds : null;
+}
+
+export function buildDefaultThreadTitle(nowMilliseconds: number): string {
+  return `Conversación del ${new Date(nowMilliseconds).toISOString().slice(0, 10)}`;
+}

--- a/apps/agent/src/threads/resume.ts
+++ b/apps/agent/src/threads/resume.ts
@@ -1,0 +1,45 @@
+export const THREAD_VECTOR_MEMORY_ID_PREFIX = 'thread-';
+
+export type ThreadResumeCandidate = {
+  readonly sessionId: string;
+  readonly title: string;
+  readonly summary: string | null;
+};
+
+export function mapVectorMemoryIdToThreadSessionId(
+  vectorMemoryId: string,
+): string | undefined {
+  if (!vectorMemoryId.startsWith(THREAD_VECTOR_MEMORY_ID_PREFIX)) {
+    return undefined;
+  }
+  const sessionId = vectorMemoryId.slice(THREAD_VECTOR_MEMORY_ID_PREFIX.length);
+  return sessionId.length > 0 ? sessionId : undefined;
+}
+
+// Keyword fallback for when embeddings are unavailable (mock mode, Vectorize
+// hiccups): scores each candidate by how many query words its title or summary
+// contains. The candidate list is expected in recency order, so ties resolve
+// to the most recent thread.
+export function selectThreadForResume(
+  candidateList: readonly ThreadResumeCandidate[],
+  query: string,
+): ThreadResumeCandidate | undefined {
+  const queryWordList = query
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter((word) => word.length > 2);
+  if (queryWordList.length === 0) {
+    return undefined;
+  }
+  let bestCandidate: ThreadResumeCandidate | undefined;
+  let bestScore = 0;
+  for (const candidate of candidateList) {
+    const haystack = `${candidate.title} ${candidate.summary ?? ''}`.toLowerCase();
+    const score = queryWordList.filter((word) => haystack.includes(word)).length;
+    if (score > bestScore) {
+      bestScore = score;
+      bestCandidate = candidate;
+    }
+  }
+  return bestCandidate;
+}

--- a/apps/agent/src/threads/store.ts
+++ b/apps/agent/src/threads/store.ts
@@ -1,0 +1,122 @@
+export type ThreadSqlExecutor = {
+  execute<Row extends Record<string, unknown>>(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly Row[];
+};
+
+export type ThreadKind = 'pending' | 'command' | 'conversation';
+
+export type ThreadMetaRecord = {
+  readonly sessionId: string;
+  readonly kind: ThreadKind;
+  readonly summary: string | null;
+  readonly lastTurnAtMilliseconds: number;
+};
+
+type ThreadMetaRow = {
+  readonly session_id: string;
+  readonly kind: string;
+  readonly summary: string | null;
+  readonly last_turn_at: number;
+};
+
+function mapRowToThreadMetaRecord(row: ThreadMetaRow): ThreadMetaRecord {
+  return {
+    sessionId: row.session_id,
+    kind: row.kind === 'command' || row.kind === 'conversation' ? row.kind : 'pending',
+    summary: row.summary,
+    lastTurnAtMilliseconds: row.last_turn_at,
+  };
+}
+
+export function recordThreadActivity(
+  sqlExecutor: ThreadSqlExecutor,
+  sessionId: string,
+  nowMilliseconds: number,
+): void {
+  sqlExecutor.execute(
+    `INSERT INTO thread_meta (session_id, kind, summary, last_turn_at)
+     VALUES (?, 'pending', NULL, ?)
+     ON CONFLICT(session_id) DO UPDATE SET last_turn_at = excluded.last_turn_at`,
+    sessionId,
+    nowMilliseconds,
+  );
+}
+
+export function markThreadFinalized(
+  sqlExecutor: ThreadSqlExecutor,
+  input: {
+    readonly sessionId: string;
+    readonly kind: Exclude<ThreadKind, 'pending'>;
+    readonly summary: string | null;
+  },
+): void {
+  sqlExecutor.execute(
+    `INSERT INTO thread_meta (session_id, kind, summary, last_turn_at)
+     VALUES (?, ?, ?, 0)
+     ON CONFLICT(session_id) DO UPDATE SET kind = excluded.kind, summary = excluded.summary`,
+    input.sessionId,
+    input.kind,
+    input.summary,
+  );
+}
+
+export function getThreadMeta(
+  sqlExecutor: ThreadSqlExecutor,
+  sessionId: string,
+): ThreadMetaRecord | undefined {
+  const rows = sqlExecutor.execute<ThreadMetaRow>(
+    'SELECT session_id, kind, summary, last_turn_at FROM thread_meta WHERE session_id = ? LIMIT 1',
+    sessionId,
+  );
+  return rows[0] === undefined ? undefined : mapRowToThreadMetaRecord(rows[0]);
+}
+
+export function listThreadMeta(
+  sqlExecutor: ThreadSqlExecutor,
+): readonly ThreadMetaRecord[] {
+  const rows = sqlExecutor.execute<ThreadMetaRow>(
+    'SELECT session_id, kind, summary, last_turn_at FROM thread_meta ORDER BY last_turn_at DESC',
+  );
+  return rows.map(mapRowToThreadMetaRecord);
+}
+
+export function reopenThreadMeta(
+  sqlExecutor: ThreadSqlExecutor,
+  sessionId: string,
+): void {
+  sqlExecutor.execute(
+    "UPDATE thread_meta SET kind = 'pending' WHERE session_id = ?",
+    sessionId,
+  );
+}
+
+export function listExpiredCommandThreadSessionIds(
+  sqlExecutor: ThreadSqlExecutor,
+  beforeMilliseconds: number,
+): readonly string[] {
+  const rows = sqlExecutor.execute<{ session_id: string }>(
+    "SELECT session_id FROM thread_meta WHERE kind = 'command' AND last_turn_at > 0 AND last_turn_at < ?",
+    beforeMilliseconds,
+  );
+  return rows.map((row) => row.session_id);
+}
+
+export function deleteThreadMeta(
+  sqlExecutor: ThreadSqlExecutor,
+  sessionId: string,
+): void {
+  sqlExecutor.execute('DELETE FROM thread_meta WHERE session_id = ?', sessionId);
+}
+
+export function listThreadSessionIdsActiveSince(
+  sqlExecutor: ThreadSqlExecutor,
+  sinceMilliseconds: number,
+): readonly string[] {
+  const rows = sqlExecutor.execute<{ session_id: string }>(
+    'SELECT session_id FROM thread_meta WHERE last_turn_at >= ? ORDER BY last_turn_at DESC',
+    sinceMilliseconds,
+  );
+  return rows.map((row) => row.session_id);
+}

--- a/apps/agent/src/tools/__tests__/intent.spec.ts
+++ b/apps/agent/src/tools/__tests__/intent.spec.ts
@@ -70,6 +70,14 @@ function createRecordingEffects(): DeskToolEffects & {
     enqueueCodingTask: async ({ repository, task }) => {
       calls.push(`coding:${repository}:${task}`);
     },
+    searchThreadHistory: async ({ query }) => {
+      calls.push(`threads:${query}`);
+      return [];
+    },
+    resumeConversationThread: async ({ query }) => {
+      calls.push(`resume:${query}`);
+      return undefined;
+    },
     callDeviceTool: async ({ deviceToolName }) => {
       calls.push(`device:${deviceToolName}`);
       return { ok: true, summary: 'true' };

--- a/apps/agent/src/tools/__tests__/recall.spec.ts
+++ b/apps/agent/src/tools/__tests__/recall.spec.ts
@@ -1,77 +1,100 @@
 import { describe, expect, it } from 'bun:test';
 
-import { createFakeApolloEnvironment } from '@/configuration/testing';
-import { recallMemoryTool } from '@/tools/memory';
+import {
+  createFakeApolloEnvironment,
+  createStubDeskToolEffects,
+} from '@/configuration/testing';
+import { recallConversationTool, resumeConversationTool } from '@/tools/history';
+import type { ToolExecutionContext } from '@/tools/types';
 
-describe('recallMemoryTool', () => {
-  it('returns matched memories from Vectorize', async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = Object.assign(
-      async () =>
-        new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), {
-          status: 200,
-        }),
-      { preconnect: () => {} },
-    ) as typeof fetch;
+function buildContext(effects: ToolExecutionContext['effects']): ToolExecutionContext {
+  return {
+    environment: createFakeApolloEnvironment(),
+    nowMilliseconds: 1,
+    ...(effects === undefined ? {} : { effects }),
+  };
+}
 
-    try {
-      const result = await recallMemoryTool.handler(
-        { query: 'mate', limit: 3 },
-        {
-          environment: createFakeApolloEnvironment({
-            OPENROUTER_API_KEY: 'key',
-            VECTORIZE: Object.assign({} as Env['VECTORIZE'], {
-              query: async () => ({
-                matches: [
-                  {
-                    id: 'm1',
-                    score: 0.91,
-                    metadata: { content: 'tomo mate a la tarde' },
-                  },
-                ],
-                count: 1,
-              }),
-            }),
-          }),
-          nowMilliseconds: 1,
-          deviceId: 'desk1',
-        },
-      );
-      expect(result.ok).toBe(true);
-      expect(result.summary).toContain('tomo mate');
-      expect(result.data).toMatchObject({
-        matchList: [{ content: 'tomo mate a la tarde', score: 0.91 }],
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+describe('recall_conversation', () => {
+  it('fails without effects', async () => {
+    const result = await recallConversationTool.handler(
+      { query: 'salta' },
+      buildContext(undefined),
+    );
+    expect(result.ok).toBe(false);
   });
 
-  it('reports empty recall honestly', async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = Object.assign(
-      async () =>
-        new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 }),
-      { preconnect: () => {} },
-    ) as typeof fetch;
-    try {
-      const result = await recallMemoryTool.handler(
-        { query: 'xyz' },
-        {
-          environment: createFakeApolloEnvironment({
-            OPENROUTER_API_KEY: 'key',
-            VECTORIZE: Object.assign({} as Env['VECTORIZE'], {
-              query: async () => ({ matches: [], count: 0 }),
-            }),
-          }),
-          nowMilliseconds: 1,
-          deviceId: 'desk1',
-        },
-      );
-      expect(result.ok).toBe(true);
-      expect(result.summary).toContain('No encontré');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+  it('reports when nothing matches', async () => {
+    const result = await recallConversationTool.handler(
+      { query: 'salta' },
+      buildContext(createStubDeskToolEffects()),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('No encontré conversaciones pasadas sobre salta');
+  });
+
+  it('summarizes matches with speaker labels', async () => {
+    const effects = createStubDeskToolEffects({
+      searchThreadHistory: async () => [
+        { id: 'match-1', role: 'user', content: 'quiero ir a Salta' },
+        { id: 'match-2', role: 'assistant', content: 'te armo la ruta' },
+      ],
+    });
+    const result = await recallConversationTool.handler(
+      { query: 'salta', limit: 2 },
+      buildContext(effects),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('Usuario: quiero ir a Salta');
+    expect(result.summary).toContain('Apollo: te armo la ruta');
+  });
+});
+
+describe('resume_conversation', () => {
+  it('fails without effects', async () => {
+    const result = await resumeConversationTool.handler(
+      { query: 'salta' },
+      buildContext(undefined),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('reports when no past conversation is found', async () => {
+    const result = await resumeConversationTool.handler(
+      { query: 'salta' },
+      buildContext(createStubDeskToolEffects()),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('No encontré una conversación anterior');
+  });
+
+  it('announces the resumed thread with its summary when present', async () => {
+    const effects = createStubDeskToolEffects({
+      resumeConversationThread: async () => ({
+        title: 'Viaje a Salta',
+        summary: 'Ruta en auto con parada en Tucumán',
+      }),
+    });
+    const result = await resumeConversationTool.handler(
+      { query: 'salta' },
+      buildContext(effects),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('Retomo la conversación "Viaje a Salta"');
+    expect(result.summary).toContain('Ruta en auto con parada en Tucumán');
+  });
+
+  it('skips the summary sentence when the thread has none', async () => {
+    const effects = createStubDeskToolEffects({
+      resumeConversationThread: async () => ({ title: 'Viaje a Salta', summary: null }),
+    });
+    const result = await resumeConversationTool.handler(
+      { query: 'salta' },
+      buildContext(effects),
+    );
+
+    expect(result.summary).toBe('Retomo la conversación "Viaje a Salta".');
   });
 });

--- a/apps/agent/src/tools/catalog.ts
+++ b/apps/agent/src/tools/catalog.ts
@@ -3,6 +3,7 @@ import { deviceStatusTool, setBrightnessTool, setVolumeTool } from '@/tools/devi
 import { dollarRateTool } from '@/tools/dollar';
 import { sendEmailTool } from '@/tools/email';
 import { setFocusTool, clearFocusTool } from '@/tools/focus';
+import { recallConversationTool, resumeConversationTool } from '@/tools/history';
 import { addToListTool, readListTool, removeFromListTool } from '@/tools/list';
 import { setWeatherLocationTool } from '@/tools/location';
 import { recallMemoryTool, rememberFactTool } from '@/tools/memory';
@@ -26,6 +27,8 @@ export function listBuiltinToolDefinitionList(): readonly ToolDefinition[] {
     webSearchTool,
     startResearchTool,
     recallMemoryTool,
+    recallConversationTool,
+    resumeConversationTool,
     translateTool,
     setReminderTool,
     listRemindersTool,

--- a/apps/agent/src/tools/history.ts
+++ b/apps/agent/src/tools/history.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+import type { ToolDefinition } from '@/tools/types';
+
+const recallConversationArgsSchema = z.object({
+  query: z.string().min(1).max(500),
+  limit: z.number().int().min(1).max(10).default(5),
+});
+
+export const recallConversationTool: ToolDefinition = {
+  name: 'recall_conversation',
+  safety: 'safe',
+  description:
+    'Busca en conversaciones pasadas con el dueño (otros hilos, otros días) por texto',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: { type: 'string' },
+      limit: { type: 'number' },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  },
+  async handler(args, context) {
+    if (!context.effects) {
+      return { ok: false, summary: 'Effects no disponibles' };
+    }
+
+    const parsedArgs = recallConversationArgsSchema.parse(args);
+    const matchList = await context.effects.searchThreadHistory({
+      query: parsedArgs.query,
+      limit: parsedArgs.limit,
+    });
+    if (matchList.length === 0) {
+      return {
+        ok: true,
+        summary: `No encontré conversaciones pasadas sobre ${parsedArgs.query}`,
+        data: { matchList: [] },
+      };
+    }
+    return {
+      ok: true,
+      summary: `Encontré ${matchList.length} momentos: ${matchList
+        .map(
+          (match) => `${match.role === 'user' ? 'Usuario' : 'Apollo'}: ${match.content}`,
+        )
+        .join(' | ')}`,
+      data: { matchList },
+    };
+  },
+};
+
+const resumeConversationArgsSchema = z.object({
+  query: z.string().min(1).max(500),
+});
+
+export const resumeConversationTool: ToolDefinition = {
+  name: 'resume_conversation',
+  safety: 'safe',
+  description:
+    'Retoma una conversación pasada: la vuelve el hilo activo y trae su resumen. Usalo cuando el dueño pide seguir con un tema anterior',
+  parameters: {
+    type: 'object',
+    properties: { query: { type: 'string' } },
+    required: ['query'],
+    additionalProperties: false,
+  },
+  async handler(args, context) {
+    if (!context.effects) {
+      return { ok: false, summary: 'Effects no disponibles' };
+    }
+
+    const parsedArgs = resumeConversationArgsSchema.parse(args);
+    const resumedThread = await context.effects.resumeConversationThread({
+      query: parsedArgs.query,
+    });
+    if (resumedThread === undefined) {
+      return {
+        ok: true,
+        summary: `No encontré una conversación anterior sobre ${parsedArgs.query}`,
+      };
+    }
+    return {
+      ok: true,
+      summary:
+        resumedThread.summary === null
+          ? `Retomo la conversación "${resumedThread.title}".`
+          : `Retomo la conversación "${resumedThread.title}". Resumen: ${resumedThread.summary}`,
+      data: resumedThread,
+    };
+  },
+};

--- a/apps/agent/src/tools/types.ts
+++ b/apps/agent/src/tools/types.ts
@@ -68,6 +68,23 @@ export type DeskToolEffects = {
     readonly removedCount: number;
     readonly removedContentList: readonly string[];
   }>;
+  readonly searchThreadHistory: (input: {
+    readonly query: string;
+    readonly limit: number;
+  }) => Promise<
+    readonly {
+      readonly id: string;
+      readonly role: string;
+      readonly content: string;
+    }[]
+  >;
+  readonly resumeConversationThread: (input: { readonly query: string }) => Promise<
+    | {
+        readonly title: string;
+        readonly summary: string | null;
+      }
+    | undefined
+  >;
   readonly callDeviceTool: (input: {
     readonly deviceToolName: string;
     readonly argumentRecord: Record<string, unknown>;

--- a/apps/agent/src/turn/run.ts
+++ b/apps/agent/src/turn/run.ts
@@ -83,6 +83,10 @@ export type TurnOutput = {
   readonly focusState: DeskFocusState;
   readonly memoryContentList: readonly string[];
   readonly toolResultList: readonly ToolExecutionResult[];
+  readonly executedToolCallList: readonly {
+    readonly name: string;
+    readonly summary: string;
+  }[];
   // Whether the reply asks the user for something, so the device should
   // reopen the mic after speaking instead of returning to idle.
   readonly expectsReply: boolean;
@@ -138,6 +142,7 @@ function buildToolResultMessage(
 export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
   const uiEventList: DeskUiEventName[] = ['START_THINK'];
   const toolResultList: ToolExecutionResult[] = [];
+  const executedToolCallList: { name: string; summary: string }[] = [];
   let pendingConfirmation = input.pendingConfirmation;
   let resolvedConfirmation: PendingToolConfirmation | undefined;
   let resolvedConfirmationResult: ToolExecutionResult | undefined;
@@ -157,6 +162,10 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
     if (!('cancelled' in resolved)) {
       resolvedConfirmation = pendingConfirmation;
       resolvedConfirmationResult = resolved;
+      executedToolCallList.push({
+        name: pendingConfirmation.toolName,
+        summary: resolved.summary,
+      });
     }
     pendingConfirmation = undefined;
     if ('cancelled' in resolved) {
@@ -169,6 +178,7 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
         focusState: input.focusState,
         memoryContentList: [],
         toolResultList,
+        executedToolCallList,
         expectsReply: false,
       };
     }
@@ -189,6 +199,7 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
       focusState: input.focusState,
       memoryContentList: [],
       toolResultList,
+      executedToolCallList,
       expectsReply: false,
     };
   }
@@ -316,10 +327,15 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
           focusState: input.focusState,
           memoryContentList,
           toolResultList,
+          executedToolCallList,
           expectsReply: false,
         };
       }
       toolResultList.push(outcome.result);
+      executedToolCallList.push({
+        name: toolCall.name,
+        summary: outcome.result.summary,
+      });
       messageList.push(buildToolResultMessage(toolCall.id, outcome.result));
     }
 
@@ -362,6 +378,7 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
     focusState: input.focusState,
     memoryContentList,
     toolResultList,
+    executedToolCallList,
     expectsReply,
   };
 }

--- a/documentation/capabilities/memory.md
+++ b/documentation/capabilities/memory.md
@@ -15,7 +15,7 @@ Apollo keeps both conversational session memory and longer-lived facts.
 
 Both layers key off the **transcript**, not the raw input: a hold-to-talk turn arrives as audio and only becomes text after STT runs inside `apps/agent/src/turn/run.ts`, which returns it as `TurnOutput.transcript`. `apps/agent/src/agents/runtime.ts` appends that transcript (and the reply) to the session, and runs semantic recall with it. Gating either on the caller's `text` instead would skip every spoken turn.
 
-Each turn also reads a small recency window back out: `buildRecentTurnHistoryMessageList` (`apps/agent/src/memory/session.ts`) calls `session.getRecentHistory` with an 8 KB budget and a 10-message floor, and `apps/agent/src/turn/run.ts` splices those prior user/assistant turns into the LLM message list ahead of the current utterance. This is what lets a follow-up said moments after a reply — including one after a fresh wake-word activation — reference what was just discussed; a new wake word does not reset the session or its history.
+Each turn also reads a small recency window back out: `buildRecentTurnHistoryMessageList` (`apps/agent/src/memory/session.ts`) calls `session.getRecentHistory` with an 8 KB budget and a 10-message floor, and `apps/agent/src/turn/run.ts` splices those prior user/assistant turns into the LLM message list ahead of the current utterance. This is what lets a follow-up said moments after a reply — including one after a fresh wake-word activation — reference what was just discussed; a new wake word does not reset the session or its history. What does bound that window is the thread cutoff: after 30 minutes of silence the next turn opens a fresh session (see [Threads](threads.md)).
 
 ## Tools
 
@@ -57,4 +57,4 @@ Small durable preferences (default weather location, speech mode) go through the
 
 ## Navigation
 
-Prev: [Tools](tools.md) · Next: [Research](research.md)
+Prev: [Tools](tools.md) · Next: [Threads](threads.md)

--- a/documentation/capabilities/research.md
+++ b/documentation/capabilities/research.md
@@ -19,4 +19,4 @@ The old homemade pipeline (Cloudflare `WEBSEARCH` binding + fetch/extract/synthe
 
 ## Navigation
 
-Prev: [Memory](memory.md) · Next: [Weather](weather.md)
+Prev: [Threads](threads.md) · Next: [Weather](weather.md)

--- a/documentation/capabilities/threads.md
+++ b/documentation/capabilities/threads.md
@@ -1,0 +1,58 @@
+# Threads
+
+Conversations with Apollo are grouped into **threads**: bounded sessions that start when the owner speaks after a silence and close after inactivity. Threads are what the console lists under History, what nightly memory consolidation walks, and what `recall_conversation` searches.
+
+## Why threads exist
+
+The desk used to run one endless session (`desk-main`), which made the history read as a single blob and gave the agent no notion of "that conversation from yesterday". Cloudflare's Agents SDK recommends `SessionManager` — one session per conversation — for agents that handle many conversations, and that is what Apollo uses now (`apps/agent/src/memory/session.ts`).
+
+## Lifecycle
+
+1. **A turn arrives.** `#rotateThreadForTurn` (`apps/agent/src/agents/apollo.ts`) compares the time since the last turn against the cutoff (`THREAD_INACTIVITY_CUTOFF_MILLISECONDS`, 30 minutes, in `apps/agent/src/threads/lifecycle.ts`).
+2. **Inside the window** the active thread session is reused; the turn appends to it as before.
+3. **Past the window** a new session is created through `SessionManager.create` and the previous thread is scheduled for finalization. If the desk simply goes quiet, a scheduled idle check (`maybeFinalizeIdleThread`) finalizes the active thread without waiting for the next turn.
+4. **Finalization** (`apps/agent/src/threads/finalize.ts`) classifies the thread:
+   - **command** — at most `COMMAND_THREAD_MAX_USER_TURNS` spoken user turns (a timer, a weather check). Titled from the first utterance; no LLM call.
+   - **conversation** — anything longer. One LLM call produces a Spanish title and a 2–4 sentence summary; if the reply does not parse, the first utterance becomes the title and the summary stays empty.
+
+Classification is by spoken turn count; the tool calls a turn ran are recorded as `tool-call` parts on the assistant message (`apps/agent/src/agents/runtime.ts`) and shown as chips in the console, but do not influence classification yet.
+
+## Continuity across the cutoff
+
+A new thread does not start cold. When rotation opens one, the tail of the previous thread's transcript (`buildThreadHandoffNote`, `apps/agent/src/threads/handoff.ts`) is written into a per-session `handoff` context block, so "como te decía hace un rato…" still lands. The idle check leaves the closed thread's id in a preference precisely so the next turn — however much later — can pick up that tail.
+
+## What is shared across threads, and what is not
+
+- **Owner facts are shared.** The memory context block is pinned to the pre-thread storage key (`SHARED_MEMORY_CONTEXT_KEY = 'memory_desk-main'`) via an explicit `AgentContextProvider`. Without that pin the SDK would namespace the block per session and learned facts would fragment silently — do not remove the explicit provider.
+- **Recency context is per thread.** The 8 KB history window a turn feeds to the LLM comes from the active thread only. A new thread starts contextually fresh; older material comes back through recall.
+- **Nightly consolidation spans threads.** `runOwnerMemoryConsolidation` receives `gatherTranscriptSince`, which stitches transcripts from every thread active since the last run (`thread_meta.last_turn_at`), so facts said in a thread that closed at noon still reach the memory block.
+
+## Recall and resume
+
+Two voice tools work across threads (`apps/agent/src/tools/history.ts`):
+
+- `recall_conversation` searches the full-text index across **all** thread sessions through `SessionManager.search` and quotes matching moments. It complements `recall_memory`, which searches distilled facts rather than raw turns.
+- `resume_conversation` finds a past thread and **makes it the active thread again**. Finalized conversation summaries are indexed in Vectorize under `thread-<sessionId>` ids, so the lookup is semantic; a keyword match over titles and summaries (`apps/agent/src/threads/resume.ts`) covers mock mode and Vectorize outages. Reopening resets the thread's meta to pending so its next close regenerates title and summary. The turn that triggered the resume still lands in the thread it started in — the reopened context feeds the *next* turn, and the tool returns the stored summary so the agent can answer immediately.
+
+## Growth limits
+
+- **Retention**: command threads older than 30 days are purged daily (`purgeExpiredCommandThreads`), deleting both the SDK session and its meta row. Conversations are kept.
+- **Compaction**: sessions auto-compact past a token threshold (`compactThreadMessageList`, `apps/agent/src/memory/session.ts`) — everything but the recent tail folds into a summary overlay. Originals stay in SQLite, so the console still shows full turns.
+
+## Storage
+
+The SDK owns `assistant_sessions` (registry: id, name, source, timestamps) and `assistant_messages`/`assistant_fts` (turns, indexed). Apollo adds one table, `thread_meta` (`apps/agent/src/threads/store.ts`): classification, summary, and last-turn timestamp per thread — deliberately outside the SDK's schema.
+
+The active thread id and last-turn timestamp persist in `session_prefs`, so rotation survives Durable Object hibernation.
+
+## Console surface
+
+`listConsoleThreads` returns the merged catalog (SDK registry + `thread_meta`); `getConsoleThread` returns one thread's turns with timestamps (messages now carry `createdAt`). The History page shows **Conversations** and **Commands** as separate views, with the active thread pinned first.
+
+## Migration
+
+The legacy `desk-main` session is frozen: it is never written again, appears in the console as "Historial previo a los hilos", and its turns stay searchable through recall. Its messages predate `createdAt` stamping and tool-call recording, so they render without timestamps or tool chips.
+
+## Navigation
+
+Prev: [Memory](memory.md) · Next: [Research](research.md)

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -23,29 +23,30 @@ This handbook is meant to be read in order. Later chapters assume the concepts i
 
 8. [Tools](capabilities/tools.md) — Router and built-in catalog
 9. [Memory](capabilities/memory.md) — Preferences, facts, and vectors
-10. [Research](capabilities/research.md) — Quick search and deep research
-11. [Weather](capabilities/weather.md) — Location, forecast, dashboard
-12. [Focus](capabilities/focus.md) — Focus timer behavior
-13. [Reminders](capabilities/reminders.md) — Schedules and delivery
-14. [Timers](capabilities/timers.md) — Countdowns and pomodoros
-15. [Lists](capabilities/lists.md) — Durable spoken lists
-16. [Dollar rates](capabilities/rates.md) — Argentine dollar quotes
-17. [Email](capabilities/email.md) — Reports and notes to the owner
-18. [Sandbox](capabilities/sandbox.md) — Isolated code execution
-19. [Coding](capabilities/coding.md) — Clone a repo, change it, open a pull request
-20. [MCP servers](capabilities/mcp.md) — Connect external tools at runtime
+10. [Threads](capabilities/threads.md) — Conversation lifecycle, cutoff, and recall
+11. [Research](capabilities/research.md) — Quick search and deep research
+12. [Weather](capabilities/weather.md) — Location, forecast, dashboard
+13. [Focus](capabilities/focus.md) — Focus timer behavior
+14. [Reminders](capabilities/reminders.md) — Schedules and delivery
+15. [Timers](capabilities/timers.md) — Countdowns and pomodoros
+16. [Lists](capabilities/lists.md) — Durable spoken lists
+17. [Dollar rates](capabilities/rates.md) — Argentine dollar quotes
+18. [Email](capabilities/email.md) — Reports and notes to the owner
+19. [Sandbox](capabilities/sandbox.md) — Isolated code execution
+20. [Coding](capabilities/coding.md) — Clone a repo, change it, open a pull request
+21. [MCP servers](capabilities/mcp.md) — Connect external tools at runtime
 
 ### Part IV — Operations
 
-21. [Setup](operations/setup.md) — Local development
-22. [Deploy](operations/deploy.md) — Workers, bindings, secrets, and vars
-23. [Auth](operations/auth.md) — Device and dashboard credentials
-24. [Testing](operations/testing.md) — How this repo verifies behavior
+22. [Setup](operations/setup.md) — Local development
+23. [Deploy](operations/deploy.md) — Workers, bindings, secrets, and vars
+24. [Auth](operations/auth.md) — Device and dashboard credentials
+25. [Testing](operations/testing.md) — How this repo verifies behavior
 
 ### Part V — Reference
 
-25. [Mapping](reference/mapping.md) — Handbook topics to `apps/agent/src/` folders
-26. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
+26. [Mapping](reference/mapping.md) — Handbook topics to `apps/agent/src/` folders
+27. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
 
 ## The firmware
 

--- a/documentation/reference/mapping.md
+++ b/documentation/reference/mapping.md
@@ -13,6 +13,7 @@ Thin map from handbook topics to code folders. Prefer the narrative chapters for
 | Face (emotion, accent color) | `apps/agent/src/persona/face.ts` |
 | Tools | `apps/agent/src/tools/` |
 | Memory | `apps/agent/src/memory/` |
+| Threads | `apps/agent/src/threads/`, `apps/agent/src/tools/history.ts`, `apps/agent/src/console/history.ts` |
 | Search / research pipeline | `apps/agent/src/search/`, `apps/agent/src/tools/research.ts`, `apps/agent/src/tools/web.ts` |
 | Weather | `apps/agent/src/weather/`, `apps/agent/src/agents/dashboard.ts` |
 | Focus | `apps/agent/src/focus/`, `apps/agent/src/tools/focus.ts` |


### PR DESCRIPTION
## What

The agent-side half of the console expansion, three areas:

**Conversation threads.** Voice turns now rotate into titled threads (30-minute inactivity cutoff) handled by a session manager; nightly consolidation reads per-thread transcripts; `listConsoleThreads` / `getConsoleThread` RPCs expose them to the console, and a history tool joins the catalog. Handbook page added under `documentation/capabilities/threads.md`.

**Speech mode reaches the device.** `setSpeechMode` pushes `ui_state` (accent color included) to every connected device socket, so changing the mode from the console recolors the desk ring immediately — previously only the on-device gesture path did this. `setConsoleSpeechMode` wraps it behind the dashboard secret.

**MCP install auth.** `installMcpServer` accepts an optional bearer `authToken` for PAT-style servers (e.g. GitHub's remote MCP), and a branded OAuth landing page — registered on every agent start — replaces the bare 404 the browser landed on after authorizing a server (Linear reproduced this; provider errors are HTML-escaped).

## Verification

- 546 agent tests pass, typecheck clean, full `bun run check` green.
- Live against prod: Linear installed via OAuth end-to-end (tokens stored, 53 tools discovered), mode changes verified against the running desk.

Companion console PR is stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RggznBzcfMitbDNpRUZSnG

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces per-conversation thread lifecycle management, thread-aware memory consolidation and console APIs, device speech-mode pushes, and authenticated MCP installation with an OAuth landing page.
- Rotates, resumes, finalizes, retains, and exposes conversation threads.
- Consolidates transcripts across recently active threads and adds history tools.
- Pushes speech-mode UI state to connected devices.
- Supports MCP bearer authentication and branded OAuth callback responses.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["test(agent): cover thread compaction and..."](https://github.com/galfrevn/apollo/commit/8c2af396df1a9af6db501c0ac1a37958770f814d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52804381)</sub>

<!-- /greptile_comment -->