### PR TITLE
docs(console): move the console handbook into documentation/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Formatting is oxfmt's job; never hand-format. Note that oxfmt does *not* sort or
 ## Monorepo layout
 
 - `apps/agent/` — the Cloudflare Worker (see `apps/agent/CLAUDE.md`)
-- `apps/console/` — management dashboard (not yet built)
+- `apps/console/` — management dashboard (see `documentation/console/`)
 - `apps/firmware/` — ESP32 firmware, a git submodule, not a JS workspace member
 - `packages/typescript-config/` — shared base tsconfig
 

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -28,7 +28,7 @@
       STORY: The owner connects, is greeted by their device with live insight sentences, scans stat tiles, and drills into sections to audit and control the agent.
       FIRST VIEWPORT: Left icon rail; 70px header with search; centered column — serif greeting, dashed-underline insights, 3x2 stat tile grid.
       FORM: User-pinned direction (quiet monochrome instrument language); pinned brief beats the roll, no seed.
-      FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, and DESIGN.md
+      FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, and documentation/console/design.md
     -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/documentation/console/design.md
+++ b/documentation/console/design.md
@@ -1,10 +1,10 @@
-# Apollo Console — Design System
+# Console design
 
-The visual authority for console work, documented from the code as built. Direction (binding, user-pinned 2026-08-12): a quiet monochrome instrument language — full monochrome, dark only, square corners, elevation by hairline border. This supersedes the amber pixel-console look, which itself superseded the stacked-echo blueprint look; both are rejected — never reintroduce either. See PRODUCT.md "Brand Commitments" and the direction contract in `index.html`.
+The visual authority for console work, documented from the code as built. Direction (binding, user-pinned 2026-08-12): a quiet monochrome instrument language — full monochrome, dark only, square corners, elevation by hairline border. This supersedes the amber pixel-console look, which itself superseded the stacked-echo blueprint look; both are rejected — never reintroduce either. See [Product](product.md) "Brand Commitments" and the direction contract in `apps/console/index.html`.
 
 ## Color
 
-All tokens live in `src/index.css` under `@theme`; the default Tailwind palette is disabled (`--color-*: initial`), so these are the only colors available.
+All tokens live in `apps/console/src/index.css` under `@theme`; the default Tailwind palette is disabled (`--color-*: initial`), so these are the only colors available.
 
 | Token                | Value                    | Role |
 | -------------------- | ------------------------ | ---- |
@@ -27,11 +27,11 @@ There is no accent hue. "Live/online" is white (`foreground`), not green; positi
 
 ## Typography
 
-Three self-hosted faces in `src/fonts/`, declared in `src/index.css`:
+Three self-hosted faces in `apps/console/src/fonts/`, declared in `apps/console/src/index.css`:
 
 - **Hedvig Letters Sans** (`font-sans`, the default) — all UI text. Ships weight 400 only; `font-medium` therefore resolves to 400 by design — weight classes are rhythm markers, not visible weight changes. Sentence case throughout.
-- **Hedvig Letters Serif** (`font-serif`) — display moments only. Exactly two exist: the overview greeting (`text-[38px] leading-tight`, `src/status/insights.tsx`) and the connect-screen title (`text-[32px] leading-tight`, `src/connection/screen.tsx`). PRODUCT.md says "the single overview greeting"; the build added the connect title as a second — both are pre-shell display moments, no serif appears inside page content.
-- **JetBrains Mono** (`font-mono`, variable 100–800) — one use: the jobs document viewer `<pre>` (`text-xs leading-relaxed`, `src/jobs/page.tsx`). Never elsewhere, not even for URLs or telemetry values.
+- **Hedvig Letters Serif** (`font-serif`) — display moments only. Exactly two exist: the overview greeting (`text-[38px] leading-tight`, `apps/console/src/status/insights.tsx`) and the connect-screen title (`text-[32px] leading-tight`, `apps/console/src/connection/screen.tsx`). [Product](product.md) says "the single overview greeting"; the build added the connect title as a second — both are pre-shell display moments, no serif appears inside page content.
+- **JetBrains Mono** (`font-mono`, variable 100–800) — one use: the jobs document viewer `<pre>` (`text-xs leading-relaxed`, `apps/console/src/jobs/page.tsx`). Never elsewhere, not even for URLs or telemetry values.
 
 Scale as used: page `Heading` is `text-xl font-medium tracking-tight`; dialog titles `text-lg font-medium tracking-tight`; body and controls `text-sm`; labels, chips, metadata `text-xs`; the ⌘K kbd hint `text-[10px]`. Labels (`ui/label.tsx`) are `text-xs font-medium text-muted-foreground`, sentence case — no uppercase, no letter-spacing. Tables get `tabular-nums` globally.
 
