### PR TITLE
refactor(agent): honest contracts for the tools module under anti-slop lint

### DIFF
--- a/apps/agent/src/tools/__tests__/catalog.spec.ts
+++ b/apps/agent/src/tools/__tests__/catalog.spec.ts
@@ -24,7 +24,7 @@ describe('builtin tool catalog', () => {
     expect(nameList).not.toContain('gmail_send');
     for (const tool of listBuiltinToolDefinitionList()) {
       expect(tool.parameters).toBeDefined();
-      expect(typeof tool.parameters).toBe('object');
+      expect(tool.parameters).toBeInstanceOf(Object);
     }
   });
 

--- a/apps/agent/src/tools/__tests__/coding.spec.ts
+++ b/apps/agent/src/tools/__tests__/coding.spec.ts
@@ -43,7 +43,7 @@ function stubGithubFetch(installedFullNameList: readonly string[]): void {
   };
   globalThis.fetch = Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 async function buildConfiguredEnvironment(): Promise<Env> {

--- a/apps/agent/src/tools/__tests__/device.spec.ts
+++ b/apps/agent/src/tools/__tests__/device.spec.ts
@@ -12,19 +12,14 @@ import {
   setBrightnessTool,
   setVolumeTool,
 } from '@/tools/device';
-import type { ToolExecutionContext } from '@/tools/types';
+import type { DeskToolEffects, ToolExecutionContext } from '@/tools/types';
+
+type DeviceToolCallInput = Parameters<DeskToolEffects['callDeviceTool']>[0];
 
 function createContextWithDeviceCallRecorder(
   deviceResponse = { ok: true, summary: 'true' },
-): {
-  context: ToolExecutionContext;
-  readCallList: () => readonly {
-    deviceToolName: string;
-    argumentRecord: Record<string, unknown>;
-  }[];
-} {
-  const callList: { deviceToolName: string; argumentRecord: Record<string, unknown> }[] =
-    [];
+) {
+  const callList: DeviceToolCallInput[] = [];
   const context: ToolExecutionContext = {
     environment: createFakeApolloEnvironment(),
     nowMilliseconds: 0,
@@ -35,7 +30,7 @@ function createContextWithDeviceCallRecorder(
       },
     }),
   };