@@ -41,18 +41,18 @@ Square everywhere — no `rounded-*` class exists in the tree except `rounded-fu
 
 ## Icons
 
-One `Icons` object in `src/components/icons.tsx`; nothing imports icon components directly. Nine Material Design **outline** icons from `react-icons/md` (Close, History, Jobs, Logout, Mcp, Memory, Schedules, Search, Status) plus `LogoMark` — the brand: a hand-drawn 20×20 SVG of the device's face, a solid `currentColor` square with two capsule eyes punched out (even-odd fill, so the ground shows through). Masters and social assets live in `branding/` at the repo root; the favicon set is in `public/`. Rendered monochrome at 20–22px in the rail and mobile header, 26px on the connect screen. Icon sizes in use: 16, 18, 20, 22, 26.
+One `Icons` object in `apps/console/src/components/icons.tsx`; nothing imports icon components directly. Nine Material Design **outline** icons from `react-icons/md` (Close, History, Jobs, Logout, Mcp, Memory, Schedules, Search, Status) plus `LogoMark` — the brand: a hand-drawn 20×20 SVG of the device's face, a solid `currentColor` square with two capsule eyes punched out (even-odd fill, so the ground shows through). Masters and social assets live in `branding/` at the repo root; the favicon set is in `apps/console/public/`. Rendered monochrome at 20–22px in the rail and mobile header, 26px on the connect screen. Icon sizes in use: 16, 18, 20, 22, 26.
 
 ## Components
 
-`src/blueprint/` — console-specific primitives:
+`apps/console/src/blueprint/` — console-specific primitives:
 
 - **Panel** — `border bg-card`, square; optional 44px (`h-11`) header with a `text-sm text-muted-foreground` title and a `meta` slot.
 - **Chip** — square status tag (`border px-2 py-0.5 text-xs font-medium`) with a round 1.5 dot. Tones: `live` (accent fill, foreground dot pulsing at 2s), `busy` (same at 1s), `idle` (muted text, static dot), `down` (destructive text and `/40` border on transparent — the only red chip).
 - **Heading** — `text-xl font-medium tracking-tight` h1 with optional muted description. No mark, no ornament.
 - **Empty** — dashed border box with `dotted-bg` texture; the message sits on a `bg-card` pill in `text-xs font-medium text-muted-foreground`.
 
-`src/components/ui/` — vendored shadcn-style primitives on Radix, restyled to the tokens (the sanctioned multi-export exception):
+`apps/console/src/components/ui/` — vendored shadcn-style primitives on Radix, restyled to the tokens (the sanctioned multi-export exception):
 
 - **Button** — variants `default` (solid `primary` fill, `primary-foreground` text, `/90` on hover), `outline` (border, transparent, `bg-accent` hover), `ghost` (muted text, `bg-accent` hover), `destructive` (red text on transparent, red-tint hover). Sizes `default` h-9, `sm` h-8 `text-xs`, `lg` h-10, `icon` 9×9. All square, `transition-colors duration-150`.
 - **Badge** — static square tag, same frame as Chip minus the dot. Variants `default` (accent fill), `strong` (`foreground/10` fill), `destructive`, `outline` (muted text).
@@ -64,7 +64,7 @@ One `Icons` object in `src/components/icons.tsx`; nothing imports icon component
 - **Skeleton** — `animate-pulse bg-accent` block, always shaped to the final content's box so nothing shifts on load.
 - **Label** — `text-xs font-medium text-muted-foreground`.
 
-Signature patterns: **stat tiles** (`src/status/tiles.tsx`) are `min-h-[110px] border bg-card p-5` with an xs muted label above a `text-xl font-medium` value; clickable ones hover to `border-border-hover bg-card-hover` over 300ms. **Insight fragments** (`src/status/insights.tsx`) are dashed underlines — `border-b border-dashed border-muted-foreground/40 text-foreground` inside muted sentences; navigable ones are buttons whose dash darkens on hover. **⌘K search** (`src/layout/search.tsx`) is a Dialog pinned to `top-[20%]` with a borderless h-12 input row and a filtered route list.
+Signature patterns: **stat tiles** (`apps/console/src/status/tiles.tsx`) are `min-h-[110px] border bg-card p-5` with an xs muted label above a `text-xl font-medium` value; clickable ones hover to `border-border-hover bg-card-hover` over 300ms. **Insight fragments** (`apps/console/src/status/insights.tsx`) are dashed underlines — `border-b border-dashed border-muted-foreground/40 text-foreground` inside muted sentences; navigable ones are buttons whose dash darkens on hover. **⌘K search** (`apps/console/src/layout/search.tsx`) is a Dialog pinned to `top-[20%]` with a borderless h-12 input row and a filtered route list.
 
 ## Motion
 
@@ -72,14 +72,14 @@ Signature patterns: **stat tiles** (`src/status/tiles.tsx`) are `min-h-[110px] b
 - `signal` — opacity pulse (1 → 0.35) for chip dots; 2s on `live`, 1s on `busy`.
 - Everything else is `transition-colors duration-150`, with two slower cases: stat tiles at 300ms and the rail expansion at 200ms `cubic-bezier(0.4, 0, 0.2, 1)` (width plus label opacity fade).
 - The 3D device auto-rotates at speed 0.9 with damping — disabled when `prefers-reduced-motion` matches.
-- A global reduced-motion guard in `src/index.css` collapses all animation and transition durations to 0.01ms.
+- A global reduced-motion guard in `apps/console/src/index.css` collapses all animation and transition durations to 0.01ms.
 
 Structural motion is limited to three moves: the rail's push (margin animation on the content column), the Sheet's 0.4s slide-in from the right (`sheet` keyframe, same ease family as `settle`), and the Skeleton pulse. No scale, spring, or blur transitions; no spinners.
 
 ## Layout
 
-- **Rail** (`src/layout/nav.tsx`) — fixed left, full height, `hidden md:flex`; 70px wide collapsed, expanding to 240px (`w-60`) on hover or focus. The expansion pushes: the shell animates the content column's `margin-left` from 70px to 240px in step with the rail, so nothing is ever covered. Three bands: 70px brand row (LogoMark + "Apollo Console"), nav list (h-10 square items, active = `border-border bg-active text-foreground`, inactive = `text-dim` borderless), 70px identity footer (device initial in a bordered `bg-accent` square, device name + worker host).
-- **Header** (`src/layout/shell.tsx`) — sticky, 70px, `border-b bg-background/70 backdrop-blur-xl`, z-40. Left: LogoMark (mobile only) + search trigger; right: connection Chip (`Link up` live / `Linking` busy / `Unauthorized` down) + ghost disconnect button.
+- **Rail** (`apps/console/src/layout/nav.tsx`) — fixed left, full height, `hidden md:flex`; 70px wide collapsed, expanding to 240px (`w-60`) on hover or focus. The expansion pushes: the shell animates the content column's `margin-left` from 70px to 240px in step with the rail, so nothing is ever covered. Three bands: 70px brand row (LogoMark + "Apollo Console"), nav list (h-10 square items, active = `border-border bg-active text-foreground`, inactive = `text-dim` borderless), 70px identity footer (device initial in a bordered `bg-accent` square, device name + worker host).
+- **Header** (`apps/console/src/layout/shell.tsx`) — sticky, 70px, `border-b bg-background/70 backdrop-blur-xl`, z-40. Left: LogoMark (mobile only) + search trigger; right: connection Chip (`Link up` live / `Linking` busy / `Unauthorized` down) + ghost disconnect button.
 - **Content** — everything offset `md:ml-[70px]`, animating to `md:ml-60` while the rail is expanded. Main is `px-4 py-6 md:px-8`. Section pages: `settle space-y-5`/`space-y-6`, full width. Overview: a single centered `mx-auto max-w-3xl space-y-8` column (greeting → insights → confirm/caption → tiles), vertically centered in the viewport below the header on md+. Device page: `lg:grid-cols-2 gap-6` — the 3D model centered in the left half (`min-h-[28rem]`), a self-centered stack of Mode / Volume & brightness / Weather location panels on the right. The jobs page adds `lg:mr-[calc(100vw/3)]` while its Sheet is open, squeezing in step with the panel.
 - **Mobile** — rail hidden; a `scrollbar-hide` horizontal chip row of h-9 square nav buttons under the header.
 - **Connect screen** — centered `max-w-sm` column: LogoMark, serif title, muted tagline, one bordered form card, `text-dim` privacy note.