-  return { context, readCallList: () => callList };
+  return { context, readCallList: (): readonly DeviceToolCallInput[] => callList };
 }
 
 describe('set_volume', () => {

--- a/apps/agent/src/tools/__tests__/intent.spec.ts
+++ b/apps/agent/src/tools/__tests__/intent.spec.ts
@@ -6,11 +6,11 @@ import { setWeatherLocationTool } from '@/tools/location';
 import { rememberFactTool } from '@/tools/memory';
 import { cancelReminderTool, listRemindersTool, setReminderTool } from '@/tools/reminder';
 import { startResearchTool } from '@/tools/research';
-import type { DeskToolEffects } from '@/tools/types';
+import type { DeskToolEffects, JsonSerializableValue } from '@/tools/types';
 import { weatherNowTool } from '@/tools/weather';
 import { clearDeskWeatherCache } from '@/weather/cache';
 
-function createTypedFetchMock(responseBody: unknown): typeof fetch {
+function createTypedFetchMock(responseBody: JsonSerializableValue): typeof fetch {
   const fetchHandler = async (
     _input: RequestInfo | URL,
     _init?: RequestInit,
@@ -18,7 +18,7 @@ function createTypedFetchMock(responseBody: unknown): typeof fetch {
 
   return Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 function createTypedFetchMockWithStatus(
@@ -32,7 +32,7 @@ function createTypedFetchMockWithStatus(
 
   return Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 function createRejectingFetchMock(error: Error): typeof fetch {
@@ -45,7 +45,7 @@ function createRejectingFetchMock(error: Error): typeof fetch {
 
   return Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 function createRecordingEffects(): DeskToolEffects & {
@@ -274,7 +274,7 @@ describe('intent tools', () => {
         );
       },
       { preconnect: () => {} },
-    ) as typeof fetch;
+    );
     try {
       const result = await weatherNowTool.handler(
         { locationQuery: 'Rosario' },

--- a/apps/agent/src/tools/__tests__/pending.spec.ts
+++ b/apps/agent/src/tools/__tests__/pending.spec.ts
@@ -9,12 +9,26 @@ import {
   savePendingToolConfirmation,
 } from '@/tools/pending';
 
-function createSingleRowSqlExecutor(row: Record<string, unknown>): MemorySqlExecutor {
-  const rowList: readonly Record<string, unknown>[] = [row];
+type StoredPendingConfirmationRow = {
+  readonly id?: string;
+  readonly tool_name?: string;
+  readonly args_json?: string;
+  readonly summary?: string;
+  readonly expires_at?: number;
+};
+
+function createSingleRowSqlExecutor(
+  row: StoredPendingConfirmationRow,
+): MemorySqlExecutor {
+  const rowList: readonly StoredPendingConfirmationRow[] = [row];
+  // SAFETY: the fake answers every select with the same canned row list no
+  // matter which row type the caller requests; the code under test validates
+  // every row with zod before trusting it, which is exactly what these tests
+  // exercise.
   return {
-    execute: <Row extends Record<string, unknown>>(query: string): readonly Row[] =>
-      query.includes('FROM pending_confirmations') ? (rowList as readonly Row[]) : [],
-  };
+    execute: (query: string) =>
+      query.includes('FROM pending_confirmations') ? rowList : [],
+  } as MemorySqlExecutor;
 }
 
 describe('pending tool confirmation store', () => {
@@ -96,12 +110,14 @@ describe('pending tool confirmation store', () => {
   });
 
   it('treats a row of the wrong shape as nothing pending', async () => {
-    const wrongShapeSqlExecutor = createSingleRowSqlExecutor({
+    const sqlExecutorReturningMalformedRows = createSingleRowSqlExecutor({
       id: 'confirm-1',
       summary: 'incompleto',
     });
 
-    expect(await readPendingToolConfirmation(wrongShapeSqlExecutor)).toBeUndefined();
+    expect(
+      await readPendingToolConfirmation(sqlExecutorReturningMalformedRows),
+    ).toBeUndefined();
   });
 });
 

--- a/apps/agent/src/tools/__tests__/recall.spec.ts
+++ b/apps/agent/src/tools/__tests__/recall.spec.ts
@@ -8,11 +8,10 @@ import { recallConversationTool, resumeConversationTool } from '@/tools/history'
 import type { ToolExecutionContext } from '@/tools/types';
 
 function buildContext(effects: ToolExecutionContext['effects']): ToolExecutionContext {
-  return {
-    environment: createFakeApolloEnvironment(),
-    nowMilliseconds: 1,
-    ...(effects === undefined ? {} : { effects }),
-  };
+  if (effects === undefined) {
+    return { environment: createFakeApolloEnvironment(), nowMilliseconds: 1 };
+  }
+  return { environment: createFakeApolloEnvironment(), nowMilliseconds: 1, effects };
 }
 
 describe('recall_conversation', () => {

--- a/apps/agent/src/tools/__tests__/timer.spec.ts
+++ b/apps/agent/src/tools/__tests__/timer.spec.ts
@@ -5,12 +5,8 @@ import {
   createStubDeskToolEffects,
 } from '@/configuration/testing';
 import { formatDurationForSpeech, setTimerTool, startPomodoroTool } from '@/tools/timer';
-import type { DeskToolEffects } from '@/tools/types';
 
-function createRecordingEffects(): {
-  readonly effects: DeskToolEffects;
-  readonly calls: string[];
-} {
+function createRecordingEffects() {
   const calls: string[] = [];
   return {
     calls,

--- a/apps/agent/src/tools/__tests__/translate.spec.ts
+++ b/apps/agent/src/tools/__tests__/translate.spec.ts
@@ -15,7 +15,7 @@ describe('translateTool', () => {
           { status: 200 },
         ),
       { preconnect: () => {} },
-    ) as typeof fetch;
+    );
 
     try {
       const result = await translateTool.handler(
@@ -49,7 +49,7 @@ describe('translateTool', () => {
           { status: 200 },
         ),
       { preconnect: () => {} },
-    ) as typeof fetch;
+    );
 
     try {
       const result = await translateTool.handler(

--- a/apps/agent/src/tools/__tests__/web.spec.ts
+++ b/apps/agent/src/tools/__tests__/web.spec.ts
@@ -3,18 +3,16 @@ import { describe, expect, it } from 'bun:test';
 import { createFakeApolloEnvironment } from '@/configuration/testing';
 import { webSearchTool } from '@/tools/web';
 
-function withMockedFetch(handler: (requestUrl: string) => Response): {
-  restore: () => void;
-} {
+function withMockedFetch(handler: (requestUrl: string) => Response) {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = Object.assign(
     async (input: RequestInfo | URL) => {
       const requestUrl =
-        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        input instanceof URL ? input.href : input instanceof Request ? input.url : input;
       return handler(requestUrl);
     },
     { preconnect: () => {} },
-  ) as typeof fetch;
+  );
   return {
     restore: () => {
       globalThis.fetch = originalFetch;

--- a/apps/agent/src/tools/device.ts
+++ b/apps/agent/src/tools/device.ts
@@ -74,10 +74,11 @@ function parseDeviceStatusSummary(
   deviceResult: ToolExecutionResult,
 ): ToolExecutionResult {
   try {
+    const parsedStatusData: unknown = JSON.parse(deviceResult.summary);
     return {
       ok: true,
       summary: 'Estado del dispositivo obtenido.',
-      data: JSON.parse(deviceResult.summary) as unknown,
+      data: parsedStatusData,
     };
   } catch {
     return deviceResult;

--- a/apps/agent/src/tools/list.ts
+++ b/apps/agent/src/tools/list.ts
@@ -131,11 +131,15 @@ export const removeFromListTool: ToolDefinition = {
     }
     const parsedArgs = parsedArgsResult.data;
     const listName = parsedArgs.listName ?? DEFAULT_LIST_NAME;
-    const removal = await context.effects.removeListItems({
-      listName,
-      ...(parsedArgs.item !== undefined ? { contentQuery: parsedArgs.item } : {}),
-      clearAll: parsedArgs.clearAll === true,
-    });
+    const removal = await context.effects.removeListItems(
+      parsedArgs.item === undefined
+        ? { listName, clearAll: parsedArgs.clearAll === true }
+        : {
+            listName,
+            contentQuery: parsedArgs.item,
+            clearAll: parsedArgs.clearAll === true,
+          },
+    );
     if (removal.removedCount === 0) {
       return {
         ok: false,

--- a/apps/agent/src/tools/pending.ts
+++ b/apps/agent/src/tools/pending.ts
@@ -32,7 +32,7 @@ export async function savePendingToolConfirmation(
 export async function readPendingToolConfirmation(
   sqlExecutor: MemorySqlExecutor,
 ): Promise<PendingToolConfirmation | undefined> {
-  const rows = sqlExecutor.execute<Record<string, unknown>>(
+  const rows = sqlExecutor.execute(
     'SELECT id, tool_name, args_json, summary, expires_at FROM pending_confirmations LIMIT 1',
   );
   const firstRow = rows[0];

--- a/apps/agent/src/tools/sandbox.ts
+++ b/apps/agent/src/tools/sandbox.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod';
 
-import {
-  truncateSandboxOutputForToolResult,
-  type SandboxCodeLanguage,
-} from '@/sandbox/helpers';
+import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
 import type { ToolDefinition } from '@/tools/types';
 
 const sandboxRunCodeArgsSchema = z.object({
@@ -44,7 +41,7 @@ export const sandboxRunCodeTool: ToolDefinition = {
       environment: context.environment,
       deviceId,
       code: parsedArgs.code,
-      language: parsedArgs.language as SandboxCodeLanguage,
+      language: parsedArgs.language,
     });
     return {
       ok: result.ok,

--- a/apps/agent/src/tools/types.ts
+++ b/apps/agent/src/tools/types.ts
@@ -3,6 +3,18 @@ import type { ScheduledReminderRow } from '@/reminders/logic';
 
 export type ToolSafetyLevel = 'safe' | 'unsafe';
 
+export type JsonSerializableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonSerializableValue[]
+  | { readonly [propertyName: string]: JsonSerializableValue };
+
+export type ToolArgumentRecord = {
+  readonly [argumentName: string]: JsonSerializableValue;
+};
+
 export type ToolExecutionResult = {
   readonly ok: boolean;
   readonly summary: string;
@@ -87,7 +99,7 @@ export type DeskToolEffects = {
   >;
   readonly callDeviceTool: (input: {
     readonly deviceToolName: string;
-    readonly argumentRecord: Record<string, unknown>;
+    readonly argumentRecord: ToolArgumentRecord;
   }) => Promise<ToolExecutionResult>;
   readonly callInstalledMcpTool: (input: {
     readonly serverId: string;


### PR DESCRIPTION
## Summary

Clears 28 of the 33 anti-slop lint findings in `apps/agent/src/tools/` with honest, behavior-preserving fixes — no rule suppressions, no type laundering.

- **`types.ts`**: new exported contract types `JsonSerializableValue` (recursive JSON union) and `ToolArgumentRecord`; `DeskToolEffects.callDeviceTool` now takes a `ToolArgumentRecord` instead of `Record<string, unknown>`.
- **`pending.ts`**: dropped the explicit `Record<string, unknown>` type argument on `execute` — rows are still zod-validated immediately after.
- **`sandbox.ts`**: removed a dead `as SandboxCodeLanguage` cast (the zod enum already produces that exact union).
- **`device.ts`**: replaced `JSON.parse(...) as unknown` with an `unknown`-annotated local.
- **`list.ts`**: replaced a conditional empty-object spread with an explicit ternary between two complete input literals.
- **Specs**: removed every `as typeof fetch` assertion (the `Object.assign(handler, { preconnect })` mocks are directly assignable), typed fetch bodies and SQL-row doubles with named contracts, replaced `typeof` narrowing with `instanceof`, dropped known-value-widening return annotations, and renamed `wrongShapeSqlExecutor` to `sqlExecutorReturningMalformedRows`. The one remaining assertion (the fake `MemorySqlExecutor` in `pending.spec.ts`) carries a `SAFETY:` comment for the generic-implementation invariant.

## Deliberately left unfixed (5 findings)

`ToolHandler.args` / `buildConfirmSummary` args / `executeToolByName.toolArgs` (`unknown`) and `callInstalledMcpTool.argumentRecord` / `ToolDefinition.parameters` (`Record<string, unknown>`) all receive values that `voice/llm.ts` and `mcp/adapter.ts` currently parse to `unknown`-valued types. Narrowing them breaks those consumers (verified via typecheck). Once those boundaries parse into concrete JSON types, the new exports in `types.ts` make these five one-line fixes.

## Verification

- `bunx oxlint --deny-warnings apps/agent/src/tools` — only the 5 documented findings remain
- `bunx tsc --noEmit` in `apps/agent` — exit 0 repo-wide
- `bun test src/tools` — 62 pass, 0 fail
- `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmwFXWf4EJMGXNE2Czw4sF

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refines tool-module contracts and test doubles to satisfy anti-slop linting while preserving runtime behavior.
- Adds recursive JSON-serializable argument types for device tool effects.
- Removes unnecessary casts and explicit generic annotations.
- Rewrites conditional object construction and test narrowing without changing production behavior.
- Improves test-double naming and documents the remaining SQL executor assertion.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The production changes preserve runtime control flow, the narrowed device argument contract matches all inspected callers and implementations, and pending SQL rows remain validated before use.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20galfrevn%2Fapollo%20PR%20%2348%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=galfrevn%2Fapollo&pr=48&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(agent): honest contracts for th..."](https://github.com/galfrevn/apollo/commit/509fbd8a25873cbaee401baa732cb131d1808f70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52827743)</sub>

<!-- /greptile_comment -->