@@ -96,7 +96,7 @@ Structural motion is limited to three moves: the rail's push (margin animation o
 
 ## The 3D device
 
-`src/device/model.tsx`, rendered with three.js via `@react-three/fiber` + `@react-three/drei`, lazy-loaded (`src/device/page.tsx`) behind a Suspense placeholder so the bundle stays off every other page. It owns the Device route alongside the Mode / Volume & brightness / Weather panels; changing the mode there re-colors the ring live, so the model is the mode picker's preview.
+`apps/console/src/device/model.tsx`, rendered with three.js via `@react-three/fiber` + `@react-three/drei`, lazy-loaded (`apps/console/src/device/page.tsx`) behind a Suspense placeholder so the bundle stays off every other page. It owns the Device route alongside the Mode / Volume & brightness / Weather panels; changing the mode there re-colors the ring live, so the model is the mode picker's preview.
 
 - **Geometry** — a black cylinder, radius 1 (diameter equals height, the real 4 × 4 cm proportions): a straight `#2e2e2e` body section, a tapering base (radius 1 → 0.8 over the bottom 0.45) so the foot closes like the real enclosure, and a dark `#0a0a0a` seam band 0.5 below the top (the physical 1 cm separator line). A matte `#030303` screen disc (r 0.86) on top carries two white (`#FAFAFA`) circular eyes (r 0.19 at x ±0.38) and a flat accent ring (inner 0.78 → outer 0.86), `toneMapped={false}` so it reads as emissive. Body hardware matches the device: USB-C and USB-A recesses with `#242424` bezels on the lower front, two `#d4d4d4` charge-light dots above them, a `#242424`/`#3a3a3a` slide switch on the left, two slot buttons on the right.
 - **Blink** — every 10 s the eyes squash to 8% height and back over 0.28 s (sine ease in `useFrame`), skipped under reduced motion.
@@ -115,6 +115,10 @@ Structural motion is limited to three moves: the rail's push (margin animation o
 - **Sentence case everywhere.** No uppercase labels, no tracked-out smallcaps.
 - **Mono only in the jobs document viewer.** URLs, telemetry, and identifiers render in the sans face like everything else.
 - **Serif is a display voice**, limited to the overview greeting and the connect-screen title.
-- **One Icons object.** All glyphs route through `src/components/icons.tsx`; Material outline style only.
+- **One Icons object.** All glyphs route through `apps/console/src/components/icons.tsx`; Material outline style only.
 - **The dashboard secret** is entered via `type="password"` and never rendered anywhere in the UI.
 - **The face LogoMark is the only brand mark** — the device's square screen with two punched capsule eyes; no third-party logos or names anywhere in the chrome (connector logos inside the MCP catalog are content, not chrome).
+
+## Navigation
+
+Prev: [Product](product.md) · Next: [Mapping](../reference/mapping.md)

--- a/documentation/console/product.md
+++ b/documentation/console/product.md
@@ -1,4 +1,4 @@
-# Product
+# Console product
 
 <!-- impeccable:product-schema 1 -->
 
@@ -32,7 +32,7 @@ The owner enters their worker URL, device instance name (default `desk`), and th
 - The console must never take the device's protocol path (dashboard connections are deliberately excluded from device message handling) and never call agent state writes; it is read-and-RPC only.
 - MCP servers can require OAuth: install returns an authUrl the owner must open; server state may be `authenticating`/`failed`; tool enablement is opt-in with safety levels (`safe`/`confirm`/`unsafe`).
 - Telemetry is a snapshot with staleness (receivedAtMs), not a stream; the device pushes it only while connected.
-- Repo conventions are binding: single-word filenames, long descriptive identifiers, zod at every boundary, no comments except non-obvious why, ~300-line file cap. Vendored shadcn components under `src/components/ui/` are the sanctioned exception.
+- Repo conventions are binding: single-word filenames, long descriptive identifiers, zod at every boundary, no comments except non-obvious why, ~300-line file cap. Vendored shadcn components under `apps/console/src/components/ui/` are the sanctioned exception.
 
 ## Brand Commitments
 
@@ -49,3 +49,7 @@ The agent's real data models in `apps/agent/src/`: `ApolloState`, `McpServerSumm
 - The device is the hero; the console is the instrument panel around it.
 - One secret gates everything: never weaken the token model for convenience.
 - Stateless console: losing the browser loses nothing but a saved connection.
+
+## Navigation
+
+Prev: [Testing](../operations/testing.md) · Next: [Design](design.md)

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -43,10 +43,15 @@ This handbook is meant to be read in order. Later chapters assume the concepts i
 24. [Auth](operations/auth.md) — Device and dashboard credentials
 25. [Testing](operations/testing.md) — How this repo verifies behavior
 
-### Part V — Reference
+### Part V — Console
 
-26. [Mapping](reference/mapping.md) — Handbook topics to `apps/agent/src/` folders
-27. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
+26. [Product](console/product.md) — What the console is for and who it serves
+27. [Design](console/design.md) — The console's visual system, documented from the code as built
+
+### Part VI — Reference
+
+28. [Mapping](reference/mapping.md) — Handbook topics to `apps/agent/src/` folders
+29. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
 
 ## The firmware
 

--- a/documentation/operations/testing.md
+++ b/documentation/operations/testing.md
@@ -21,4 +21,4 @@ Before considering a change done, `bun run check` should pass — it runs lint, 
 
 ## Navigation
 
-Prev: [Auth](auth.md) · Next: [Mapping](../reference/mapping.md)
+Prev: [Auth](auth.md) · Next: [Product](../console/product.md)

--- a/documentation/reference/mapping.md
+++ b/documentation/reference/mapping.md
@@ -35,4 +35,4 @@ Thin map from handbook topics to code folders. Prefer the narrative chapters for
 
 ## Navigation
 
-Prev: [Testing](../operations/testing.md) · Next: [Roadmap](roadmap.md)
+Prev: [Design](../console/design.md) · Next: [Roadmap](roadmap.md)


### PR DESCRIPTION
## What

Reland of #44, restacked onto #45 (the branding reland) after the #42 squash-merge orphaned the previous chain.

The console's DESIGN.md and PRODUCT.md move out of `apps/console/` and into the handbook as **Part V — Console** (`documentation/console/product.md` and `design.md`), so no doc markdown lives outside `documentation/` anymore.

- Both chapters adapted to the handbook structure: repo-relative code paths, cross-links, and navigation footers.
- `documentation/index.md` gains Part V — Console; Reference becomes Part VI and renumbers.
- The read-in-order chain is rewired: Testing → Product → Design → Mapping.
- Stale pointers updated: root CLAUDE.md's console line and the direction-contract comment in `apps/console/index.html`.

Left in place on purpose: README.md (GitHub landing page), CLAUDE.md files (agent instructions), and `.agents/`/`.impeccable/` tooling files.

Merge order: #45 first, then this (GitHub will retarget it to main automatically).

## Verification

`bun run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yaGn8wXY1YY4ffjmCyNVa

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves the console product and design handbooks into `documentation/` and incorporates them into the handbook reading order.

- Adds Part V — Console and renumbers Reference as Part VI.
- Rewrites console implementation references as repository-relative paths.
- Updates navigation links and stale pointers to the relocated documents.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge, with all changed links, navigation relationships, and repository paths resolving correctly.

The relocated chapters are integrated into a reciprocal reading-order chain, their rewritten references resolve to existing implementation files, and no blocking or independently actionable changed-code issue remains.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20galfrevn%2Fapollo%20PR%20%2346%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=galfrevn%2Fapollo&pr=46&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["docs(console): move the console handbook..."](https://github.com/galfrevn/apollo/commit/aa0ed4a6fb6de658246a49ef5216797ff5bb5682) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52820308)</sub>

<!-- /greptile_comment -->