### PR TITLE
refactor(lint): anti-slop oxlint plugin, every finding fixed

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,9 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "import", "node", "promise", "react"],
+  "jsPlugins": [
+    { "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }
+  ],
   "categories": {
     "correctness": "error",
     "suspicious": "error"
@@ -16,7 +19,22 @@
     "react/react-in-jsx-scope": "off",
     "unicorn/require-module-specifiers": "off",
     "import/no-unassigned-import": "off",
-    "promise/valid-params": "off"
+    "promise/valid-params": "off",
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-shape-in-symbol-names": "error",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-returns": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "error",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": "error"
   },
   "env": {
     "builtin": true
@@ -24,6 +42,7 @@
   "ignorePatterns": [
     ".agents/skills/**",
     ".claude/skills/**",
+    "tools/oxlint/**",
     "apps/console/src/components/ui/**"
   ]
 }

--- a/apps/agent/src/agents/apollo.ts
+++ b/apps/agent/src/agents/apollo.ts
@@ -6,6 +6,7 @@ import {
   type WSMessage,
 } from 'agents';
 import type { Session, SessionManager } from 'agents/experimental/memory/session';
+import type { z } from 'zod';
 
 import {
   buildDeskDashboardPayload,
@@ -111,7 +112,9 @@ import {
   removeMcpServerInputSchema,
   retryMcpServerInputSchema,
   setMcpToolEnabledInputSchema,
+  type InstallMcpServerInput,
   type McpServerSummary,
+  type SetMcpToolEnabledInput,
 } from '@/mcp/servers';
 import {
   deleteMcpToolSettingsForServer,
@@ -134,6 +137,7 @@ import {
   getSessionPreference,
   setSessionPreference,
   type MemorySqlExecutor,
+  type MemorySqlRow,
 } from '@/memory/store';
 import { embedTextWithOpenRouter, queryMemoryVectors } from '@/memory/vector';
 import { PUBLIC_ORIGIN_PREFERENCE_KEY, runFirmwareLifecycle } from '@/ota/lifecycle';
@@ -147,11 +151,11 @@ import {
   type ConfirmCloseReasonName,
   type DeskSoundEffectName,
   type DeviceToServerMessage,
+  type ServerToDeviceMessage,
 } from '@/protocol/schema';
 import {
   mapAgentScheduleListToReminderList,
   selectReminderRowsForCancel,
-  type AgentScheduleLike,
   type ScheduledReminderRow,
 } from '@/reminders/logic';
 import { createDeskUiMachine, type DeskUiMachine } from '@/session/machine';
@@ -222,26 +226,47 @@ const LOW_BATTERY_ANNOUNCE_PREFERENCE_KEY = 'lowBatteryLastAnnounceAt';
 const TELEMETRY_SNAPSHOT_PREFERENCE_KEY = 'lastTelemetrySnapshot';
 const INITIATIVE_STATE_PREFERENCE_KEY = 'initiativeState';
 
-function mapUnknownScheduleListToAgentScheduleLikeList(
-  scheduleList: readonly {
-    readonly id: string;
-    readonly callback: string;
-    readonly payload: unknown;
-    readonly time: number;
-    readonly type?: string;
-    readonly delayInSeconds?: number;
-  }[],
-): readonly AgentScheduleLike[] {
-  return scheduleList.map((schedule) => ({
-    id: schedule.id,
-    callback: schedule.callback,
-    payload: schedule.payload,
-    time: schedule.time,
-    ...(schedule.type !== undefined ? { type: schedule.type } : {}),
-    ...(typeof schedule.delayInSeconds === 'number'
-      ? { delayInSeconds: schedule.delayInSeconds }
-      : {}),
-  }));
+type McpSecretInput = z.infer<typeof mcpSecretInputSchema>;
+type RemoveMcpServerInput = z.infer<typeof removeMcpServerInputSchema>;
+type RetryMcpServerInput = z.infer<typeof retryMcpServerInputSchema>;
+type ConsoleSecretInput = z.infer<typeof consoleSecretInputSchema>;
+type ConsoleMemoryBrowseInput = z.infer<typeof consoleMemoryBrowseInputSchema>;
+type ConsoleCancelReminderInput = z.infer<typeof consoleCancelReminderInputSchema>;
+type ConsoleCreateReminderInput = z.infer<typeof consoleCreateReminderInputSchema>;
+type ConsoleDeviceVolumeInput = z.infer<typeof consoleDeviceVolumeInputSchema>;
+type ConsoleDeviceBrightnessInput = z.infer<typeof consoleDeviceBrightnessInputSchema>;
+type ConsoleAddMemoryInput = z.infer<typeof consoleAddMemoryInputSchema>;
+type ConsoleDeleteMemoryInput = z.infer<typeof consoleDeleteMemoryInputSchema>;
+type ConsoleAddListItemInput = z.infer<typeof consoleAddListItemInputSchema>;
+type ConsoleRemoveListItemInput = z.infer<typeof consoleRemoveListItemInputSchema>;
+type ConsoleWeatherInput = z.infer<typeof consoleWeatherInputSchema>;
+type ConsoleThreadListInput = z.infer<typeof consoleThreadListInputSchema>;
+type ConsoleThreadInput = z.infer<typeof consoleThreadInputSchema>;
+type ConsoleDocumentInput = z.infer<typeof consoleDocumentInputSchema>;
+type ConsoleSpeechModeInput = z.infer<typeof consoleSpeechModeInputSchema>;
+type NotifyBackgroundResultInput = z.infer<typeof notifyBackgroundResultInputSchema>;
+type DeliverReminderPayload = z.infer<typeof deliverReminderPayloadSchema>;
+type ExpireConfirmPayload = z.infer<typeof expireConfirmPayloadSchema>;
+type RetryInitiativeUtterancePayload = z.infer<
+  typeof retryInitiativeUtterancePayloadSchema
+>;
+type FinalizeThreadPayload = z.infer<typeof finalizeThreadPayloadSchema>;
+
+type DeviceToolArgumentRecord = Parameters<typeof buildDeviceToolCallPayload>[2];
+type UiStatePushMessage = Extract<ServerToDeviceMessage, { type: 'ui_state' }>;
+
+function createDurableObjectSqlExecutor(sqlStorage: SqlStorage): MemorySqlExecutor {
+  function executeMemorySqlQuery<Row extends MemorySqlRow>(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly Row[];
+  function executeMemorySqlQuery(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly MemorySqlRow[] {
+    return sqlStorage.exec(query, ...bindValues).toArray();
+  }
+  return { execute: executeMemorySqlQuery };
 }
 
 export type DeskUiState =
@@ -530,8 +555,16 @@ export class Apollo extends Agent<Env, ApolloState> {
       return;
     }
 
-    if (typeof message !== 'string') {
-      this.#audioChunkList.push(message as ArrayBuffer);
+    if (message instanceof ArrayBuffer) {
+      this.#audioChunkList.push(message);
+      return;
+    }
+    if (ArrayBuffer.isView(message)) {
+      const audioChunkBuffer = new ArrayBuffer(message.byteLength);
+      new Uint8Array(audioChunkBuffer).set(
+        new Uint8Array(message.buffer, message.byteOffset, message.byteLength),
+      );
+      this.#audioChunkList.push(audioChunkBuffer);
       return;
     }
 
@@ -658,7 +691,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async installMcpServer(rawInput: unknown): Promise<{
+  async installMcpServer(rawInput: InstallMcpServerInput): Promise<{
     readonly serverId: string;
     readonly state: string;
     readonly authUrl: string | null;
@@ -684,7 +717,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async uninstallMcpServer(rawInput: unknown): Promise<readonly McpServerSummary[]> {
+  async uninstallMcpServer(
+    rawInput: RemoveMcpServerInput,
+  ): Promise<readonly McpServerSummary[]> {
     const input = removeMcpServerInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     await this.removeMcpServer(input.serverId);
@@ -693,14 +728,16 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async listMcpServers(rawInput: unknown): Promise<readonly McpServerSummary[]> {
+  async listMcpServers(rawInput: McpSecretInput): Promise<readonly McpServerSummary[]> {
     const input = mcpSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return this.#listMcpServerSummaryList();
   }
 
   @callable()
-  async retryMcpServer(rawInput: unknown): Promise<readonly McpServerSummary[]> {
+  async retryMcpServer(
+    rawInput: RetryMcpServerInput,
+  ): Promise<readonly McpServerSummary[]> {
     const input = retryMcpServerInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     // Reconnects the existing installation with its stored transport — auth
@@ -712,17 +749,21 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async enableMcpTool(rawInput: unknown): Promise<readonly McpServerSummary[]> {
+  async enableMcpTool(
+    rawInput: SetMcpToolEnabledInput,
+  ): Promise<readonly McpServerSummary[]> {
     return this.#setMcpToolEnabled(rawInput, true);
   }
 
   @callable()
-  async disableMcpTool(rawInput: unknown): Promise<readonly McpServerSummary[]> {
+  async disableMcpTool(
+    rawInput: SetMcpToolEnabledInput,
+  ): Promise<readonly McpServerSummary[]> {
     return this.#setMcpToolEnabled(rawInput, false);
   }
 
   async #setMcpToolEnabled(
-    rawInput: unknown,
+    rawInput: SetMcpToolEnabledInput,
     isEnabled: boolean,
   ): Promise<readonly McpServerSummary[]> {
     const input = setMcpToolEnabledInputSchema.parse(rawInput);
@@ -752,7 +793,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async getConsoleStatus(rawInput: unknown): Promise<ConsoleStatusSnapshot> {
+  async getConsoleStatus(rawInput: ConsoleSecretInput): Promise<ConsoleStatusSnapshot> {
     const input = consoleSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     await this.#ensureTelemetrySnapshotLoaded();
@@ -766,7 +807,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async browseConsoleMemory(rawInput: unknown): Promise<ConsoleMemoryBrowseResult> {
+  async browseConsoleMemory(
+    rawInput: ConsoleMemoryBrowseInput,
+  ): Promise<ConsoleMemoryBrowseResult> {
     const input = consoleMemoryBrowseInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return browseConsoleMemoryRecords(this.#sqlExecutor(), {
@@ -776,7 +819,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async listConsoleLists(rawInput: unknown): Promise<readonly ListItemRecord[]> {
+  async listConsoleLists(
+    rawInput: ConsoleSecretInput,
+  ): Promise<readonly ListItemRecord[]> {
     const input = consoleSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return listListItemRecords(this.#sqlExecutor());
@@ -784,7 +829,7 @@ export class Apollo extends Agent<Env, ApolloState> {
 
   @callable()
   async listConsoleReminders(
-    rawInput: unknown,
+    rawInput: ConsoleSecretInput,
   ): Promise<readonly ScheduledReminderRow[]> {
     const input = consoleSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
@@ -793,7 +838,7 @@ export class Apollo extends Agent<Env, ApolloState> {
 
   @callable()
   async cancelConsoleReminder(
-    rawInput: unknown,
+    rawInput: ConsoleCancelReminderInput,
   ): Promise<readonly ScheduledReminderRow[]> {
     const input = consoleCancelReminderInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
@@ -803,14 +848,12 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   async #listConsoleReminderRowList(): Promise<readonly ScheduledReminderRow[]> {
-    return mapAgentScheduleListToReminderList(
-      mapUnknownScheduleListToAgentScheduleLikeList(await this.listSchedules()),
-    );
+    return mapAgentScheduleListToReminderList(await this.listSchedules());
   }
 
   @callable()
   async createConsoleReminder(
-    rawInput: unknown,
+    rawInput: ConsoleCreateReminderInput,
   ): Promise<readonly ScheduledReminderRow[]> {
     const input = consoleCreateReminderInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
@@ -829,7 +872,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async setConsoleDeviceVolume(rawInput: unknown): Promise<ToolExecutionResult> {
+  async setConsoleDeviceVolume(
+    rawInput: ConsoleDeviceVolumeInput,
+  ): Promise<ToolExecutionResult> {
     const input = consoleDeviceVolumeInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return this.#callDeviceTool('self.audio_speaker.set_volume', {
@@ -838,7 +883,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async setConsoleDeviceBrightness(rawInput: unknown): Promise<ToolExecutionResult> {
+  async setConsoleDeviceBrightness(
+    rawInput: ConsoleDeviceBrightnessInput,
+  ): Promise<ToolExecutionResult> {
     const input = consoleDeviceBrightnessInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return this.#callDeviceTool('self.screen.set_brightness', {
@@ -847,14 +894,18 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async getConsoleDeviceStatus(rawInput: unknown): Promise<ToolExecutionResult> {
+  async getConsoleDeviceStatus(
+    rawInput: ConsoleSecretInput,
+  ): Promise<ToolExecutionResult> {
     const input = consoleSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return this.#callDeviceTool('self.get_device_status', {});
   }
 
   @callable()
-  async addConsoleMemory(rawInput: unknown): Promise<ConsoleMemoryBrowseResult> {
+  async addConsoleMemory(
+    rawInput: ConsoleAddMemoryInput,
+  ): Promise<ConsoleMemoryBrowseResult> {
     const input = consoleAddMemoryInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     const memoryRecord = await addMemoryRecord(this.#sqlExecutor(), input.content);
@@ -868,7 +919,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async deleteConsoleMemory(rawInput: unknown): Promise<ConsoleMemoryBrowseResult> {
+  async deleteConsoleMemory(
+    rawInput: ConsoleDeleteMemoryInput,
+  ): Promise<ConsoleMemoryBrowseResult> {
     const input = consoleDeleteMemoryInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     await deleteConsoleMemoryRecord(
@@ -880,7 +933,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async addConsoleListItem(rawInput: unknown): Promise<readonly ListItemRecord[]> {
+  async addConsoleListItem(
+    rawInput: ConsoleAddListItemInput,
+  ): Promise<readonly ListItemRecord[]> {
     const input = consoleAddListItemInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     await addListItemRecord(this.#sqlExecutor(), {
@@ -891,7 +946,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async removeConsoleListItem(rawInput: unknown): Promise<readonly ListItemRecord[]> {
+  async removeConsoleListItem(
+    rawInput: ConsoleRemoveListItemInput,
+  ): Promise<readonly ListItemRecord[]> {
     const input = consoleRemoveListItemInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     await removeListItemRecordById(this.#sqlExecutor(), input.itemId);
@@ -899,14 +956,14 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async getConsoleWeather(rawInput: unknown): Promise<DeskWeatherLocation> {
+  async getConsoleWeather(rawInput: ConsoleSecretInput): Promise<DeskWeatherLocation> {
     const input = consoleSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return this.#resolveWeatherLocation();
   }
 
   @callable()
-  async setConsoleWeather(rawInput: unknown): Promise<DeskWeatherLocation> {
+  async setConsoleWeather(rawInput: ConsoleWeatherInput): Promise<DeskWeatherLocation> {
     const input = consoleWeatherInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     const location = await geocodeDeskWeatherLocation({
@@ -922,7 +979,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async listConsoleThreads(rawInput: unknown): Promise<readonly ConsoleThreadSummary[]> {
+  async listConsoleThreads(
+    rawInput: ConsoleThreadListInput,
+  ): Promise<readonly ConsoleThreadSummary[]> {
     const input = consoleThreadListInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     const legacyMessageCount = await this.sessionManager.getMessageCount(
@@ -938,7 +997,9 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async getConsoleThread(rawInput: unknown): Promise<readonly ConsoleHistoryTurn[]> {
+  async getConsoleThread(
+    rawInput: ConsoleThreadInput,
+  ): Promise<readonly ConsoleHistoryTurn[]> {
     const input = consoleThreadInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     const recentHistory = await this.sessionManager
@@ -948,14 +1009,16 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async listConsoleJobs(rawInput: unknown): Promise<readonly ConsoleJobDocument[]> {
+  async listConsoleJobs(
+    rawInput: ConsoleSecretInput,
+  ): Promise<readonly ConsoleJobDocument[]> {
     const input = consoleSecretInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return listConsoleJobDocuments(this.env.MEDIA, this.name ?? 'default');
   }
 
   @callable()
-  async getConsoleDocument(rawInput: unknown): Promise<{
+  async getConsoleDocument(rawInput: ConsoleDocumentInput): Promise<{
     readonly documentKey: string;
     readonly content: string | null;
   }> {
@@ -970,7 +1033,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async setConsoleSpeechMode(rawInput: unknown): Promise<ApolloState> {
+  async setConsoleSpeechMode(rawInput: ConsoleSpeechModeInput): Promise<ApolloState> {
     const input = consoleSpeechModeInputSchema.parse(rawInput);
     await this.#assertDashboardSecret(input.secret);
     return this.setSpeechMode(input.speechModeId);
@@ -993,7 +1056,7 @@ export class Apollo extends Agent<Env, ApolloState> {
     return this.state;
   }
 
-  async expireConfirm(payload: unknown): Promise<void> {
+  async expireConfirm(payload: ExpireConfirmPayload | undefined): Promise<void> {
     if (this.state.pendingConfirmId === null) {
       return;
     }
@@ -1043,7 +1106,7 @@ export class Apollo extends Agent<Env, ApolloState> {
     }
   }
 
-  async deliverReminder(payload: unknown): Promise<void> {
+  async deliverReminder(payload: DeliverReminderPayload): Promise<void> {
     const parsedPayload = deliverReminderPayloadSchema.parse(payload);
     // The earcon goes out before the notification so it lands while the TTS
     // announcement is still being synthesized.
@@ -1061,16 +1124,14 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   @callable()
-  async notifyBackgroundResult(input: unknown): Promise<void> {
+  async notifyBackgroundResult(input: NotifyBackgroundResultInput): Promise<void> {
     const parsedInput = notifyBackgroundResultInputSchema.parse(input);
     await deliverDeskDeviceNotification({
       notification: {
         type: 'background_result',
         prompt: parsedInput.prompt,
         summary: parsedInput.summary,
-        ...(parsedInput.documentKey !== undefined
-          ? { documentKey: parsedInput.documentKey }
-          : {}),
+        documentKey: parsedInput.documentKey,
       },
       connectionList: [...this.getConnections(DEVICE_CONNECTION_TAG)],
       sqlExecutor: this.#sqlExecutor(),
@@ -1113,7 +1174,7 @@ export class Apollo extends Agent<Env, ApolloState> {
         message: 'initiative_decision',
         source: input.source,
         action: decision.action,
-        ...(decision.action !== 'deliver' ? { reason: decision.reason } : {}),
+        reason: decision.action === 'deliver' ? undefined : decision.reason,
       }),
     );
     if (decision.action === 'defer') {
@@ -1121,14 +1182,19 @@ export class Apollo extends Agent<Env, ApolloState> {
         60,
         Math.ceil((decision.retryAtMilliseconds - nowMilliseconds) / 1000),
       );
-      await this.schedule(retryDelaySeconds, 'retryInitiativeUtterance', {
+      const deferredRetryPayload: RetryInitiativeUtterancePayload = {
         source: input.source,
         priority: input.priority,
         message: input.message,
-        ...(input.earconName !== undefined ? { earconName: input.earconName } : {}),
-        ...(input.utteranceKey !== undefined ? { utteranceKey: input.utteranceKey } : {}),
+        earconName: input.earconName,
+        utteranceKey: input.utteranceKey,
         deferCount,
-      });
+      };
+      await this.schedule(
+        retryDelaySeconds,
+        'retryInitiativeUtterance',
+        deferredRetryPayload,
+      );
       return 'deferred';
     }
     if (decision.action === 'suppress' || this.#isDeliveringInitiative) {
@@ -1148,7 +1214,7 @@ export class Apollo extends Agent<Env, ApolloState> {
         deviceId: this.name ?? 'default',
         ttsVoiceId: APOLLO_TTS_VOICE,
         isMockVoice: this.env.MOCK_VOICE === '1',
-        ...(input.priority === 'critical' ? { announceKind: 'critical' as const } : {}),
+        announceKind: input.priority === 'critical' ? 'critical' : undefined,
       });
       // Recorded only after delivery succeeds, so a failed delivery neither
       // consumes budget nor starts the source cooldown.
@@ -1177,24 +1243,20 @@ export class Apollo extends Agent<Env, ApolloState> {
     return 'delivered';
   }
 
-  async retryInitiativeUtterance(payload: unknown): Promise<void> {
+  async retryInitiativeUtterance(
+    payload: RetryInitiativeUtterancePayload,
+  ): Promise<void> {
     const parsedPayload = retryInitiativeUtterancePayloadSchema.parse(payload);
     const nextDeferCount = parsedPayload.deferCount + 1;
-    const retryPayload = {
+    const retryPayload: RetryInitiativeUtterancePayload = {
       source: parsedPayload.source,
       priority: parsedPayload.priority,
       message: parsedPayload.message,
-      ...(parsedPayload.earconName !== undefined
-        ? { earconName: parsedPayload.earconName }
-        : {}),
-      ...(parsedPayload.utteranceKey !== undefined
-        ? { utteranceKey: parsedPayload.utteranceKey }
-        : {}),
-    };
-    const deliveryOutcome = await this.#deliverInitiativeUtterance({
-      ...retryPayload,
+      earconName: parsedPayload.earconName,
+      utteranceKey: parsedPayload.utteranceKey,
       deferCount: nextDeferCount,
-    });
+    };
+    const deliveryOutcome = await this.#deliverInitiativeUtterance(retryPayload);
     // A deferred utterance already survived one policy window; letting its
     // retry vanish on a transient suppression (device offline at 09:00, budget
     // spent) would lose it for good — so it re-schedules itself, bounded by
@@ -1206,7 +1268,7 @@ export class Apollo extends Agent<Env, ApolloState> {
       await this.schedule(
         INITIATIVE_SUPPRESSED_RETRY_DELAY_SECONDS,
         'retryInitiativeUtterance',
-        { ...retryPayload, deferCount: nextDeferCount },
+        retryPayload,
       );
     }
   }
@@ -1477,7 +1539,7 @@ export class Apollo extends Agent<Env, ApolloState> {
     await targetSession.refreshSystemPrompt();
   }
 
-  async finalizeThread(rawPayload: unknown): Promise<void> {
+  async finalizeThread(rawPayload: FinalizeThreadPayload): Promise<void> {
     const payload = finalizeThreadPayloadSchema.parse(rawPayload);
     const sqlExecutor = this.#sqlExecutor();
     // A resumed thread is active again by the time a delayed finalizer fires;
@@ -1559,15 +1621,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   #sqlExecutor(): MemorySqlExecutor {
-    return {
-      execute: <Row extends Record<string, unknown>>(
-        query: string,
-        ...bindValues: unknown[]
-      ): readonly Row[] => {
-        const result = this.ctx.storage.sql.exec(query, ...bindValues);
-        return result.toArray() as unknown as readonly Row[];
-      },
-    };
+    return createDurableObjectSqlExecutor(this.ctx.storage.sql);
   }
 
   async #ensurePreferencesLoaded(): Promise<void> {
@@ -1603,30 +1657,25 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   #pushUiState(connection: Connection): void {
-    const focusRemainingSec =
-      this.state.focusEndsAt === null
-        ? undefined
-        : Math.max(0, Math.ceil((this.state.focusEndsAt - Date.now()) / 1000));
-    connection.send(
-      encodeServerToDeviceMessage({
-        type: 'ui_state',
-        state: this.state.uiState,
-        speechMode: this.state.speechMode,
-        caption: this.state.caption ?? undefined,
-        focusRemainingSec,
-        ...(this.state.focusEndsAt !== null
-          ? {
-              focusEndsAt: Math.floor(this.state.focusEndsAt / 1000),
-              ...(this.state.focusStartedAt !== null &&
-              this.state.focusStartedAt !== undefined
-                ? { focusStartedAt: Math.floor(this.state.focusStartedAt / 1000) }
-                : {}),
-            }
-          : {}),
-        emotion: resolveDeskFaceEmotion(this.state.uiState),
-        accentColor: resolveDeskSpeechMode(this.state.speechMode).accentColor,
-      }),
-    );
+    const uiStateMessage: UiStatePushMessage = {
+      type: 'ui_state',
+      state: this.state.uiState,
+      speechMode: this.state.speechMode,
+      caption: this.state.caption ?? undefined,
+      emotion: resolveDeskFaceEmotion(this.state.uiState),
+      accentColor: resolveDeskSpeechMode(this.state.speechMode).accentColor,
+    };
+    if (this.state.focusEndsAt !== null) {
+      uiStateMessage.focusRemainingSec = Math.max(
+        0,
+        Math.ceil((this.state.focusEndsAt - Date.now()) / 1000),
+      );
+      uiStateMessage.focusEndsAt = Math.floor(this.state.focusEndsAt / 1000);
+      if (this.state.focusStartedAt !== null) {
+        uiStateMessage.focusStartedAt = Math.floor(this.state.focusStartedAt / 1000);
+      }
+    }
+    connection.send(encodeServerToDeviceMessage(uiStateMessage));
   }
 
   async #pushDashboard(connection: Connection): Promise<void> {
@@ -1700,17 +1749,11 @@ export class Apollo extends Agent<Env, ApolloState> {
     deviceMessage: Extract<DeviceToServerMessage, { type: 'telemetry' }>,
   ): Promise<void> {
     const snapshot: DeskTelemetrySnapshot = {
-      ...(deviceMessage.battery !== undefined ? { battery: deviceMessage.battery } : {}),
-      ...(deviceMessage.charging !== undefined
-        ? { charging: deviceMessage.charging }
-        : {}),
-      ...(deviceMessage.volume !== undefined ? { volume: deviceMessage.volume } : {}),
-      ...(deviceMessage.wifiRssi !== undefined
-        ? { wifiRssi: deviceMessage.wifiRssi }
-        : {}),
-      ...(deviceMessage.firmwareVersion !== undefined
-        ? { firmwareVersion: deviceMessage.firmwareVersion }
-        : {}),
+      battery: deviceMessage.battery,
+      charging: deviceMessage.charging,
+      volume: deviceMessage.volume,
+      wifiRssi: deviceMessage.wifiRssi,
+      firmwareVersion: deviceMessage.firmwareVersion,
       receivedAtMs: Date.now(),
     };
     // The previous snapshot is read before the overwrite because the firmware
@@ -1849,7 +1892,7 @@ export class Apollo extends Agent<Env, ApolloState> {
 
   async #callDeviceTool(
     deviceToolName: string,
-    argumentRecord: Record<string, unknown>,
+    argumentRecord: DeviceToolArgumentRecord,
   ): Promise<ToolExecutionResult> {
     const connectionList = [...this.getConnections(DEVICE_CONNECTION_TAG)];
     if (connectionList.length === 0) {
@@ -1911,13 +1954,12 @@ export class Apollo extends Agent<Env, ApolloState> {
 
   async #broadcastSoonestRemainingTimerArc(): Promise<void> {
     const remainingReminderList = mapAgentScheduleListToReminderList(
-      mapUnknownScheduleListToAgentScheduleLikeList(await this.listSchedules()),
+      await this.listSchedules(),
     );
     const remainingTimerList = remainingReminderList
       .filter(
         (reminder) =>
-          reminder.message.startsWith('Timer') &&
-          typeof reminder.delayInSeconds === 'number',
+          reminder.message.startsWith('Timer') && reminder.delayInSeconds !== undefined,
       )
       .toSorted((left, right) => left.firesAtIso.localeCompare(right.firesAtIso));
     const soonestTimer = remainingTimerList[0];
@@ -2029,14 +2071,11 @@ export class Apollo extends Agent<Env, ApolloState> {
         });
       },
       listReminders: async () => {
-        const scheduleList = await this.listSchedules();
-        return mapAgentScheduleListToReminderList(
-          mapUnknownScheduleListToAgentScheduleLikeList(scheduleList),
-        );
+        return mapAgentScheduleListToReminderList(await this.listSchedules());
       },
       cancelReminders: async ({ message, cancelAll }) => {
         const reminderList = mapAgentScheduleListToReminderList(
-          mapUnknownScheduleListToAgentScheduleLikeList(await this.listSchedules()),
+          await this.listSchedules(),
         );
         const selectedReminderList = selectReminderRowsForCancel(reminderList, {
           message,
@@ -2118,9 +2157,7 @@ export class Apollo extends Agent<Env, ApolloState> {
                   receivedAtMilliseconds: this.#lastPlaybackAck.receivedAtMilliseconds,
                 }
               : null,
-          ...(this.#lastTelemetrySnapshot !== undefined
-            ? { telemetrySnapshot: this.#lastTelemetrySnapshot }
-            : {}),
+          telemetrySnapshot: this.#lastTelemetrySnapshot,
         },
         turnPart,
       );

--- a/apps/agent/src/agents/notify.ts
+++ b/apps/agent/src/agents/notify.ts
@@ -3,10 +3,8 @@ import { z } from 'zod';
 
 import type { DeskAnnounceKind, DeskFocusState } from '@/focus/logic';
 import { shouldAnnounceDuringFocus } from '@/focus/logic';
-import {
-  enqueuePendingDeviceMessage,
-  type PendingDeviceMessageType,
-} from '@/memory/pending';
+import { enqueuePendingDeviceMessage } from '@/memory/pending';
+import type { listPendingDeviceMessages } from '@/memory/pending';
 import type { MemorySqlExecutor } from '@/memory/store';
 import { encodeServerToDeviceMessage } from '@/protocol/schema';
 import { TTS_PCM_CHANNEL_COUNT, TTS_PCM_SAMPLE_RATE_HZ } from '@/voice/elevenlabs';
@@ -32,10 +30,18 @@ const backgroundResultPendingPayloadSchema = z.object({
   documentKey: z.string().min(1).optional(),
 });
 
-export function parsePendingDeviceMessageAsNotification(pendingMessage: {
-  readonly type: PendingDeviceMessageType;
-  readonly payload: Record<string, unknown>;
-}): DeskDeviceNotification {
+type ReminderPendingPayload = z.infer<typeof reminderPendingPayloadSchema>;
+type BackgroundResultPendingPayload = z.infer<
+  typeof backgroundResultPendingPayloadSchema
+>;
+
+type StoredPendingDeviceMessage = Awaited<
+  ReturnType<typeof listPendingDeviceMessages>
+>[number];
+
+export function parsePendingDeviceMessageAsNotification(
+  pendingMessage: Pick<StoredPendingDeviceMessage, 'type' | 'payload'>,
+): DeskDeviceNotification {
   if (pendingMessage.type === 'reminder') {
     return {
       type: 'reminder',
@@ -50,21 +56,29 @@ export function parsePendingDeviceMessageAsNotification(pendingMessage: {
 
 function extractNotificationPendingPayload(
   notification: DeskDeviceNotification,
-): Record<string, unknown> {
+): ReminderPendingPayload | BackgroundResultPendingPayload {
   if (notification.type === 'reminder') {
     return { message: notification.message };
   }
-  return {
+  const backgroundResultPayload: BackgroundResultPendingPayload = {
     summary: notification.summary,
     prompt: notification.prompt,
-    ...(notification.documentKey !== undefined
-      ? { documentKey: notification.documentKey }
-      : {}),
   };
+  if (notification.documentKey !== undefined) {
+    backgroundResultPayload.documentKey = notification.documentKey;
+  }
+  return backgroundResultPayload;
 }
 
 function extractNotificationSpokenText(notification: DeskDeviceNotification): string {
   return notification.type === 'reminder' ? notification.message : notification.summary;
+}
+
+function encodeMockSpeechAudio(spokenText: string): ArrayBuffer {
+  const encodedSpokenTextBytes = new TextEncoder().encode(spokenText);
+  const mockSpeechAudioBuffer = new ArrayBuffer(encodedSpokenTextBytes.byteLength);
+  new Uint8Array(mockSpeechAudioBuffer).set(encodedSpokenTextBytes);
+  return mockSpeechAudioBuffer;
 }
 
 export async function deliverDeskDeviceNotification(input: {
@@ -114,7 +128,7 @@ async function announceNotificationWithTts(input: {
     extractNotificationSpokenText(input.notification),
   );
   const ttsAudio = input.isMockVoice
-    ? (new TextEncoder().encode(spokenText).buffer as ArrayBuffer)
+    ? encodeMockSpeechAudio(spokenText)
     : await synthesizeApolloSpeech({
         environment: input.environment,
         text: spokenText,

--- a/apps/agent/src/agents/runtime.ts
+++ b/apps/agent/src/agents/runtime.ts
@@ -13,7 +13,10 @@ import { recallSemanticMemoryContent } from '@/memory/vector';
 import { resolveDeskSpeechMode } from '@/persona/catalog';
 import { resolveDeskFaceEmotion } from '@/persona/face';
 import { APOLLO_TTS_VOICE, buildInstalledToolPromptNote } from '@/persona/soul';
-import { encodeServerToDeviceMessage } from '@/protocol/schema';
+import {
+  encodeServerToDeviceMessage,
+  type ServerToDeviceMessage,
+} from '@/protocol/schema';
 import type { DeskUiMachine } from '@/session/machine';
 import { buildTelemetryPromptNote, type DeskTelemetrySnapshot } from '@/telemetry/logic';
 import { createBuiltinToolDefinitionMap } from '@/tools/catalog';
@@ -22,7 +25,7 @@ import type {
   PendingToolConfirmation,
   ToolDefinition,
 } from '@/tools/types';
-import { runDeskTurn, type VoiceAdapters } from '@/turn/run';
+import { runDeskTurn, type TurnInput, type VoiceAdapters } from '@/turn/run';
 import { TTS_PCM_CHANNEL_COUNT, TTS_PCM_SAMPLE_RATE_HZ } from '@/voice/elevenlabs';
 import { chatWithOpenRouter } from '@/voice/llm';
 import { transcribeAudioWithOpenRouter } from '@/voice/stt';
@@ -32,6 +35,15 @@ import {
 } from '@/voice/stream';
 import { synthesizeApolloSpeech } from '@/voice/synthesize';
 import { wrapPcmAsWavBuffer } from '@/voice/wav';
+
+type DeskUiStateDeviceMessage = Extract<ServerToDeviceMessage, { type: 'ui_state' }>;
+type TtsStartDeviceMessage = Extract<ServerToDeviceMessage, { type: 'tts_start' }>;
+
+type PlaybackPacingOptions = {
+  prebufferMilliseconds?: number;
+  shouldStop?: () => boolean;
+  getPlaybackAck?: () => PlaybackAckSnapshot | null;
+};
 
 export type ApolloTurnRuntimeDependencies = {
   readonly environment: Env;
@@ -115,7 +127,7 @@ export async function executeApolloTurn(
             toolCallList: [],
           };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeMockSpeechAudio(text),
       }
     : {
         stt: async (audioBuffer) =>
@@ -124,14 +136,19 @@ export async function executeApolloTurn(
             openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
             modelId: dependencies.environment.OPENROUTER_STT_MODEL,
           }),
-        llm: async ({ messageList, toolDefinitionList, onTextDelta }) =>
-          chatWithOpenRouter({
+        llm: async ({ messageList, toolDefinitionList, onTextDelta }) => {
+          const baseChatRequest = {
             openRouterApiKey: dependencies.environment.OPENROUTER_API_KEY,
             modelId: dependencies.environment.OPENROUTER_MODEL,
             messageList,
             toolDefinitionList,
-            ...(onTextDelta !== undefined ? { onTextDelta } : {}),
-          }),
+          };
+          return chatWithOpenRouter(
+            onTextDelta === undefined
+              ? baseChatRequest
+              : { ...baseChatRequest, onTextDelta },
+          );
+        },
         tts: async (text, voiceId) =>
           synthesizeApolloSpeech({
             environment: dependencies.environment,
@@ -140,7 +157,7 @@ export async function executeApolloTurn(
           }),
       };
 
-  const turnOutput = await runDeskTurn({
+  const baseTurnInput: TurnInput = {
     text: turnPart.text,
     audioBuffer: turnPart.audioBuffer,
     speechMode: dependencies.currentState.speechMode,
@@ -154,7 +171,6 @@ export async function executeApolloTurn(
     deviceId: dependencies.deviceId,
     systemPromptOverride: `${sessionSystemPrompt}${focusNote}${telemetryNote}${installedToolNote}`,
     recentHistoryMessageList,
-    ...(isMockVoice ? {} : { recallSemanticMemoryContentList }),
     effects: dependencies.effects,
     onThinkingCaption: async (caption) => {
       const liveState = dependencies.getCurrentState();
@@ -163,31 +179,33 @@ export async function executeApolloTurn(
         uiState: 'thinking',
         caption,
       });
-      connection.send(
-        encodeServerToDeviceMessage({
-          type: 'ui_state',
-          state: 'thinking',
-          speechMode: liveState.speechMode,
-          caption,
-          emotion: resolveDeskFaceEmotion('thinking'),
-          accentColor: resolveDeskSpeechMode(liveState.speechMode).accentColor,
-          ...(liveState.focusEndsAt !== null
-            ? {
-                focusRemainingSec: Math.max(
-                  0,
-                  Math.ceil((liveState.focusEndsAt - Date.now()) / 1000),
-                ),
-                focusEndsAt: Math.floor(liveState.focusEndsAt / 1000),
-                ...(liveState.focusStartedAt !== null
-                  ? { focusStartedAt: Math.floor(liveState.focusStartedAt / 1000) }
-                  : {}),
-              }
-            : {}),
-        }),
-      );
+      const thinkingUiStateMessage: DeskUiStateDeviceMessage = {
+        type: 'ui_state',
+        state: 'thinking',
+        speechMode: liveState.speechMode,
+        caption,
+        emotion: resolveDeskFaceEmotion('thinking'),
+        accentColor: resolveDeskSpeechMode(liveState.speechMode).accentColor,
+      };
+      if (liveState.focusEndsAt !== null) {
+        thinkingUiStateMessage.focusRemainingSec = Math.max(
+          0,
+          Math.ceil((liveState.focusEndsAt - Date.now()) / 1000),
+        );
+        thinkingUiStateMessage.focusEndsAt = Math.floor(liveState.focusEndsAt / 1000);
+        if (liveState.focusStartedAt !== null) {
+          thinkingUiStateMessage.focusStartedAt = Math.floor(
+            liveState.focusStartedAt / 1000,
+          );
+        }
+      }
+      connection.send(encodeServerToDeviceMessage(thinkingUiStateMessage));
     },
     adapters: voiceAdapters,
-  });
+  };
+  const turnOutput = await runDeskTurn(
+    isMockVoice ? baseTurnInput : { ...baseTurnInput, recallSemanticMemoryContentList },
+  );
 
   for (const uiEventName of turnOutput.uiEventList) {
     dependencies.uiMachine.transition(uiEventName);
@@ -251,40 +269,66 @@ export async function executeApolloTurn(
     let followUpIndex = 0;
     let wasAborted = false;
 
+    const synthesizeFollowUpSegmentAudio = async (
+      segmentText: string,
+    ): Promise<ArrayBuffer | undefined> => {
+      try {
+        return await voiceAdapters.tts(segmentText, APOLLO_TTS_VOICE);
+      } catch (synthesisError) {
+        console.error(
+          JSON.stringify({
+            level: 'error',
+            message: 'apollo_tts_follow_up_segment_failed',
+            error:
+              synthesisError instanceof Error
+                ? synthesisError.message
+                : String(synthesisError),
+          }),
+        );
+        return undefined;
+      }
+    };
+
     while (currentAudioBuffer !== undefined) {
       // The next segment renders while this one plays, so synthesis latency
       // hides behind the paced stream instead of gapping the speech. A failed
       // follow-up just ends the reply early — the turn already committed.
-      const nextAudioBufferPromise: Promise<ArrayBuffer | undefined> | undefined =
+      const nextAudioBufferPromise =
         followUpIndex < followUpSegmentTextList.length
-          ? voiceAdapters
-              .tts(followUpSegmentTextList[followUpIndex], APOLLO_TTS_VOICE)
-              .catch((error: unknown): undefined => {
-                console.error(
-                  JSON.stringify({
-                    level: 'error',
-                    message: 'apollo_tts_follow_up_segment_failed',
-                    error: error instanceof Error ? error.message : String(error),
-                  }),
-                );
-                return undefined;
-              })
+          ? synthesizeFollowUpSegmentAudio(followUpSegmentTextList[followUpIndex])
           : undefined;
       const isFirstSegment = followUpIndex === 0;
       followUpIndex += 1;
       const ttsSequence = dependencies.allocateTtsSequence?.();
 
-      connection.send(
-        encodeServerToDeviceMessage({
-          type: 'tts_start',
-          format: 'pcm',
-          bytes: currentAudioBuffer.byteLength,
-          ...(ttsSequence !== undefined ? { sequence: ttsSequence } : {}),
-          sampleRate: TTS_PCM_SAMPLE_RATE_HZ,
-          channels: TTS_PCM_CHANNEL_COUNT,
-        }),
-      );
+      const ttsStartMessage: TtsStartDeviceMessage = {
+        type: 'tts_start',
+        format: 'pcm',
+        bytes: currentAudioBuffer.byteLength,
+        sampleRate: TTS_PCM_SAMPLE_RATE_HZ,
+        channels: TTS_PCM_CHANNEL_COUNT,
+      };
+      if (ttsSequence !== undefined) {
+        ttsStartMessage.sequence = ttsSequence;
+      }
+      connection.send(encodeServerToDeviceMessage(ttsStartMessage));
+
       const getPlaybackAckForSequence = dependencies.getPlaybackAckForSequence;
+      const playbackPacingOptions: PlaybackPacingOptions = {};
+      if (!isFirstSegment) {
+        // Follow-up segments land on a device that is still draining the
+        // previous one, so the full 2 s burst would risk the same queue
+        // overflow the pacing exists to avoid; a small allowance only
+        // covers network jitter.
+        playbackPacingOptions.prebufferMilliseconds = 500;
+      }
+      if (dependencies.isSpeechAborted !== undefined) {
+        playbackPacingOptions.shouldStop = dependencies.isSpeechAborted;
+      }
+      if (ttsSequence !== undefined && getPlaybackAckForSequence !== undefined) {
+        playbackPacingOptions.getPlaybackAck = () =>
+          getPlaybackAckForSequence(ttsSequence);
+      }
       await streamAudioChunksAtPlaybackPace({
         audioBuffer: currentAudioBuffer,
         sampleRateHz: TTS_PCM_SAMPLE_RATE_HZ,
@@ -292,17 +336,7 @@ export async function executeApolloTurn(
         send: (audioChunk) => {
           connection.send(audioChunk);
         },
-        // Follow-up segments land on a device that is still draining the
-        // previous one, so the full 2 s burst would risk the same queue
-        // overflow the pacing exists to avoid; a small allowance only
-        // covers network jitter.
-        ...(isFirstSegment ? {} : { prebufferMilliseconds: 500 }),
-        ...(dependencies.isSpeechAborted !== undefined
-          ? { shouldStop: dependencies.isSpeechAborted }
-          : {}),
-        ...(ttsSequence !== undefined && getPlaybackAckForSequence !== undefined
-          ? { getPlaybackAck: () => getPlaybackAckForSequence(ttsSequence) }
-          : {}),
+        ...playbackPacingOptions,
       });
 
       if (dependencies.isSpeechAborted?.() === true) {
@@ -350,6 +384,13 @@ export async function executeApolloTurn(
       createdAt: new Date(),
     });
   }
+}
+
+function encodeMockSpeechAudio(spokenText: string): ArrayBuffer {
+  const encodedSpokenTextBytes = new TextEncoder().encode(spokenText);
+  const mockSpeechAudioBuffer = new ArrayBuffer(encodedSpokenTextBytes.byteLength);
+  new Uint8Array(mockSpeechAudioBuffer).set(encodedSpokenTextBytes);
+  return mockSpeechAudioBuffer;
 }
 
 export function concatenateArrayBufferList(

--- a/apps/agent/src/auth/__tests__/token.spec.ts
+++ b/apps/agent/src/auth/__tests__/token.spec.ts
@@ -16,8 +16,6 @@ describe('device token', () => {
 
   it('rejects instead of throwing when the worker secret is unset', async () => {
     await expect(isDeviceSharedSecretValid('abc', '')).resolves.toBe(false);
-    await expect(
-      isDeviceSharedSecretValid('abc', undefined as unknown as string),
-    ).resolves.toBe(false);
+    await expect(isDeviceSharedSecretValid('abc', undefined)).resolves.toBe(false);
   });
 });

--- a/apps/agent/src/auth/token.ts
+++ b/apps/agent/src/auth/token.ts
@@ -20,11 +20,12 @@ function areByteArraysEqualTimingSafe(
 
 export async function isDeviceSharedSecretValid(
   presentedSecret: string | null,
-  expectedSecret: string,
+  // The generated Env type claims the Worker secret is always a string, but an
+  // unset secret arrives as undefined at runtime: accept that honestly and
+  // reject the connection instead of throwing a 500.
+  expectedSecret: string | undefined,
 ): Promise<boolean> {
-  // `expectedSecret` is typed as a string, but an unset Worker secret arrives
-  // as undefined at runtime: reject the connection instead of throwing a 500.
-  if (typeof expectedSecret !== 'string' || expectedSecret.length === 0) {
+  if (expectedSecret === undefined || expectedSecret.length === 0) {
     return false;
   }
   if (presentedSecret === null) {

--- a/apps/agent/src/coding/__tests__/agent.spec.ts
+++ b/apps/agent/src/coding/__tests__/agent.spec.ts
@@ -13,11 +13,15 @@ type RecordedSandboxCall = {
   readonly content?: string;
 };
 
-function createFakeSandbox(fileContentByPath: Record<string, string> = {}): {
+type FakeCodingSandboxHarness = {
   readonly sandbox: CodingSandboxPort;
   readonly callList: RecordedSandboxCall[];
   readonly writtenFileByPath: Record<string, string>;
-} {
+};
+
+function createFakeSandbox(
+  fileContentByPath: Record<string, string> = {},
+): FakeCodingSandboxHarness {
   const callList: RecordedSandboxCall[] = [];
   const writtenFileByPath: Record<string, string> = {};
   return {
@@ -44,10 +48,14 @@ function createFakeSandbox(fileContentByPath: Record<string, string> = {}): {
   };
 }
 
-function createScriptedLlm(resultList: readonly OpenRouterChatResult[]): {
+type ScriptedLlmHarness = {
   readonly callLlm: CodingLlmCaller;
   readonly roundCount: () => number;
-} {
+};
+
+function createScriptedLlm(
+  resultList: readonly OpenRouterChatResult[],
+): ScriptedLlmHarness {
   let callIndex = 0;
   return {
     roundCount: () => callIndex,

--- a/apps/agent/src/coding/__tests__/opencode.spec.ts
+++ b/apps/agent/src/coding/__tests__/opencode.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import {
   buildOpencodeConfig,
@@ -9,30 +10,29 @@ import {
 } from '@/coding/opencode';
 import type { SandboxLike } from '@/coding/run';
 
+type RecordedExecutionOptions = {
+  readonly cwd?: string;
+  readonly env?: Record<string, string>;
+  readonly timeout?: number;
+};
+
+type RecordedExecutionCall = {
+  readonly command: string;
+  readonly options?: RecordedExecutionOptions;
+};
+
+type FakeOpencodeSandboxHarness = {
+  readonly sandbox: SandboxLike;
+  readonly writtenFileByPath: Record<string, string>;
+  readonly execCallList: RecordedExecutionCall[];
+};
+
 function createFakeSandbox(input: {
   readonly execResult?: { stdout: string; stderr: string; exitCode: number };
   readonly summaryContent?: string;
-}): {
-  readonly sandbox: SandboxLike;
-  readonly writtenFileByPath: Record<string, string>;
-  readonly execCallList: {
-    readonly command: string;
-    readonly options?: {
-      readonly cwd?: string;
-      readonly env?: Record<string, string>;
-      readonly timeout?: number;
-    };
-  }[];
-} {
+}): FakeOpencodeSandboxHarness {
   const writtenFileByPath: Record<string, string> = {};
-  const execCallList: {
-    command: string;
-    options?: {
-      readonly cwd?: string;
-      readonly env?: Record<string, string>;
-      readonly timeout?: number;
-    };
-  }[] = [];
+  const execCallList: RecordedExecutionCall[] = [];
   return {
     writtenFileByPath,
     execCallList,
@@ -55,13 +55,15 @@ function createFakeSandbox(input: {
   };
 }
 
+const opencodeConfigModelSchema = z.object({ model: z.string() });
+
 describe('buildOpencodeConfig', () => {
   it('points the provider at the worker proxy with the token as env reference', () => {
     const configText = buildOpencodeConfig({
       proxyOrigin: 'https://apollo.example',
       modelId: 'moonshotai/kimi-k3',
     });
-    const config = JSON.parse(configText) as Record<string, unknown>;
+    const config = opencodeConfigModelSchema.parse(JSON.parse(configText));
 
     expect(configText).toContain('https://apollo.example/coding-llm/v1');
     expect(configText).toContain('{env:APOLLO_LLM_TOKEN}');

--- a/apps/agent/src/coding/__tests__/proxy.spec.ts
+++ b/apps/agent/src/coding/__tests__/proxy.spec.ts
@@ -64,8 +64,15 @@ describe('coding proxy tokens', () => {
   });
 });
 
+type ProxiedChatCompletionRequestBody = {
+  readonly model?: string;
+  readonly messages: readonly { readonly role: string; readonly content: string }[];
+};
+
 describe('handleCodingLlmProxyRequest', () => {
-  async function buildAuthorizedRequest(bodyObject: unknown): Promise<Request> {
+  async function buildAuthorizedRequest(
+    requestBody: ProxiedChatCompletionRequestBody,
+  ): Promise<Request> {
     const token = await mintCodingProxyToken({
       instanceId: 'wf-1',
       openRouterApiKey: OPENROUTER_API_KEY,
@@ -74,7 +81,7 @@ describe('handleCodingLlmProxyRequest', () => {
     return new Request('https://apollo.example/coding-llm/v1/chat/completions', {
       method: 'POST',
       headers: { authorization: `Bearer ${token}` },
-      body: JSON.stringify(bodyObject),
+      body: JSON.stringify(requestBody),
     });
   }
 
@@ -86,12 +93,15 @@ describe('handleCodingLlmProxyRequest', () => {
     let forwardedUrl = '';
     let forwardedAuthorization = '';
     let forwardedBody = '';
-    const fakeFetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
-      forwardedUrl = String(url);
-      forwardedAuthorization = new Headers(init?.headers).get('authorization') ?? '';
-      forwardedBody = String(init?.body);
-      return new Response('{"ok":true}');
-    }) as typeof fetch;
+    const fakeFetch: typeof fetch = Object.assign(
+      async (url: RequestInfo | URL, init?: RequestInit) => {
+        forwardedUrl = String(url);
+        forwardedAuthorization = new Headers(init?.headers).get('authorization') ?? '';
+        forwardedBody = String(init?.body);
+        return new Response('{"ok":true}');
+      },
+      { preconnect: () => {} },
+    );
 
     const request = await buildAuthorizedRequest({
       model: 'moonshotai/kimi-k3',

--- a/apps/agent/src/coding/__tests__/run.spec.ts
+++ b/apps/agent/src/coding/__tests__/run.spec.ts
@@ -11,14 +11,20 @@ import {
 import { parseGithubRepositoryReference } from '@/github/repository';
 
 type RecordedExec = {
-  readonly command: string;
-  readonly cwd?: string;
-  readonly env?: Record<string, string>;
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
 };
 
 type RecordedWrite = {
   readonly path: string;
   readonly content: string;
+};
+
+type FakeSandboxHarness = {
+  readonly sandbox: SandboxLike;
+  readonly execList: RecordedExec[];
+  readonly writeList: RecordedWrite[];
 };
 
 function createFakeSandbox(
@@ -27,11 +33,7 @@ function createFakeSandbox(
     readonly result: { stdout: string; stderr: string; exitCode: number };
   }[] = [],
   fileContentByPath: Readonly<Record<string, string>> = {},
-): {
-  readonly sandbox: SandboxLike;
-  readonly execList: RecordedExec[];
-  readonly writeList: RecordedWrite[];
-} {
+): FakeSandboxHarness {
   const execList: RecordedExec[] = [];
   const writeList: RecordedWrite[] = [];
   return {
@@ -39,11 +41,14 @@ function createFakeSandbox(
     writeList,
     sandbox: {
       exec: async (command, options) => {
-        execList.push({
-          command,
-          ...(options?.cwd !== undefined ? { cwd: options.cwd } : {}),
-          ...(options?.env !== undefined ? { env: options.env } : {}),
-        });
+        const recordedExec: RecordedExec = { command };
+        if (options?.cwd !== undefined) {
+          recordedExec.cwd = options.cwd;
+        }
+        if (options?.env !== undefined) {
+          recordedExec.env = options.env;
+        }
+        execList.push(recordedExec);
         const matched = execResultByFragment.find((candidate) =>
           command.includes(candidate.fragment),
         );
@@ -95,16 +100,21 @@ describe('prepareCodingWorkspace', () => {
       },
     ]);
 
-    const failure = await prepareCodingWorkspace({
-      sandbox,
-      repository: apolloRepository,
-      baseBranch: 'main',
-      installationToken: 'ghs_secrettoken',
-    }).catch((error: unknown) => error);
+    let caughtFailure: unknown;
+    try {
+      await prepareCodingWorkspace({
+        sandbox,
+        repository: apolloRepository,
+        baseBranch: 'main',
+        installationToken: 'ghs_secrettoken',
+      });
+    } catch (error) {
+      caughtFailure = error;
+    }
 
-    expect(failure).toBeInstanceOf(Error);
-    expect(String(failure)).not.toContain('ghs_secrettoken');
-    expect(String(failure)).toContain('***');
+    expect(caughtFailure).toBeInstanceOf(Error);
+    expect(String(caughtFailure)).not.toContain('ghs_secrettoken');
+    expect(String(caughtFailure)).toContain('***');
   });
 });
 

--- a/apps/agent/src/coding/agent.ts
+++ b/apps/agent/src/coding/agent.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import { CODING_WORKSPACE_PATH } from '@/coding/git';
 import { resolveWorkspaceFilePath } from '@/coding/workspace';
 import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
-import type { OpenRouterChatMessage, OpenRouterChatResult } from '@/voice/llm';
+import type {
+  OpenRouterChatMessage,
+  OpenRouterChatResult,
+  OpenRouterToolCall,
+} from '@/voice/llm';
 
 export const DEFAULT_CODING_ROUND_LIMIT = 24;
 // Two rounds with identical calls and identical results get the model a
@@ -29,13 +33,26 @@ export type CodingSandboxPort = {
   }>;
 };
 
+export type CodingToolParameterFieldSchema = {
+  readonly type: 'string';
+};
+
+export type CodingToolParameterSchema = {
+  readonly type: 'object';
+  readonly properties: Readonly<Record<string, CodingToolParameterFieldSchema>>;
+  readonly required?: readonly string[];
+  readonly additionalProperties: false;
+};
+
+export type CodingToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: CodingToolParameterSchema;
+};
+
 export type CodingLlmCaller = (input: {
   readonly messageList: readonly OpenRouterChatMessage[];
-  readonly toolDefinitionList: readonly {
-    readonly name: string;
-    readonly description: string;
-    readonly parameters: Record<string, unknown>;
-  }[];
+  readonly toolDefinitionList: readonly CodingToolDefinition[];
 }) => Promise<OpenRouterChatResult>;
 
 export type CodingAgentOutcome = {
@@ -52,12 +69,6 @@ const writeFileArgsSchema = z.object({
   content: z.string(),
 });
 const runCommandArgsSchema = z.object({ command: z.string().min(1).max(2000) });
-
-type CodingToolDefinition = {
-  readonly name: string;
-  readonly description: string;
-  readonly parameters: Record<string, unknown>;
-};
 
 const codingToolDefinitionList: readonly CodingToolDefinition[] = [
   {
@@ -127,17 +138,14 @@ export function buildCodingSystemPrompt(input: {
 
 // The transcript is persisted to R2 and emailed, so a write_file call records
 // what changed rather than the whole file it wrote.
-export function summarizeToolCallForTranscript(
-  toolName: string,
-  toolArgs: unknown,
-): string {
-  if (toolName === 'write_file') {
-    const parsedArgs = writeFileArgsSchema.safeParse(toolArgs);
+export function summarizeToolCallForTranscript(toolCall: OpenRouterToolCall): string {
+  if (toolCall.name === 'write_file') {
+    const parsedArgs = writeFileArgsSchema.safeParse(toolCall.args);
     if (parsedArgs.success) {
       return `write_file ${parsedArgs.data.path} (${parsedArgs.data.content.length} caracteres)`;
     }
   }
-  return `${toolName} ${JSON.stringify(toolArgs)}`;
+  return `${toolCall.name} ${JSON.stringify(toolCall.args)}`;
 }
 
 async function executeCodingTool(input: {
@@ -294,7 +302,7 @@ export async function runCodingAgent(input: {
 
     const toolOutputList: string[] = [];
     for (const toolCall of llmResult.toolCallList) {
-      transcript.push(summarizeToolCallForTranscript(toolCall.name, toolCall.args));
+      transcript.push(summarizeToolCallForTranscript(toolCall));
       let toolOutput: string;
       try {
         toolOutput = await executeCodingTool({

--- a/apps/agent/src/coding/run.ts
+++ b/apps/agent/src/coding/run.ts
@@ -54,19 +54,28 @@ export function buildAgentSandboxPort(sandbox: SandboxLike): CodingSandboxPort {
   };
 }
 
+type GitCommandExecutionOptions = {
+  cwd?: string;
+  env?: Record<string, string>;
+  timeout: number;
+};
+
 async function runGitCommand(input: {
   readonly sandbox: SandboxLike;
   readonly command: string;
   readonly installationToken?: string;
   readonly cwd?: string;
 }): Promise<SandboxExecResult> {
-  const result = await input.sandbox.exec(input.command, {
-    ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
-    ...(input.installationToken !== undefined
-      ? { env: { [CODING_TOKEN_ENVIRONMENT_NAME]: input.installationToken } }
-      : {}),
+  const executionOptions: GitCommandExecutionOptions = {
     timeout: GIT_COMMAND_TIMEOUT_MILLISECONDS,
-  });
+  };
+  if (input.cwd !== undefined) {
+    executionOptions.cwd = input.cwd;
+  }
+  if (input.installationToken !== undefined) {
+    executionOptions.env = { [CODING_TOKEN_ENVIRONMENT_NAME]: input.installationToken };
+  }
+  const result = await input.sandbox.exec(input.command, executionOptions);
   if (result.exitCode !== 0) {
     const failureText = redactSecretsFromText(
       `${result.stderr}\n${result.stdout}`.trim(),

--- a/apps/agent/src/configuration/testing.ts
+++ b/apps/agent/src/configuration/testing.ts
@@ -1,13 +1,26 @@
 import type { MemorySqlExecutor } from '@/memory/store';
 import type { DeskToolEffects } from '@/tools/types';
 
+type PendingConfirmationRow = {
+  readonly id: string;
+  readonly tool_name: string;
+  readonly args_json: string;
+  readonly summary: string;
+  readonly expires_at: number;
+};
+
+type McpToolSettingRow = {
+  readonly namespaced_name: string;
+  readonly server_id: string;
+  readonly tool_name: string;
+  readonly is_enabled: number;
+  readonly safety: string;
+};
+
 export function createInMemoryPendingConfirmationSqlExecutor(): MemorySqlExecutor {
-  let rowList: readonly Record<string, unknown>[] = [];
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
+  let rowList: readonly PendingConfirmationRow[] = [];
+  const fakeExecutor = {
+    execute(query: string, ...bindValues: unknown[]): readonly PendingConfirmationRow[] {
       if (query.startsWith('DELETE FROM pending_confirmations')) {
         rowList = [];
         return [];
@@ -26,22 +39,22 @@ export function createInMemoryPendingConfirmationSqlExecutor(): MemorySqlExecuto
         return [];
       }
       if (query.includes('FROM pending_confirmations')) {
-        return rowList.slice(0, 1) as readonly Row[];
+        return rowList.slice(0, 1);
       }
       return [];
     },
   };
+  // SAFETY: the fake only ever serves pending_confirmations columns, which is
+  // exactly the Row shape every query against this table selects.
+  return fakeExecutor as MemorySqlExecutor;
 }
 
 export function createInMemoryMcpToolSettingsSqlExecutor(
-  initialRowList: readonly Record<string, unknown>[] = [],
+  initialRowList: readonly McpToolSettingRow[] = [],
 ): MemorySqlExecutor {
-  let rowList: readonly Record<string, unknown>[] = [...initialRowList];
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
+  let rowList: readonly McpToolSettingRow[] = [...initialRowList];
+  const fakeExecutor = {
+    execute(query: string, ...bindValues: unknown[]): readonly McpToolSettingRow[] {
       if (query.startsWith('DELETE FROM mcp_tool_settings')) {
         const removedServerId = String(bindValues[0]);
         rowList = rowList.filter((row) => row.server_id !== removedServerId);
@@ -62,11 +75,14 @@ export function createInMemoryMcpToolSettingsSqlExecutor(
         return [];
       }
       if (query.includes('FROM mcp_tool_settings')) {
-        return rowList as readonly Row[];
+        return rowList;
       }
       return [];
     },
   };
+  // SAFETY: the fake only ever serves mcp_tool_settings columns, which is
+  // exactly the Row shape every query against this table selects.
+  return fakeExecutor as MemorySqlExecutor;
 }
 
 export function createFakeMediaBucket(
@@ -75,7 +91,7 @@ export function createFakeMediaBucket(
   const storedObjectMap = new Map<string, Uint8Array>(
     Object.entries(initialObjectMap).map(([objectKey, content]) => [
       objectKey,
-      typeof content === 'string' ? new TextEncoder().encode(content) : content,
+      content instanceof Uint8Array ? content : new TextEncoder().encode(content),
     ]),
   );
   const partialBucket = {
@@ -98,19 +114,24 @@ export function createFakeMediaBucket(
           return storedText;
         },
         async json() {
-          return JSON.parse(storedText) as unknown;
+          const parsedJson: unknown = JSON.parse(storedText);
+          return parsedJson;
         },
       };
     },
     async put(objectKey: string, content: string | ArrayBuffer | Uint8Array) {
       const contentBytes =
-        typeof content === 'string'
-          ? new TextEncoder().encode(content)
-          : new Uint8Array(content instanceof ArrayBuffer ? content : content);
+        content instanceof Uint8Array
+          ? new Uint8Array(content)
+          : content instanceof ArrayBuffer
+            ? new Uint8Array(content)
+            : new TextEncoder().encode(content);
       storedObjectMap.set(objectKey, contentBytes);
       return null;
     },
   };
+  // SAFETY: specs exercise only get and put on the media bucket; no other
+  // R2Bucket member is ever read through this fake.
   return partialBucket as Env['MEDIA'];
 }
 
@@ -142,6 +163,9 @@ export async function buildTestRsaPrivateKeyPem(): Promise<string> {
 }
 
 export function createFakeApolloEnvironment(overrides: Partial<Env> = {}): Env {
+  // SAFETY: specs read only the vars, secrets, and owner email above the
+  // binding stubs; the empty binding objects exist to satisfy Env's shape and
+  // are never invoked unless a test overrides them with a working fake.
   return {
     OPENROUTER_MODEL: 'deepseek/deepseek-v4-flash-0731',
     OPENROUTER_STT_MODEL: 'openai/whisper-large-v3',

--- a/apps/agent/src/console/__tests__/jobs.spec.ts
+++ b/apps/agent/src/console/__tests__/jobs.spec.ts
@@ -23,12 +23,11 @@ function createFakeDocumentBucket(
       const startIndex = cursor === undefined ? 0 : Number(cursor);
       const endIndex =
         pageSize === undefined ? matchingObjectList.length : startIndex + pageSize;
-      const isTruncated = endIndex < matchingObjectList.length;
-      return {
-        objects: matchingObjectList.slice(startIndex, endIndex),
-        truncated: isTruncated,
-        ...(isTruncated ? { cursor: String(endIndex) } : {}),
-      };
+      const pageObjectList = matchingObjectList.slice(startIndex, endIndex);
+      if (endIndex < matchingObjectList.length) {
+        return { objects: pageObjectList, truncated: true, cursor: String(endIndex) };
+      }
+      return { objects: pageObjectList, truncated: false };
     },
     async get(key) {
       const object = objectMap[key];

--- a/apps/agent/src/console/__tests__/memory.spec.ts
+++ b/apps/agent/src/console/__tests__/memory.spec.ts
@@ -2,56 +2,78 @@ import { describe, expect, it } from 'bun:test';
 
 import { browseConsoleMemory, deleteConsoleMemory } from '@/console/memory';
 import { addMemoryRecord, setSessionPreference } from '@/memory/store';
-import type { MemorySqlExecutor } from '@/memory/store';
+import type { MemorySqlExecutor, MemorySqlRow } from '@/memory/store';
+
+type StoredMemoryRow = {
+  readonly id: string;
+  readonly content: string;
+  readonly created_at: number;
+};
+
+type StoredPreferenceRow = {
+  readonly value: string;
+};
 
 function createInMemoryConsoleSqlExecutor(): MemorySqlExecutor {
-  const memoryRowList: Array<{ id: string; content: string; created_at: number }> = [];
+  const memoryRowList: StoredMemoryRow[] = [];
   const preferenceMap = new Map<string, string>();
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
-      if (query.startsWith('INSERT INTO memories')) {
-        memoryRowList.push({
-          id: String(bindValues[0]),
-          content: String(bindValues[1]),
-          created_at: Number(bindValues[2]),
-        });
-        return [];
+  function executeConsoleQuery<Row extends MemorySqlRow>(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly Row[] {
+    if (query.startsWith('INSERT INTO memories')) {
+      memoryRowList.push({
+        id: String(bindValues[0]),
+        content: String(bindValues[1]),
+        created_at: Number(bindValues[2]),
+      });
+      return [];
+    }
+    if (query.startsWith('DELETE FROM memories')) {
+      const targetId = String(bindValues[0]);
+      const targetIndex = memoryRowList.findIndex((row) => row.id === targetId);
+      if (targetIndex >= 0) {
+        memoryRowList.splice(targetIndex, 1);
       }
-      if (query.startsWith('DELETE FROM memories')) {
-        const targetId = String(bindValues[0]);
-        const targetIndex = memoryRowList.findIndex((row) => row.id === targetId);
-        if (targetIndex >= 0) {
-          memoryRowList.splice(targetIndex, 1);
-        }
-        return [];
-      }
-      if (query.startsWith('INSERT INTO session_prefs')) {
-        preferenceMap.set(String(bindValues[0]), String(bindValues[1]));
-        return [];
-      }
-      if (query.startsWith('SELECT value FROM session_prefs')) {
-        const storedValue = preferenceMap.get(String(bindValues[0]));
-        return (storedValue === undefined
+      return [];
+    }
+    if (query.startsWith('INSERT INTO session_prefs')) {
+      preferenceMap.set(String(bindValues[0]), String(bindValues[1]));
+      return [];
+    }
+    if (query.startsWith('SELECT value FROM session_prefs')) {
+      const storedValue = preferenceMap.get(String(bindValues[0]));
+      const preferenceRowList: readonly MemorySqlRow[] =
+        storedValue === undefined
           ? []
-          : [{ value: storedValue }]) as unknown as readonly Row[];
-      }
-      if (query.includes('WHERE content LIKE')) {
-        const likePattern = String(bindValues[0]).replaceAll('%', '').toLowerCase();
-        const limit = Number(bindValues[1]);
-        return memoryRowList
-          .filter((row) => row.content.toLowerCase().includes(likePattern))
-          .toSorted((left, right) => right.created_at - left.created_at)
-          .slice(0, limit) as unknown as readonly Row[];
-      }
-      const limit = Number(bindValues[0]);
-      return memoryRowList
+          : [{ value: storedValue } satisfies StoredPreferenceRow];
+      // SAFETY: the session_prefs SELECT is only issued by getSessionPreference,
+      // which requests rows shaped StoredPreferenceRow — exactly what this
+      // branch returns.
+      return preferenceRowList as readonly Row[];
+    }
+    if (query.includes('WHERE content LIKE')) {
+      const likePattern = String(bindValues[0]).replaceAll('%', '').toLowerCase();
+      const limit = Number(bindValues[1]);
+      const matchingRowList: readonly MemorySqlRow[] = memoryRowList
+        .filter((row) => row.content.toLowerCase().includes(likePattern))
         .toSorted((left, right) => right.created_at - left.created_at)
-        .slice(0, limit) as unknown as readonly Row[];
-    },
-  };
+        .slice(0, limit);
+      // SAFETY: the LIKE recall query is only issued by recallMemoryRecords,
+      // which requests rows shaped StoredMemoryRow — exactly what this branch
+      // returns.
+      return matchingRowList as readonly Row[];
+    }
+    const limit = Number(bindValues[0]);
+    const recentRowList: readonly MemorySqlRow[] = memoryRowList
+      .toSorted((left, right) => right.created_at - left.created_at)
+      .slice(0, limit);
+    // SAFETY: the remaining query is the recent-memories listing issued by
+    // listRecentMemoryRecords, which requests rows shaped StoredMemoryRow —
+    // exactly what this branch returns.
+    return recentRowList as readonly Row[];
+  }
+  return { execute: executeConsoleQuery };
 }
 
 describe('console memory browse', () => {
@@ -115,7 +137,12 @@ describe('console memory browse', () => {
 
     await deleteConsoleMemory(
       sqlExecutor,
-      { deleteByIds: async (idList) => deletedVectorIdList.push(...idList) },
+      {
+        deleteByIds: async (idList) => {
+          deletedVectorIdList.push(...idList);
+          return { ids: idList, count: idList.length };
+        },
+      },
       addedRecord.id,
     );
 

--- a/apps/agent/src/console/history.ts
+++ b/apps/agent/src/console/history.ts
@@ -15,6 +15,8 @@ export type ConsoleThreadSummary = {
   readonly lastTurnAtIso: string | null;
 };
 
+type SessionMessageTimestamp = Date | string;
+
 type SessionMessageLike = {
   readonly id: string;
   readonly role: string;
@@ -23,7 +25,7 @@ type SessionMessageLike = {
     readonly text?: string;
     readonly toolName?: string;
   }[];
-  readonly createdAt?: unknown;
+  readonly createdAt?: SessionMessageTimestamp;
 };
 
 type SessionInfoLike = {
@@ -38,12 +40,14 @@ type ThreadMetaLike = {
   readonly lastTurnAtMilliseconds: number;
 };
 
-function normalizeMessageCreatedAt(rawCreatedAt: unknown): string | null {
-  if (rawCreatedAt instanceof Date) {
-    return rawCreatedAt.toISOString();
+function normalizeMessageCreatedAt(
+  createdAtValue: SessionMessageTimestamp | undefined,
+): string | null {
+  if (createdAtValue instanceof Date) {
+    return createdAtValue.toISOString();
   }
-  if (typeof rawCreatedAt === 'string' && rawCreatedAt.length > 0) {
-    return rawCreatedAt;
+  if (createdAtValue !== undefined && createdAtValue.length > 0) {
+    return createdAtValue;
   }
   return null;
 }
@@ -54,12 +58,12 @@ export function mapSessionMessagesToConsoleHistory(
   const turnList: ConsoleHistoryTurn[] = [];
   for (const message of messageList) {
     const text = message.parts
-      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .filter((part) => part.type === 'text' && part.text !== undefined)
       .map((part) => part.text)
       .join('\n')
       .trim();
     const toolNameList = message.parts
-      .filter((part) => part.type === 'tool-call' && typeof part.toolName === 'string')
+      .filter((part) => part.type === 'tool-call' && part.toolName !== undefined)
       .map((part) => part.toolName)
       .filter((toolName): toolName is string => toolName !== undefined);
     if (text.length === 0 && toolNameList.length === 0) {

--- a/apps/agent/src/console/jobs.ts
+++ b/apps/agent/src/console/jobs.ts
@@ -15,12 +15,14 @@ type BucketListingLike = {
   readonly cursor?: string;
 };
 
+type BucketListingOptions = {
+  prefix: string;
+  limit?: number;
+  cursor?: string;
+};
+
 export type ConsoleDocumentBucket = {
-  list(options: {
-    prefix: string;
-    limit?: number;
-    cursor?: string;
-  }): Promise<BucketListingLike>;
+  list(options: BucketListingOptions): Promise<BucketListingLike>;
   get(key: string): Promise<{ text(): Promise<string> } | null>;
 };
 
@@ -37,11 +39,14 @@ export async function listConsoleJobDocuments(
     let cursor: string | undefined;
     let collectedCount = 0;
     do {
-      const listing = await bucket.list({
+      const listingOptions: BucketListingOptions = {
         prefix: `${kind}/${deviceId}/`,
         limit: JOB_LISTING_PAGE_SIZE,
-        ...(cursor === undefined ? {} : { cursor }),
-      });
+      };
+      if (cursor !== undefined) {
+        listingOptions.cursor = cursor;
+      }
+      const listing = await bucket.list(listingOptions);
       for (const object of listing.objects) {
         documentList.push({
           documentKey: object.key,

--- a/apps/agent/src/console/memory.ts
+++ b/apps/agent/src/console/memory.ts
@@ -17,7 +17,7 @@ export type ConsoleMemoryBrowseResult = {
 };
 
 type MemoryVectorIndexLike = {
-  deleteByIds(idList: string[]): Promise<unknown>;
+  deleteByIds(idList: string[]): Promise<VectorizeVectorMutation>;
 };
 
 // The Vectorize entry shares the memory record's UUID, so both stores are

--- a/apps/agent/src/github/__tests__/api.spec.ts
+++ b/apps/agent/src/github/__tests__/api.spec.ts
@@ -18,7 +18,7 @@ function createFetchMock(
     readonly status: number;
     readonly body: unknown;
   }[],
-): { readonly fetchImplementation: typeof fetch; readonly callList: CapturedRequest[] } {
+) {
   const callList: CapturedRequest[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -34,12 +34,13 @@ function createFetchMock(
     }
     return new Response(JSON.stringify(matched.body), { status: matched.status });
   };
-  return {
-    fetchImplementation: Object.assign(fetchHandler, {
-      preconnect: () => {},
-    }) as typeof fetch,
-    callList,
-  };
+  // SAFETY: the code under test only invokes fetch's call signature and never
+  // touches other members, so the handler plus a preconnect stub covers the
+  // whole surface this suite exercises.
+  const fetchImplementation = Object.assign(fetchHandler, {
+    preconnect: () => {},
+  }) as typeof fetch;
+  return { fetchImplementation, callList };
 }
 
 const apolloRepository = parseGithubRepositoryReference('galfrevn/apollo');

--- a/apps/agent/src/github/__tests__/app.spec.ts
+++ b/apps/agent/src/github/__tests__/app.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import { buildTestRsaPrivateKeyPem } from '@/configuration/testing';
 import {
@@ -14,10 +15,20 @@ type CapturedRequest = {
   readonly init: RequestInit;
 };
 
-function decodeBase64UrlJson(segment: string): Record<string, unknown> {
+const jsonWebTokenSegmentSchema = z
+  .object({
+    alg: z.string(),
+    typ: z.string(),
+    iss: z.string(),
+    iat: z.number(),
+    exp: z.number(),
+  })
+  .partial();
+
+function decodeBase64UrlJson(segment: string): z.infer<typeof jsonWebTokenSegmentSchema> {
   const base64Text = segment.replaceAll('-', '+').replaceAll('_', '/');
   const padded = base64Text.padEnd(Math.ceil(base64Text.length / 4) * 4, '=');
-  return JSON.parse(atob(padded)) as Record<string, unknown>;
+  return jsonWebTokenSegmentSchema.parse(JSON.parse(atob(padded)));
 }
 
 function createFetchMock(
@@ -26,7 +37,7 @@ function createFetchMock(
     readonly status: number;
     readonly body: unknown;
   }[],
-): { readonly fetchImplementation: typeof fetch; readonly callList: CapturedRequest[] } {
+) {
   const callList: CapturedRequest[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -44,12 +55,13 @@ function createFetchMock(
     }
     return new Response(JSON.stringify(matched.body), { status: matched.status });
   };
-  return {
-    fetchImplementation: Object.assign(fetchHandler, {
-      preconnect: () => {},
-    }) as typeof fetch,
-    callList,
-  };
+  // SAFETY: the code under test only invokes fetch's call signature and never
+  // touches other members, so the handler plus a preconnect stub covers the
+  // whole surface this suite exercises.
+  const fetchImplementation = Object.assign(fetchHandler, {
+    preconnect: () => {},
+  }) as typeof fetch;
+  return { fetchImplementation, callList };
 }
 
 describe('signGithubAppJsonWebToken', () => {

--- a/apps/agent/src/github/app.ts
+++ b/apps/agent/src/github/app.ts
@@ -200,9 +200,7 @@ export async function listGithubAppRepositoryFullNameList(input: {
     const installationToken = await createGithubInstallationToken({
       installationId: installation.id,
       appJsonWebToken,
-      ...(input.fetchImplementation !== undefined
-        ? { fetchImplementation: input.fetchImplementation }
-        : {}),
+      fetchImplementation,
     });
     for (let pageNumber = 1; ; pageNumber += 1) {
       const repositoriesResponse = await fetchImplementation(
@@ -238,6 +236,7 @@ export async function createGithubInstallationTokenForRepository(input: {
   if (input.appId.length === 0 || input.privateKeyPem.length === 0) {
     throw new Error('Faltan GITHUB_APP_ID o GITHUB_APP_PRIVATE_KEY');
   }
+  const fetchImplementation = input.fetchImplementation ?? globalThis.fetch;
   const appJsonWebToken = await signGithubAppJsonWebToken({
     appId: input.appId,
     privateKeyPem: input.privateKeyPem,
@@ -246,15 +245,11 @@ export async function createGithubInstallationTokenForRepository(input: {
   const installationId = await resolveGithubInstallationId({
     repository: input.repository,
     appJsonWebToken,
-    ...(input.fetchImplementation !== undefined
-      ? { fetchImplementation: input.fetchImplementation }
-      : {}),
+    fetchImplementation,
   });
   return createGithubInstallationToken({
     installationId,
     appJsonWebToken,
-    ...(input.fetchImplementation !== undefined
-      ? { fetchImplementation: input.fetchImplementation }
-      : {}),
+    fetchImplementation,
   });
 }

--- a/apps/agent/src/lists/__tests__/store.spec.ts
+++ b/apps/agent/src/lists/__tests__/store.spec.ts
@@ -8,18 +8,17 @@ import {
 } from '@/lists/store';
 import type { MemorySqlExecutor } from '@/memory/store';
 
+type ListItemRow = {
+  id: string;
+  list_name: string;
+  content: string;
+  created_at: number;
+};
+
 function createInMemoryListSqlExecutor(): MemorySqlExecutor {
-  const rowList: Array<{
-    id: string;
-    list_name: string;
-    content: string;
-    created_at: number;
-  }> = [];
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
+  const rowList: ListItemRow[] = [];
+  const inMemoryExecutor = {
+    execute(query: string, ...bindValues: unknown[]): readonly ListItemRow[] {
       if (query.startsWith('INSERT INTO list_items')) {
         rowList.push({
           id: String(bindValues[0]),
@@ -43,17 +42,19 @@ function createInMemoryListSqlExecutor(): MemorySqlExecutor {
         return rowList.filter(
           (row) =>
             row.list_name === listName && row.content.toLowerCase().includes(likePattern),
-        ) as unknown as readonly Row[];
+        );
       }
       if (query.includes('WHERE list_name = ?')) {
         const listName = String(bindValues[0]);
-        return rowList.filter(
-          (row) => row.list_name === listName,
-        ) as unknown as readonly Row[];
+        return rowList.filter((row) => row.list_name === listName);
       }
-      return [...rowList] as unknown as readonly Row[];
+      return [...rowList];
     },
   };
+  // SAFETY: the double stores full list_items rows and every branch returns
+  // them unchanged, so the Row type each store function requests always
+  // describes the rows it receives.
+  return inMemoryExecutor as MemorySqlExecutor;
 }
 
 describe('list store', () => {
@@ -115,10 +116,16 @@ describe('list store', () => {
     await addListItemRecord(sqlExecutor, { listName: 'super', content: 'yerba' }, 1);
     await addListItemRecord(sqlExecutor, { listName: 'super', content: 'pan' }, 2);
 
-    for (const contentQuery of [undefined, '', '   ']) {
+    const omittedQueryRemoval = await removeListItemRecords(sqlExecutor, {
+      listName: 'super',
+      clearAll: false,
+    });
+    expect(omittedQueryRemoval.removedCount).toBe(0);
+
+    for (const blankContentQuery of ['', '   ']) {
       const removal = await removeListItemRecords(sqlExecutor, {
         listName: 'super',
-        ...(contentQuery === undefined ? {} : { contentQuery }),
+        contentQuery: blankContentQuery,
         clearAll: false,
       });
       expect(removal.removedCount).toBe(0);

--- a/apps/agent/src/mcp/__tests__/adapter.spec.ts
+++ b/apps/agent/src/mcp/__tests__/adapter.spec.ts
@@ -260,7 +260,10 @@ describe('installed mcp tool definitions', () => {
       settingList: [buildSettingRow({ safety: 'unsafe' })],
       callInstalledMcpTool,
     });
-    const circularArguments: Record<string, unknown> = {};
+    type SelfReferencingArgumentRecord = {
+      self?: SelfReferencingArgumentRecord;
+    };
+    const circularArguments: SelfReferencingArgumentRecord = {};
     circularArguments.self = circularArguments;
     expect(() => definition?.buildConfirmSummary?.(circularArguments)).not.toThrow();
     expect(() => definition?.buildConfirmSummary?.(undefined)).not.toThrow();

--- a/apps/agent/src/mcp/__tests__/result.spec.ts
+++ b/apps/agent/src/mcp/__tests__/result.spec.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'bun:test';
 
-import { summarizeMcpCallToolResult } from '@/mcp/result';
+import { mcpCallToolResultSchema, summarizeMcpCallToolResult } from '@/mcp/result';
 
 describe('mcp call tool result summary', () => {
   it('joins every text entry of a successful call', () => {
     expect(
       summarizeMcpCallToolResult(
-        {
+        mcpCallToolResultSchema.safeParse({
           content: [
             { type: 'text', text: 'first' },
             { type: 'text', text: 'second' },
           ],
-        },
+        }),
         'Listo.',
         'Falló.',
       ),
@@ -21,9 +21,9 @@ describe('mcp call tool result summary', () => {
   it('ignores content entries that carry no text', () => {
     expect(
       summarizeMcpCallToolResult(
-        {
+        mcpCallToolResultSchema.safeParse({
           content: [{ type: 'image' }, { type: 'text', text: 'only this' }],
-        },
+        }),
         'Listo.',
         'Falló.',
       ),
@@ -33,7 +33,10 @@ describe('mcp call tool result summary', () => {
   it('treats isError as a failure and keeps the server text', () => {
     expect(
       summarizeMcpCallToolResult(
-        { content: [{ type: 'text', text: 'rate limited' }], isError: true },
+        mcpCallToolResultSchema.safeParse({
+          content: [{ type: 'text', text: 'rate limited' }],
+          isError: true,
+        }),
         'Listo.',
         'Falló.',
       ),
@@ -42,20 +45,42 @@ describe('mcp call tool result summary', () => {
 
   it('uses the error summary when a failure carries no text', () => {
     expect(
-      summarizeMcpCallToolResult({ content: [], isError: true }, 'Listo.', 'Falló.'),
+      summarizeMcpCallToolResult(
+        mcpCallToolResultSchema.safeParse({ content: [], isError: true }),
+        'Listo.',
+        'Falló.',
+      ),
     ).toEqual({ ok: false, summary: 'Falló.' });
   });
 
   it('uses the fallback summary for an empty or unrecognized result', () => {
-    expect(summarizeMcpCallToolResult({}, 'Listo.', 'Falló.')).toEqual({
+    expect(
+      summarizeMcpCallToolResult(
+        mcpCallToolResultSchema.safeParse({}),
+        'Listo.',
+        'Falló.',
+      ),
+    ).toEqual({
       ok: true,
       summary: 'Listo.',
     });
-    expect(summarizeMcpCallToolResult(42, 'Listo.', 'Falló.')).toEqual({
+    expect(
+      summarizeMcpCallToolResult(
+        mcpCallToolResultSchema.safeParse(42),
+        'Listo.',
+        'Falló.',
+      ),
+    ).toEqual({
       ok: true,
       summary: 'Listo.',
     });
-    expect(summarizeMcpCallToolResult(null, 'Listo.', 'Falló.')).toEqual({
+    expect(
+      summarizeMcpCallToolResult(
+        mcpCallToolResultSchema.safeParse(null),
+        'Listo.',
+        'Falló.',
+      ),
+    ).toEqual({
       ok: true,
       summary: 'Listo.',
     });

--- a/apps/agent/src/mcp/__tests__/runtime.spec.ts
+++ b/apps/agent/src/mcp/__tests__/runtime.spec.ts
@@ -19,7 +19,7 @@ const stubMcpEffect: DeskToolEffects['callInstalledMcpTool'] = async () => ({
   summary: 'done',
 });
 
-const githubServerRecordMap: Record<string, unknown> = {
+const githubServerRecordMap = {
   github: {
     name: 'GitHub',
     server_url: 'https://mcp.github.example',

--- a/apps/agent/src/mcp/adapter.ts
+++ b/apps/agent/src/mcp/adapter.ts
@@ -2,7 +2,14 @@ import { z } from 'zod';
 
 import { buildNamespacedMcpToolName } from '@/mcp/naming';
 import { findMcpToolSetting, type McpToolSettingRow } from '@/mcp/settings';
-import type { DeskToolEffects, ToolDefinition, ToolSafetyLevel } from '@/tools/types';
+import {
+  jsonSerializableValueSchema,
+  type DeskToolEffects,
+  type JsonSerializableValue,
+  type ToolArgumentRecord,
+  type ToolDefinition,
+  type ToolSafetyLevel,
+} from '@/tools/types';
 
 // Descriptions are authored by the installed server and land in the system
 // prompt verbatim.
@@ -10,18 +17,24 @@ export const MCP_TOOL_DESCRIPTION_MAX_LENGTH = 400;
 
 const MCP_CONFIRM_SUMMARY_ARGUMENT_MAX_LENGTH = 160;
 
-const EMPTY_MCP_TOOL_PARAMETERS: Record<string, unknown> = {
+const EMPTY_MCP_TOOL_PARAMETERS = {
   type: 'object',
   properties: {},
 };
 
-const mcpToolArgumentRecordSchema = z.record(z.unknown());
+// Every caller hands this schema a value that is already statically
+// JsonSerializableValue, so only the record shape needs checking at runtime;
+// recursing into values would blow the stack on the self-referencing records
+// the JSON.stringify guard below exists to survive.
+const mcpToolArgumentRecordSchema: z.ZodType<ToolArgumentRecord> = z.record(
+  z.custom<JsonSerializableValue>(() => true),
+);
 
 export const discoveredMcpToolSchema = z.object({
   serverId: z.string().min(1),
   name: z.string().min(1),
   description: z.string().optional(),
-  inputSchema: z.record(z.unknown()).optional(),
+  inputSchema: z.record(jsonSerializableValueSchema).optional(),
   annotations: z
     .object({
       readOnlyHint: z.boolean().optional(),
@@ -56,11 +69,6 @@ export function truncateMcpText(text: string, maxLength: number): string {
   return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
 }
 
-function readMcpToolArgumentRecord(toolArgs: unknown): Record<string, unknown> {
-  const parsedArguments = mcpToolArgumentRecordSchema.safeParse(toolArgs);
-  return parsedArguments.success ? parsedArguments.data : {};
-}
-
 function buildInstalledMcpToolDescription(
   discoveredTool: DiscoveredMcpTool,
   serverLabel: string,
@@ -91,9 +99,12 @@ function buildInstalledMcpToolDefinition(input: {
     // The router reads a throw here as arguments the tool cannot accept, and an
     // installed server owns its own schema, so this renders without validating.
     buildConfirmSummary(toolArgs) {
+      const parsedArgumentRecord = mcpToolArgumentRecordSchema.safeParse(toolArgs);
       let renderedArguments: string;
       try {
-        renderedArguments = JSON.stringify(readMcpToolArgumentRecord(toolArgs)) ?? '{}';
+        renderedArguments =
+          JSON.stringify(parsedArgumentRecord.success ? parsedArgumentRecord.data : {}) ??
+          '{}';
       } catch {
         renderedArguments = '{}';
       }
@@ -105,11 +116,12 @@ function buildInstalledMcpToolDefinition(input: {
     // executeToolByName does not wrap safe handlers, so an escaping network
     // error would fail the whole turn instead of this one call.
     async handler(toolArgs) {
+      const parsedArgumentRecord = mcpToolArgumentRecordSchema.safeParse(toolArgs);
       try {
         return await input.callInstalledMcpTool({
           serverId: discoveredTool.serverId,
           toolName: discoveredTool.name,
-          argumentRecord: readMcpToolArgumentRecord(toolArgs),
+          argumentRecord: parsedArgumentRecord.success ? parsedArgumentRecord.data : {},
         });
       } catch (error) {
         return {

--- a/apps/agent/src/mcp/bridge.ts
+++ b/apps/agent/src/mcp/bridge.ts
@@ -1,13 +1,20 @@
-import { summarizeMcpCallToolResult } from '@/mcp/result';
-import type { ToolExecutionResult } from '@/tools/types';
+import { mcpCallToolResultSchema, summarizeMcpCallToolResult } from '@/mcp/result';
+import type { DeskToolEffects, ToolExecutionResult } from '@/tools/types';
 
 export const DEVICE_TOOL_CALL_TIMEOUT_MILLISECONDS = 5_000;
+
+export type DeviceToolArgumentRecord = Parameters<
+  DeskToolEffects['callDeviceTool']
+>[0]['argumentRecord'];
 
 export type DeviceMcpRequestPayload = {
   readonly jsonrpc: '2.0';
   readonly id: number;
   readonly method: string;
-  readonly params?: Record<string, unknown>;
+  readonly params?: {
+    readonly name: string;
+    readonly arguments: DeviceToolArgumentRecord;
+  };
 };
 
 export type DeviceMcpResponsePayload = {
@@ -78,7 +85,7 @@ export function createDeviceMcpRequestRegistry(): DeviceMcpRequestRegistry {
 export function buildDeviceToolCallPayload(
   requestId: number,
   deviceToolName: string,
-  argumentRecord: Record<string, unknown>,
+  argumentRecord: DeviceToolArgumentRecord,
 ): DeviceMcpRequestPayload {
   return {
     jsonrpc: '2.0',
@@ -101,7 +108,7 @@ export function summarizeDeviceToolResult(
     };
   }
   return summarizeMcpCallToolResult(
-    responsePayload.result,
+    mcpCallToolResultSchema.safeParse(responsePayload.result),
     'Hecho.',
     'El dispositivo devolvió un error.',
   );

--- a/apps/agent/src/mcp/result.ts
+++ b/apps/agent/src/mcp/result.ts
@@ -11,24 +11,28 @@ export const mcpCallToolResultSchema = z.object({
 
 export type McpCallToolResult = z.infer<typeof mcpCallToolResultSchema>;
 
+export type McpCallToolResultParseOutcome = ReturnType<
+  typeof mcpCallToolResultSchema.safeParse
+>;
+
 export function readMcpCallToolResultText(parsedResult: McpCallToolResult): string {
   return (parsedResult.content ?? [])
-    .map((contentEntry) => contentEntry.text)
-    .filter((text): text is string => typeof text === 'string')
+    .flatMap((contentEntry) =>
+      contentEntry.text === undefined ? [] : [contentEntry.text],
+    )
     .join('\n');
 }
 
 export function summarizeMcpCallToolResult(
-  rawResult: unknown,
+  parseOutcome: McpCallToolResultParseOutcome,
   fallbackSummary: string,
   errorSummary: string,
 ): ToolExecutionResult {
-  const parsedResult = mcpCallToolResultSchema.safeParse(rawResult);
-  if (!parsedResult.success) {
+  if (!parseOutcome.success) {
     return { ok: true, summary: fallbackSummary };
   }
-  const textContent = readMcpCallToolResultText(parsedResult.data);
-  if (parsedResult.data.isError === true) {
+  const textContent = readMcpCallToolResultText(parseOutcome.data);
+  if (parseOutcome.data.isError === true) {
     return {
       ok: false,
       summary: textContent === '' ? errorSummary : textContent,

--- a/apps/agent/src/mcp/runtime.ts
+++ b/apps/agent/src/mcp/runtime.ts
@@ -4,10 +4,15 @@ import {
   resolveDiscoveredMcpToolSafety,
   type DiscoveredMcpTool,
 } from '@/mcp/adapter';
-import { summarizeMcpCallToolResult } from '@/mcp/result';
+import {
+  mcpCallToolResultSchema,
+  summarizeMcpCallToolResult,
+  type McpCallToolResult,
+} from '@/mcp/result';
 import {
   buildMcpServerSummaryList,
   mcpServerRecordSchema,
+  type McpServerRecordCandidateMap,
   type McpServerSummary,
 } from '@/mcp/servers';
 import type { McpToolSettingRow } from '@/mcp/settings';
@@ -25,12 +30,14 @@ export type McpToolDiscoverySource = {
   readonly listTools: () => readonly unknown[];
 };
 
+type InstalledMcpToolCallInput = Parameters<DeskToolEffects['callInstalledMcpTool']>[0];
+
 export type McpToolCallSource = {
   readonly callTool: (params: {
     readonly serverId: string;
     readonly name: string;
-    readonly arguments: Record<string, unknown>;
-  }) => Promise<unknown>;
+    readonly arguments: InstalledMcpToolCallInput['argumentRecord'];
+  }) => Promise<McpCallToolResult>;
 };
 
 // Waking from hibernation restores MCP connections asynchronously, so listTools()
@@ -57,7 +64,7 @@ export async function discoverInstalledMcpToolList(
 }
 
 export function buildMcpServerLabelMap(
-  serverRecordMap: Record<string, unknown>,
+  serverRecordMap: McpServerRecordCandidateMap,
 ): ReadonlyMap<string, string> {
   return new Map(
     Object.entries(serverRecordMap).flatMap(([serverId, rawRecord]) => {
@@ -70,7 +77,7 @@ export function buildMcpServerLabelMap(
 export function buildTurnToolDefinitionMap(input: {
   readonly discoveredToolList: readonly DiscoveredMcpTool[];
   readonly settingList: readonly McpToolSettingRow[];
-  readonly serverRecordMap: Record<string, unknown>;
+  readonly serverRecordMap: McpServerRecordCandidateMap;
   readonly callInstalledMcpTool: DeskToolEffects['callInstalledMcpTool'];
 }): ReadonlyMap<string, ToolDefinition> {
   const installedToolList = buildInstalledMcpToolDefinitionList({
@@ -88,7 +95,7 @@ export function buildTurnToolDefinitionMap(input: {
 }
 
 export function buildInstalledMcpServerSummaryList(input: {
-  readonly serverRecordMap: Record<string, unknown>;
+  readonly serverRecordMap: McpServerRecordCandidateMap;
   readonly discoveredToolList: readonly DiscoveredMcpTool[];
   readonly settingList: readonly McpToolSettingRow[];
 }): readonly McpServerSummary[] {
@@ -102,11 +109,7 @@ export function buildInstalledMcpServerSummaryList(input: {
 
 export async function callInstalledMcpTool(
   mcpClientManager: McpToolCallSource,
-  input: {
-    readonly serverId: string;
-    readonly toolName: string;
-    readonly argumentRecord: Record<string, unknown>;
-  },
+  input: InstalledMcpToolCallInput,
 ): Promise<ToolExecutionResult> {
   try {
     const callResult = await mcpClientManager.callTool({
@@ -115,7 +118,7 @@ export async function callInstalledMcpTool(
       arguments: input.argumentRecord,
     });
     return summarizeMcpCallToolResult(
-      callResult,
+      mcpCallToolResultSchema.safeParse(callResult),
       'Hecho.',
       `El servidor rechazó ${input.toolName}.`,
     );

--- a/apps/agent/src/mcp/servers.ts
+++ b/apps/agent/src/mcp/servers.ts
@@ -77,8 +77,16 @@ export const mcpServerRecordSchema = z.object({
   error: z.string().nullable().optional(),
 });
 
+// The SDK's server registry survives hibernation, so a stored record may be
+// null or miss any field; every record is re-validated with the schema before use.
+export type McpServerRecordCandidate = Partial<
+  z.input<typeof mcpServerRecordSchema>
+> | null;
+
+export type McpServerRecordCandidateMap = Record<string, McpServerRecordCandidate>;
+
 export function buildMcpServerSummaryList(input: {
-  readonly serverRecordMap: Record<string, unknown>;
+  readonly serverRecordMap: McpServerRecordCandidateMap;
   readonly discoveredToolList: readonly DiscoveredMcpTool[];
   readonly settingList: readonly McpToolSettingRow[];
   readonly defaultSafetyResolver: (discoveredTool: DiscoveredMcpTool) => ToolSafetyLevel;

--- a/apps/agent/src/mcp/settings.ts
+++ b/apps/agent/src/mcp/settings.ts
@@ -19,10 +19,14 @@ const mcpToolSettingSqlRowSchema = z.object({
   safety: z.enum(['safe', 'unsafe']),
 });
 
+// Stored rows can predate the current schema, so any column may be missing or
+// corrupt until the schema re-validates each row.
+type McpToolSettingSqlRowCandidate = Partial<z.input<typeof mcpToolSettingSqlRowSchema>>;
+
 export async function listMcpToolSettings(
   sqlExecutor: MemorySqlExecutor,
 ): Promise<readonly McpToolSettingRow[]> {
-  const rows = sqlExecutor.execute<Record<string, unknown>>(
+  const rows = sqlExecutor.execute<McpToolSettingSqlRowCandidate>(
     'SELECT namespaced_name, server_id, tool_name, is_enabled, safety FROM mcp_tool_settings',
   );
   // Dropped rather than repaired: a corrupt safety level would otherwise decide

--- a/apps/agent/src/memory/__tests__/pending.spec.ts
+++ b/apps/agent/src/memory/__tests__/pending.spec.ts
@@ -5,7 +5,7 @@ import {
   enqueuePendingDeviceMessage,
   listPendingDeviceMessages,
 } from '@/memory/pending';
-import type { MemorySqlExecutor } from '@/memory/store';
+import type { MemorySqlExecutor, MemorySqlRow } from '@/memory/store';
 
 function createInMemorySqlExecutor(): MemorySqlExecutor {
   const pendingRowList: Array<{
@@ -15,42 +15,43 @@ function createInMemorySqlExecutor(): MemorySqlExecutor {
     created_at: number;
   }> = [];
 
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
-      if (query.startsWith('INSERT INTO pending_device_messages')) {
-        pendingRowList.push({
-          id: String(bindValues[0]),
-          type: String(bindValues[1]),
-          payload_json: String(bindValues[2]),
-          created_at: Number(bindValues[3]),
-        });
-        return [];
+  function executeFakeQuery(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly MemorySqlRow[] {
+    if (query.startsWith('INSERT INTO pending_device_messages')) {
+      pendingRowList.push({
+        id: String(bindValues[0]),
+        type: String(bindValues[1]),
+        payload_json: String(bindValues[2]),
+        created_at: Number(bindValues[3]),
+      });
+      return [];
+    }
+    if (query.startsWith('SELECT id, type, payload_json FROM pending_device_messages')) {
+      return [...pendingRowList]
+        .toSorted((left, right) => left.created_at - right.created_at)
+        .map((row) => ({
+          id: row.id,
+          type: row.type,
+          payload_json: row.payload_json,
+        }));
+    }
+    if (query.startsWith('DELETE FROM pending_device_messages WHERE id = ?')) {
+      const identifierToDelete = String(bindValues[0]);
+      const rowIndex = pendingRowList.findIndex((row) => row.id === identifierToDelete);
+      if (rowIndex >= 0) {
+        pendingRowList.splice(rowIndex, 1);
       }
-      if (
-        query.startsWith('SELECT id, type, payload_json FROM pending_device_messages')
-      ) {
-        return [...pendingRowList]
-          .toSorted((left, right) => left.created_at - right.created_at)
-          .map((row) => ({
-            id: row.id,
-            type: row.type,
-            payload_json: row.payload_json,
-          })) as unknown as readonly Row[];
-      }
-      if (query.startsWith('DELETE FROM pending_device_messages WHERE id = ?')) {
-        const identifierToDelete = String(bindValues[0]);
-        const rowIndex = pendingRowList.findIndex((row) => row.id === identifierToDelete);
-        if (rowIndex >= 0) {
-          pendingRowList.splice(rowIndex, 1);
-        }
-        return [];
-      }
-      throw new Error(`Unsupported query in fake: ${query}`);
-    },
-  };
+      return [];
+    }
+    throw new Error(`Unsupported query in fake: ${query}`);
+  }
+
+  // SAFETY: every branch of the fake returns rows carrying exactly the columns
+  // the matched production query selects, so the caller's Row type argument
+  // always matches the rows handed back.
+  return { execute: executeFakeQuery as MemorySqlExecutor['execute'] };
 }
 
 describe('pending device messages', () => {

--- a/apps/agent/src/memory/__tests__/session.spec.ts
+++ b/apps/agent/src/memory/__tests__/session.spec.ts
@@ -12,14 +12,7 @@ import {
   mapRecentHistoryToChatMessageList,
 } from '@/memory/session';
 
-function createFakeSessionProvider(recentHistoryResult: RecentHistoryResult): {
-  readonly provider: SessionProvider;
-  readonly getRecentHistoryCallArgList: readonly [
-    leafId: string | null | undefined,
-    maxContentBytes: number,
-    minRecentMessages: number | undefined,
-  ][];
-} {
+function createFakeSessionProvider(recentHistoryResult: RecentHistoryResult) {
   const getRecentHistoryCallArgList: [
     leafId: string | null | undefined,
     maxContentBytes: number,

--- a/apps/agent/src/memory/__tests__/store.spec.ts
+++ b/apps/agent/src/memory/__tests__/store.spec.ts
@@ -7,6 +7,7 @@ import {
   recallMemoryRecords,
   setSessionPreference,
   type MemorySqlExecutor,
+  type MemorySqlRow,
 } from '@/memory/store';
 
 function createInMemorySqlExecutor(): MemorySqlExecutor {
@@ -17,44 +18,47 @@ function createInMemorySqlExecutor(): MemorySqlExecutor {
   }> = [];
   const preferenceMap = new Map<string, string>();
 
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
-      if (query.startsWith('INSERT INTO memories')) {
-        memoryRowList.push({
-          id: String(bindValues[0]),
-          content: String(bindValues[1]),
-          created_at: Number(bindValues[2]),
-        });
-        return [];
-      }
-      if (query.startsWith('SELECT id, content, created_at FROM memories WHERE')) {
-        const likePattern = String(bindValues[0]).replaceAll('%', '');
-        const limit = Number(bindValues[1]);
-        return memoryRowList
-          .filter((row) => row.content.includes(likePattern))
-          .toSorted((left, right) => right.created_at - left.created_at)
-          .slice(0, limit) as unknown as readonly Row[];
-      }
-      if (query.startsWith('SELECT id, content, created_at FROM memories')) {
-        const limit = Number(bindValues[0]);
-        return [...memoryRowList]
-          .toSorted((left, right) => right.created_at - left.created_at)
-          .slice(0, limit) as unknown as readonly Row[];
-      }
-      if (query.startsWith('SELECT value FROM session_prefs')) {
-        const value = preferenceMap.get(String(bindValues[0]));
-        return value === undefined ? [] : ([{ value }] as unknown as readonly Row[]);
-      }
-      if (query.startsWith('INSERT INTO session_prefs')) {
-        preferenceMap.set(String(bindValues[0]), String(bindValues[1]));
-        return [];
-      }
-      throw new Error(`Unsupported query in fake: ${query}`);
-    },
-  };
+  function executeFakeQuery(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly MemorySqlRow[] {
+    if (query.startsWith('INSERT INTO memories')) {
+      memoryRowList.push({
+        id: String(bindValues[0]),
+        content: String(bindValues[1]),
+        created_at: Number(bindValues[2]),
+      });
+      return [];
+    }
+    if (query.startsWith('SELECT id, content, created_at FROM memories WHERE')) {
+      const likePattern = String(bindValues[0]).replaceAll('%', '');
+      const limit = Number(bindValues[1]);
+      return memoryRowList
+        .filter((row) => row.content.includes(likePattern))
+        .toSorted((left, right) => right.created_at - left.created_at)
+        .slice(0, limit);
+    }
+    if (query.startsWith('SELECT id, content, created_at FROM memories')) {
+      const limit = Number(bindValues[0]);
+      return [...memoryRowList]
+        .toSorted((left, right) => right.created_at - left.created_at)
+        .slice(0, limit);
+    }
+    if (query.startsWith('SELECT value FROM session_prefs')) {
+      const value = preferenceMap.get(String(bindValues[0]));
+      return value === undefined ? [] : [{ value }];
+    }
+    if (query.startsWith('INSERT INTO session_prefs')) {
+      preferenceMap.set(String(bindValues[0]), String(bindValues[1]));
+      return [];
+    }
+    throw new Error(`Unsupported query in fake: ${query}`);
+  }
+
+  // SAFETY: every branch of the fake returns rows carrying exactly the columns
+  // the matched production query selects, so the caller's Row type argument
+  // always matches the rows handed back.
+  return { execute: executeFakeQuery as MemorySqlExecutor['execute'] };
 }
 
 describe('memory store', () => {

--- a/apps/agent/src/memory/consolidate.ts
+++ b/apps/agent/src/memory/consolidate.ts
@@ -70,8 +70,9 @@ export function flattenRecentHistoryToTranscript(
   const lineList: string[] = [];
   for (const message of messageList) {
     const spokenText = message.parts
-      .filter((part) => part.type === 'text' && typeof part.text === 'string')
-      .map((part) => part.text)
+      .flatMap((part) =>
+        part.type === 'text' && part.text !== undefined ? [part.text] : [],
+      )
       .join(' ')
       .trim();
     if (spokenText.length === 0) {
@@ -202,15 +203,17 @@ export function seedOwnerFactsFromMemoryBlock(input: {
   return seededFactList;
 }
 
+export type OwnerFactMergeResult = {
+  readonly nextFactList: readonly OwnerFact[];
+  readonly genuinelyNewFactList: readonly OwnerFact[];
+};
+
 export function mergeOwnerFacts(input: {
   readonly existingFactList: readonly OwnerFact[];
   readonly extraction: MemoryExtractionResult;
   readonly nowMilliseconds: number;
   readonly createIdentifier: () => string;
-}): {
-  readonly nextFactList: readonly OwnerFact[];
-  readonly genuinelyNewFactList: readonly OwnerFact[];
-} {
+}): OwnerFactMergeResult {
   const reinforcedIdSet = new Set(input.extraction.reinforcedFactIdList);
   const staleIdSet = new Set(input.extraction.staleFactIdList);
   const decayCutoffMilliseconds =

--- a/apps/agent/src/memory/pending.ts
+++ b/apps/agent/src/memory/pending.ts
@@ -4,14 +4,41 @@ import type { MemorySqlExecutor } from '@/memory/store';
 
 export type PendingDeviceMessageType = 'background_result' | 'reminder';
 
+export type PendingDeviceMessagePayloadValue =
+  | string
+  | number
+  | boolean
+  | null
+  | PendingDeviceMessagePayloadValue[]
+  | { [fieldName: string]: PendingDeviceMessagePayloadValue };
+
+export type PendingDeviceMessagePayload = Record<
+  string,
+  PendingDeviceMessagePayloadValue
+>;
+
 const pendingDeviceMessageTypeSchema = z.enum(['background_result', 'reminder']);
-const pendingDeviceMessagePayloadSchema = z.record(z.string(), z.unknown());
+const pendingDeviceMessagePayloadValueSchema: z.ZodType<PendingDeviceMessagePayloadValue> =
+  z.lazy(() =>
+    z.union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.null(),
+      z.array(pendingDeviceMessagePayloadValueSchema),
+      z.record(z.string(), pendingDeviceMessagePayloadValueSchema),
+    ]),
+  );
+const pendingDeviceMessagePayloadSchema = z.record(
+  z.string(),
+  pendingDeviceMessagePayloadValueSchema,
+);
 
 export async function enqueuePendingDeviceMessage(
   sqlExecutor: MemorySqlExecutor,
   input: {
     readonly type: PendingDeviceMessageType;
-    readonly payload: Record<string, unknown>;
+    readonly payload: PendingDeviceMessagePayload;
     readonly nowMilliseconds?: number;
     readonly createIdentifier?: () => string;
   },
@@ -31,7 +58,7 @@ export async function listPendingDeviceMessages(sqlExecutor: MemorySqlExecutor):
   readonly {
     id: string;
     type: PendingDeviceMessageType;
-    payload: Record<string, unknown>;
+    payload: PendingDeviceMessagePayload;
   }[]
 > {
   const rows = sqlExecutor.execute<{

--- a/apps/agent/src/memory/session.ts
+++ b/apps/agent/src/memory/session.ts
@@ -100,8 +100,9 @@ export async function compactThreadMessageList(
   const transcriptText = compactableMessageList
     .map((message) => {
       const spokenText = message.parts
-        .filter((part) => part.type === 'text' && typeof part.text === 'string')
-        .map((part) => part.text)
+        .flatMap((part) =>
+          part.type === 'text' && part.text !== undefined ? [part.text] : [],
+        )
         .join(' ')
         .trim();
       if (spokenText.length === 0) {
@@ -118,7 +119,7 @@ export async function compactThreadMessageList(
   const chatResult = await chatWithOpenRouter({
     openRouterApiKey: environment.OPENROUTER_API_KEY,
     modelId: environment.OPENROUTER_MODEL,
-    ...(fetchImplementation === undefined ? {} : { fetchImplementation }),
+    fetchImplementation,
     messageList: [
       {
         role: 'system',
@@ -158,8 +159,9 @@ function mapSessionMessageToChatMessage(
     return undefined;
   }
   const messageText = message.parts
-    .filter((part) => part.type === 'text' && typeof part.text === 'string')
-    .map((part) => part.text)
+    .flatMap((part) =>
+      part.type === 'text' && part.text !== undefined ? [part.text] : [],
+    )
     .join(' ')
     .trim();
   if (messageText.length === 0) {

--- a/apps/agent/src/memory/store.ts
+++ b/apps/agent/src/memory/store.ts
@@ -4,8 +4,12 @@ export type MemoryRecord = {
   readonly createdAt: number;
 };
 
+export type MemorySqlValue = ArrayBuffer | string | number | null;
+
+export type MemorySqlRow = Record<string, MemorySqlValue>;
+
 export type MemorySqlExecutor = {
-  execute<Row extends Record<string, unknown>>(
+  execute<Row extends MemorySqlRow>(
     query: string,
     ...bindValues: unknown[]
   ): readonly Row[];

--- a/apps/agent/src/memory/vector.ts
+++ b/apps/agent/src/memory/vector.ts
@@ -10,6 +10,10 @@ const openRouterEmbeddingResponseSchema = z.object({
     .min(1),
 });
 
+const memoryVectorMetadataSchema = z.object({
+  content: z.string(),
+});
+
 export type MemoryVectorMatch = {
   readonly id: string;
   readonly content: string;
@@ -72,11 +76,14 @@ export async function queryMemoryVectors(input: {
     returnMetadata: 'all',
   });
 
-  return queryResult.matches.map((match) => ({
-    id: match.id,
-    content: typeof match.metadata?.content === 'string' ? match.metadata.content : '',
-    score: match.score,
-  }));
+  return queryResult.matches.map((match) => {
+    const parsedMetadata = memoryVectorMetadataSchema.safeParse(match.metadata);
+    return {
+      id: match.id,
+      content: parsedMetadata.success ? parsedMetadata.data.content : '',
+      score: match.score,
+    };
+  });
 }
 
 export async function recallSemanticMemoryContent(input: {

--- a/apps/agent/src/notifications/__tests__/email.spec.ts
+++ b/apps/agent/src/notifications/__tests__/email.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import { sendEmailWithResend } from '@/notifications/email';
 
@@ -7,10 +8,18 @@ type CapturedFetchCall = {
   readonly init: RequestInit;
 };
 
-function createCapturingFetchMock(status = 200): {
+type CapturingFetchMock = {
   readonly fetchImplementation: typeof fetch;
   readonly callList: CapturedFetchCall[];
-} {
+};
+
+const sentEmailPayloadSchema = z.object({
+  to: z.array(z.string()),
+  subject: z.string(),
+  text: z.string(),
+});
+
+function createCapturingFetchMock(status = 200): CapturingFetchMock {
   const callList: CapturedFetchCall[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -22,7 +31,7 @@ function createCapturingFetchMock(status = 200): {
   return {
     fetchImplementation: Object.assign(fetchHandler, {
       preconnect: () => {},
-    }) as typeof fetch,
+    }),
     callList,
   };
 }
@@ -41,10 +50,8 @@ describe('sendEmailWithResend', () => {
 
     expect(callList[0].url).toBe('https://api.resend.com/emails');
     expect(callList[0].init.headers).toMatchObject({ Authorization: 'Bearer re-key' });
-    const requestBody = JSON.parse(callList[0].init.body as string) as Record<
-      string,
-      unknown
-    >;
+    const rawRequestBody: unknown = JSON.parse(z.string().parse(callList[0].init.body));
+    const requestBody = sentEmailPayloadSchema.parse(rawRequestBody);
     expect(requestBody).toMatchObject({
       to: ['dueno@example.com'],
       subject: 'Informe',

--- a/apps/agent/src/ota/lifecycle.ts
+++ b/apps/agent/src/ota/lifecycle.ts
@@ -27,6 +27,10 @@ export const FIRMWARE_PUSH_STATE_PREFERENCE_KEY = 'firmwarePushState';
 export const FIRMWARE_CHANGELOG_STATE_PREFERENCE_KEY = 'firmwareChangelogState';
 export const PUBLIC_ORIGIN_PREFERENCE_KEY = 'publicOrigin';
 
+export type FirmwareUpgradeArgumentRecord = {
+  readonly url: string;
+};
+
 export type FirmwareLifecycleDependencies = {
   readonly sqlExecutor: MemorySqlExecutor;
   readonly mediaBucket: R2Bucket;
@@ -43,7 +47,7 @@ export type FirmwareLifecycleDependencies = {
   readonly hasScheduledInitiativeRetry: (source: InitiativeSource) => Promise<boolean>;
   readonly callDeviceTool: (
     deviceToolName: string,
-    argumentRecord: Record<string, unknown>,
+    argumentRecord: FirmwareUpgradeArgumentRecord,
   ) => Promise<ToolExecutionResult>;
 };
 
@@ -124,13 +128,14 @@ export async function runFirmwareLifecycle(
         manifest !== undefined && manifest.version === pendingVersion
           ? manifest.changelog
           : undefined;
+      const changelogMessage =
+        changelogText !== undefined
+          ? buildFirmwareChangelogMessage({ toVersion: pendingVersion, changelogText })
+          : buildFirmwareChangelogMessage({ toVersion: pendingVersion });
       const deliveryOutcome = await dependencies.deliverInitiativeUtterance({
         source: 'firmware_changelog',
         priority: 'normal',
-        message: buildFirmwareChangelogMessage({
-          toVersion: pendingVersion,
-          ...(changelogText !== undefined ? { changelogText } : {}),
-        }),
+        message: changelogMessage,
         earconName: 'chime',
         utteranceKey: `firmware-changelog-${pendingVersion}`,
       });

--- a/apps/agent/src/persona/face.ts
+++ b/apps/agent/src/persona/face.ts
@@ -1,7 +1,7 @@
 import type { DeskFaceEmotionName } from '@/protocol/schema';
 import type { DeskUiStateName } from '@/protocol/schema';
 
-const deskUiStateToFaceEmotionMap: Record<DeskUiStateName, DeskFaceEmotionName> = {
+const deskUiStateToFaceEmotionMap = {
   idle: 'neutral',
   listening: 'curious',
   thinking: 'focused',
@@ -9,7 +9,7 @@ const deskUiStateToFaceEmotionMap: Record<DeskUiStateName, DeskFaceEmotionName> 
   speaking: 'talking',
   focus: 'calm',
   dashboard: 'neutral',
-};
+} satisfies Record<DeskUiStateName, DeskFaceEmotionName>;
 
 export function resolveDeskFaceEmotion(uiState: DeskUiStateName): DeskFaceEmotionName {
   return deskUiStateToFaceEmotionMap[uiState];

--- a/apps/agent/src/protocol/__tests__/schema.spec.ts
+++ b/apps/agent/src/protocol/__tests__/schema.spec.ts
@@ -14,7 +14,9 @@ describe('protocol schema', () => {
   });
 
   it('parses audio_end', () => {
-    const message = parseDeviceToServerMessage({ type: 'audio_end', ts: 2 });
+    const message = parseDeviceToServerMessage(
+      JSON.stringify({ type: 'audio_end', ts: 2 }),
+    );
     expect(message.type).toBe('audio_end');
   });
 
@@ -23,15 +25,17 @@ describe('protocol schema', () => {
   });
 
   it('parses telemetry with every field', () => {
-    const message = parseDeviceToServerMessage({
-      type: 'telemetry',
-      battery: 87,
-      charging: false,
-      volume: 70,
-      wifiRssi: -52,
-      firmwareVersion: '2.4.2',
-      ts: 3,
-    });
+    const message = parseDeviceToServerMessage(
+      JSON.stringify({
+        type: 'telemetry',
+        battery: 87,
+        charging: false,
+        volume: 70,
+        wifiRssi: -52,
+        firmwareVersion: '2.4.2',
+        ts: 3,
+      }),
+    );
     expect(message).toEqual({
       type: 'telemetry',
       battery: 87,
@@ -44,16 +48,22 @@ describe('protocol schema', () => {
   });
 
   it('parses telemetry with only type and ts', () => {
-    const message = parseDeviceToServerMessage({ type: 'telemetry', ts: 4 });
+    const message = parseDeviceToServerMessage(
+      JSON.stringify({ type: 'telemetry', ts: 4 }),
+    );
     expect(message).toEqual({ type: 'telemetry', ts: 4 });
   });
 
   it('rejects telemetry with battery out of range', () => {
     expect(() =>
-      parseDeviceToServerMessage({ type: 'telemetry', battery: -1, ts: 5 }),
+      parseDeviceToServerMessage(
+        JSON.stringify({ type: 'telemetry', battery: -1, ts: 5 }),
+      ),
     ).toThrow();
     expect(() =>
-      parseDeviceToServerMessage({ type: 'telemetry', battery: 101, ts: 5 }),
+      parseDeviceToServerMessage(
+        JSON.stringify({ type: 'telemetry', battery: 101, ts: 5 }),
+      ),
     ).toThrow();
   });
 
@@ -158,6 +168,7 @@ describe('protocol schema', () => {
         reason: 'expired',
       }),
     ).toThrow();
+    // SAFETY: forges a reason the union forbids, to prove the runtime schema rejects it.
     expect(() =>
       encodeServerToDeviceMessage({
         type: 'confirm_close',
@@ -178,6 +189,7 @@ describe('protocol schema', () => {
   });
 
   it('rejects play_effect with an unknown name', () => {
+    // SAFETY: forges an effect name outside the catalog, to prove the runtime schema rejects it.
     expect(() =>
       encodeServerToDeviceMessage({
         type: 'play_effect',
@@ -188,38 +200,46 @@ describe('protocol schema', () => {
 
   it('parses mcp responses with result or error', () => {
     expect(
-      parseDeviceToServerMessage({
-        type: 'mcp',
-        payload: {
-          jsonrpc: '2.0',
-          id: 3,
-          result: { content: [{ type: 'text', text: 'true' }], isError: false },
-        },
-        ts: 6,
-      }).type,
+      parseDeviceToServerMessage(
+        JSON.stringify({
+          type: 'mcp',
+          payload: {
+            jsonrpc: '2.0',
+            id: 3,
+            result: { content: [{ type: 'text', text: 'true' }], isError: false },
+          },
+          ts: 6,
+        }),
+      ).type,
     ).toBe('mcp');
     expect(
-      parseDeviceToServerMessage({
-        type: 'mcp',
-        payload: { jsonrpc: '2.0', id: 4, error: { message: 'Unknown tool' } },
-        ts: 7,
-      }).type,
+      parseDeviceToServerMessage(
+        JSON.stringify({
+          type: 'mcp',
+          payload: { jsonrpc: '2.0', id: 4, error: { message: 'Unknown tool' } },
+          ts: 7,
+        }),
+      ).type,
     ).toBe('mcp');
   });
 
   it('rejects mcp responses without an integer id or without ts', () => {
     expect(() =>
-      parseDeviceToServerMessage({
-        type: 'mcp',
-        payload: { jsonrpc: '2.0', id: 'abc', result: {} },
-        ts: 8,
-      }),
+      parseDeviceToServerMessage(
+        JSON.stringify({
+          type: 'mcp',
+          payload: { jsonrpc: '2.0', id: 'abc', result: {} },
+          ts: 8,
+        }),
+      ),
     ).toThrow();
     expect(() =>
-      parseDeviceToServerMessage({
-        type: 'mcp',
-        payload: { jsonrpc: '2.0', id: 5, result: {} },
-      }),
+      parseDeviceToServerMessage(
+        JSON.stringify({
+          type: 'mcp',
+          payload: { jsonrpc: '2.0', id: 5, result: {} },
+        }),
+      ),
     ).toThrow();
   });
 
@@ -248,6 +268,7 @@ describe('protocol schema', () => {
   });
 
   it('rejects outbound mcp calls with a string id', () => {
+    // SAFETY: forges a string id the contract forbids, to prove the runtime schema rejects it.
     expect(() =>
       encodeServerToDeviceMessage({
         type: 'mcp',

--- a/apps/agent/src/protocol/schema.ts
+++ b/apps/agent/src/protocol/schema.ts
@@ -215,11 +215,10 @@ export const serverToDeviceMessageSchema = z.discriminatedUnion('type', [
 
 export type ServerToDeviceMessage = z.infer<typeof serverToDeviceMessageSchema>;
 
-export function parseDeviceToServerMessage(rawPayload: unknown): DeviceToServerMessage {
-  if (typeof rawPayload === 'string') {
-    return deviceToServerMessageSchema.parse(JSON.parse(rawPayload));
-  }
-  return deviceToServerMessageSchema.parse(rawPayload);
+export function parseDeviceToServerMessage(
+  rawMessageText: string,
+): DeviceToServerMessage {
+  return deviceToServerMessageSchema.parse(JSON.parse(rawMessageText));
 }
 
 export function encodeServerToDeviceMessage(message: ServerToDeviceMessage): string {

--- a/apps/agent/src/queues/jobs.ts
+++ b/apps/agent/src/queues/jobs.ts
@@ -23,6 +23,4 @@ export const apolloQueueJobSchema = z.discriminatedUnion('type', [
 
 export type ApolloQueueJob = z.infer<typeof apolloQueueJobSchema>;
 
-export function parseApolloQueueJob(rawPayload: unknown): ApolloQueueJob {
-  return apolloQueueJobSchema.parse(rawPayload);
-}
+export const parseApolloQueueJob = apolloQueueJobSchema.parse.bind(apolloQueueJobSchema);

--- a/apps/agent/src/rates/__tests__/dollar.spec.ts
+++ b/apps/agent/src/rates/__tests__/dollar.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   type DollarHttpFetchImplementation,
+  type DollarRate,
   fetchDollarRate,
   fetchDollarRateList,
 } from '@/rates/dollar';
@@ -15,20 +16,15 @@ const blueRate = {
 };
 
 function createCapturingFetchMock(
-  payload: unknown,
+  payload: DollarRate | readonly DollarRate[],
   status = 200,
-): {
-  readonly fetchImpl: DollarHttpFetchImplementation;
-  readonly requestedUrlList: string[];
-} {
+) {
   const requestedUrlList: string[] = [];
-  return {
-    requestedUrlList,
-    fetchImpl: async (url) => {
-      requestedUrlList.push(url);
-      return new Response(JSON.stringify(payload), { status });
-    },
+  const fetchImpl: DollarHttpFetchImplementation = async (url) => {
+    requestedUrlList.push(url);
+    return new Response(JSON.stringify(payload), { status });
   };
+  return { fetchImpl, requestedUrlList };
 }
 
 describe('fetchDollarRate', () => {
@@ -43,7 +39,7 @@ describe('fetchDollarRate', () => {
   });
 
   it('throws on a non-ok response', async () => {
-    const { fetchImpl } = createCapturingFetchMock({}, 500);
+    const { fetchImpl } = createCapturingFetchMock(blueRate, 500);
 
     await expect(fetchDollarRate({ type: 'blue', fetchImpl })).rejects.toThrow(
       'dolarapi request failed with status 500',

--- a/apps/agent/src/rates/dollar.ts
+++ b/apps/agent/src/rates/dollar.ts
@@ -27,10 +27,11 @@ const dollarRateSchema = z.object({
 
 export type DollarRate = z.infer<typeof dollarRateSchema>;
 
-async function requestDollarApi(
+async function requestDollarApi<ParsedPayload>(
   requestUrl: string,
+  payloadSchema: z.ZodType<ParsedPayload>,
   fetchImpl: DollarHttpFetchImplementation | undefined,
-): Promise<unknown> {
+): Promise<ParsedPayload> {
   const fetchImplementation: DollarHttpFetchImplementation =
     fetchImpl ?? ((url) => fetch(url));
   const response = await fetchImplementation(requestUrl);
@@ -39,23 +40,27 @@ async function requestDollarApi(
     throw new Error(`dolarapi request failed with status ${response.status}`);
   }
 
-  return response.json();
+  const rawPayload: unknown = await response.json();
+  return payloadSchema.parse(rawPayload);
 }
 
 export async function fetchDollarRate(input: {
   readonly type: DollarRateType;
   readonly fetchImpl?: DollarHttpFetchImplementation;
 }): Promise<DollarRate> {
-  const rawPayload = await requestDollarApi(
+  return requestDollarApi(
     `${DOLLAR_API_BASE_URL}/${input.type}`,
+    dollarRateSchema,
     input.fetchImpl,
   );
-  return dollarRateSchema.parse(rawPayload);
 }
 
 export async function fetchDollarRateList(
   input: { readonly fetchImpl?: DollarHttpFetchImplementation } = {},
 ): Promise<readonly DollarRate[]> {
-  const rawPayload = await requestDollarApi(DOLLAR_API_BASE_URL, input.fetchImpl);
-  return z.array(dollarRateSchema).parse(rawPayload);
+  return requestDollarApi(
+    DOLLAR_API_BASE_URL,
+    z.array(dollarRateSchema),
+    input.fetchImpl,
+  );
 }

--- a/apps/agent/src/reminders/logic.ts
+++ b/apps/agent/src/reminders/logic.ts
@@ -30,14 +30,14 @@ export function mapAgentScheduleListToReminderList(
     if (!parsedPayload.success) {
       continue;
     }
-    const reminderRow: ScheduledReminderRow = {
+    let reminderRow: ScheduledReminderRow = {
       id: schedule.id,
       message: parsedPayload.data.message,
       firesAtIso: new Date(schedule.time * 1000).toISOString(),
-      ...(typeof schedule.delayInSeconds === 'number'
-        ? { delayInSeconds: schedule.delayInSeconds }
-        : {}),
     };
+    if (schedule.delayInSeconds !== undefined) {
+      reminderRow = { ...reminderRow, delayInSeconds: schedule.delayInSeconds };
+    }
     reminderList.push(reminderRow);
   }
   return reminderList;

--- a/apps/agent/src/sandbox/__tests__/wiring.spec.ts
+++ b/apps/agent/src/sandbox/__tests__/wiring.spec.ts
@@ -14,16 +14,16 @@ import { createBuiltinToolDefinitionMap } from '@/tools/catalog';
 import { executeToolByName, resolvePendingToolConfirmation } from '@/tools/router';
 
 type CapturedSandboxCall = {
-  readonly sandboxId: string;
-  readonly code?: string;
-  readonly command?: string;
-  readonly timeoutMilliseconds?: number;
+  sandboxId: string;
+  code?: string;
+  command?: string;
+  timeoutMilliseconds?: number;
 };
 
 const capturedSandboxCallList: CapturedSandboxCall[] = [];
 
 mock.module('@cloudflare/sandbox', () => ({
-  getSandbox: (_namespace: unknown, sandboxId: string) => ({
+  getSandbox: (_sandboxNamespace: Env['Sandbox'], sandboxId: string) => ({
     createCodeContext: async () => ({ id: 'context-1' }),
     runCode: async (code: string) => {
       capturedSandboxCallList.push({ sandboxId, code });
@@ -34,13 +34,11 @@ mock.module('@cloudflare/sandbox', () => ({
       };
     },
     exec: async (command: string, options?: { timeout?: number }) => {
-      capturedSandboxCallList.push({
-        sandboxId,
-        command,
-        ...(options?.timeout !== undefined
-          ? { timeoutMilliseconds: options.timeout }
-          : {}),
-      });
+      const capturedCall: CapturedSandboxCall = { sandboxId, command };
+      if (options?.timeout !== undefined) {
+        capturedCall.timeoutMilliseconds = options.timeout;
+      }
+      capturedSandboxCallList.push(capturedCall);
       return {
         success: true,
         exitCode: 0,

--- a/apps/agent/src/sandbox/runner.ts
+++ b/apps/agent/src/sandbox/runner.ts
@@ -42,12 +42,7 @@ export async function runCodeInApolloSandbox(input: {
   const stdout = [
     ...(executionResult.logs?.stdout ?? []),
     ...executionResult.results
-      .map((result) => {
-        if ('text' in result && typeof result.text === 'string') {
-          return result.text;
-        }
-        return '';
-      })
+      .map((result) => result.text ?? '')
       .filter((text) => text.length > 0),
   ].join('\n');
   const stderr = (executionResult.logs?.stderr ?? []).join('\n');

--- a/apps/agent/src/search/__tests__/tavily.spec.ts
+++ b/apps/agent/src/search/__tests__/tavily.spec.ts
@@ -7,13 +7,21 @@ type CapturedFetchCall = {
   readonly init: RequestInit;
 };
 
+type TavilySearchResultFixture = {
+  readonly url: string;
+  readonly title: string;
+  readonly content: string;
+  readonly raw_content: string | null;
+};
+
+type TavilySearchResponseFixture = {
+  readonly results?: readonly TavilySearchResultFixture[];
+};
+
 function createCapturingFetchMock(
-  responseBody: unknown,
+  responseBody: TavilySearchResponseFixture,
   status = 200,
-): {
-  readonly fetchImplementation: typeof fetch;
-  readonly callList: CapturedFetchCall[];
-} {
+) {
   const callList: CapturedFetchCall[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -22,12 +30,10 @@ function createCapturingFetchMock(
     callList.push({ url: String(input), init: init ?? {} });
     return new Response(JSON.stringify(responseBody), { status });
   };
-  return {
-    fetchImplementation: Object.assign(fetchHandler, {
-      preconnect: () => {},
-    }) as typeof fetch,
-    callList,
-  };
+  const fetchImplementation: typeof fetch = Object.assign(fetchHandler, {
+    preconnect: () => {},
+  });
+  return { fetchImplementation, callList };
 }
 
 describe('searchWebSourcesWithTavily', () => {
@@ -59,11 +65,8 @@ describe('searchWebSourcesWithTavily', () => {
     expect(callList[0].init.headers).toMatchObject({
       Authorization: 'Bearer tvly-key',
     });
-    const requestBody = JSON.parse(callList[0].init.body as string) as Record<
-      string,
-      unknown
-    >;
-    expect(requestBody).toEqual({
+    const capturedRequestBody: unknown = JSON.parse(String(callList[0].init.body));
+    expect(capturedRequestBody).toEqual({
       query: 'capital de Francia',
       max_results: 5,
       include_raw_content: true,

--- a/apps/agent/src/search/deepresearch.ts
+++ b/apps/agent/src/search/deepresearch.ts
@@ -5,6 +5,8 @@ import { chatWithOpenRouter } from '@/voice/llm';
 // executes its own multi-source web searches and returns a cited report in one
 // call, replacing the old plan-queries → fetch-pages → synthesize pipeline
 // (which sat on the now-disabled Cloudflare Web Search binding).
+type DeepResearchChatRequest = Parameters<typeof chatWithOpenRouter>[0];
+
 export async function runDeepResearchWithPerplexity(input: {
   readonly openRouterApiKey: string;
   readonly modelId: string;
@@ -12,7 +14,7 @@ export async function runDeepResearchWithPerplexity(input: {
   readonly nowMilliseconds: number;
   readonly fetchImplementation?: typeof fetch;
 }): Promise<string> {
-  const chatResult = await chatWithOpenRouter({
+  let chatRequest: DeepResearchChatRequest = {
     openRouterApiKey: input.openRouterApiKey,
     modelId: input.modelId,
     messageList: [
@@ -24,9 +26,10 @@ export async function runDeepResearchWithPerplexity(input: {
       },
       { role: 'user', content: input.prompt },
     ],
-    ...(input.fetchImplementation !== undefined
-      ? { fetchImplementation: input.fetchImplementation }
-      : {}),
-  });
+  };
+  if (input.fetchImplementation !== undefined) {
+    chatRequest = { ...chatRequest, fetchImplementation: input.fetchImplementation };
+  }
+  const chatResult = await chatWithOpenRouter(chatRequest);
   return chatResult.text.trim();
 }

--- a/apps/agent/src/threads/__tests__/store.spec.ts
+++ b/apps/agent/src/threads/__tests__/store.spec.ts
@@ -19,13 +19,17 @@ type ThreadMetaRow = {
   last_turn_at: number;
 };
 
+type ThreadSessionIdRow = {
+  session_id: string;
+};
+
 function createInMemoryThreadSqlExecutor(): ThreadSqlExecutor {
   const rowMap = new Map<string, ThreadMetaRow>();
-  return {
-    execute<Row extends Record<string, unknown>>(
+  const inMemoryExecutor = {
+    execute(
       query: string,
       ...bindValues: unknown[]
-    ): readonly Row[] {
+    ): ReadonlyArray<ThreadMetaRow | ThreadSessionIdRow> {
       if (query.includes("VALUES (?, 'pending', NULL, ?)")) {
         const sessionId = String(bindValues[0]);
         const lastTurnAt = Number(bindValues[1]);
@@ -80,26 +84,28 @@ function createInMemoryThreadSqlExecutor(): ThreadSqlExecutor {
               row.last_turn_at > 0 &&
               row.last_turn_at < beforeMilliseconds,
           )
-          .map((row) => ({ session_id: row.session_id })) as unknown as readonly Row[];
+          .map((row) => ({ session_id: row.session_id }));
       }
       if (query.includes('WHERE last_turn_at >=')) {
         const sinceMilliseconds = Number(bindValues[0]);
         return [...rowMap.values()]
           .filter((row) => row.last_turn_at >= sinceMilliseconds)
           .toSorted((left, right) => right.last_turn_at - left.last_turn_at)
-          .map((row) => ({ session_id: row.session_id })) as unknown as readonly Row[];
+          .map((row) => ({ session_id: row.session_id }));
       }
       if (query.includes('WHERE session_id = ? LIMIT 1')) {
         const targetRow = rowMap.get(String(bindValues[0]));
-        return (targetRow === undefined
-          ? []
-          : [{ ...targetRow }]) as unknown as readonly Row[];
+        return targetRow === undefined ? [] : [{ ...targetRow }];
       }
       return [...rowMap.values()]
         .toSorted((left, right) => right.last_turn_at - left.last_turn_at)
-        .map((row) => ({ ...row })) as unknown as readonly Row[];
+        .map((row) => ({ ...row }));
     },
   };
+  // SAFETY: each branch of the double returns rows shaped exactly like the
+  // columns the matched production query selects, so the Row type each store
+  // function requests always describes the rows it receives.
+  return inMemoryExecutor as ThreadSqlExecutor;
 }
 
 describe('thread meta store', () => {

--- a/apps/agent/src/threads/finalize.ts
+++ b/apps/agent/src/threads/finalize.ts
@@ -21,8 +21,9 @@ export type ThreadDigestResult = z.infer<typeof threadDigestResultSchema>;
 
 function extractSpokenText(message: SessionMessage): string {
   return message.parts
-    .filter((part) => part.type === 'text' && typeof part.text === 'string')
-    .map((part) => part.text)
+    .flatMap((part) =>
+      part.type === 'text' && part.text !== undefined ? [part.text] : [],
+    )
     .join(' ')
     .trim();
 }

--- a/apps/agent/src/threads/store.ts
+++ b/apps/agent/src/threads/store.ts
@@ -1,5 +1,7 @@
+export type ThreadSqlValue = string | number | null;
+
 export type ThreadSqlExecutor = {
-  execute<Row extends Record<string, unknown>>(
+  execute<Row extends Record<string, ThreadSqlValue>>(
     query: string,
     ...bindValues: unknown[]
   ): readonly Row[];

--- a/apps/agent/src/tools/__tests__/catalog.spec.ts
+++ b/apps/agent/src/tools/__tests__/catalog.spec.ts
@@ -24,7 +24,7 @@ describe('builtin tool catalog', () => {
     expect(nameList).not.toContain('gmail_send');
     for (const tool of listBuiltinToolDefinitionList()) {
       expect(tool.parameters).toBeDefined();
-      expect(typeof tool.parameters).toBe('object');
+      expect(tool.parameters).toBeInstanceOf(Object);
     }
   });
 

--- a/apps/agent/src/tools/__tests__/coding.spec.ts
+++ b/apps/agent/src/tools/__tests__/coding.spec.ts
@@ -43,7 +43,7 @@ function stubGithubFetch(installedFullNameList: readonly string[]): void {
   };
   globalThis.fetch = Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 async function buildConfiguredEnvironment(): Promise<Env> {

--- a/apps/agent/src/tools/__tests__/device.spec.ts
+++ b/apps/agent/src/tools/__tests__/device.spec.ts
@@ -12,19 +12,14 @@ import {
   setBrightnessTool,
   setVolumeTool,
 } from '@/tools/device';
-import type { ToolExecutionContext } from '@/tools/types';
+import type { DeskToolEffects, ToolExecutionContext } from '@/tools/types';
+
+type DeviceToolCallInput = Parameters<DeskToolEffects['callDeviceTool']>[0];
 
 function createContextWithDeviceCallRecorder(
   deviceResponse = { ok: true, summary: 'true' },
-): {
-  context: ToolExecutionContext;
-  readCallList: () => readonly {
-    deviceToolName: string;
-    argumentRecord: Record<string, unknown>;
-  }[];
-} {
-  const callList: { deviceToolName: string; argumentRecord: Record<string, unknown> }[] =
-    [];
+) {
+  const callList: DeviceToolCallInput[] = [];
   const context: ToolExecutionContext = {
     environment: createFakeApolloEnvironment(),
     nowMilliseconds: 0,
@@ -35,7 +30,7 @@ function createContextWithDeviceCallRecorder(
       },
     }),
   };
-  return { context, readCallList: () => callList };
+  return { context, readCallList: (): readonly DeviceToolCallInput[] => callList };
 }
 
 describe('set_volume', () => {

--- a/apps/agent/src/tools/__tests__/intent.spec.ts
+++ b/apps/agent/src/tools/__tests__/intent.spec.ts
@@ -6,11 +6,11 @@ import { setWeatherLocationTool } from '@/tools/location';
 import { rememberFactTool } from '@/tools/memory';
 import { cancelReminderTool, listRemindersTool, setReminderTool } from '@/tools/reminder';
 import { startResearchTool } from '@/tools/research';
-import type { DeskToolEffects } from '@/tools/types';
+import type { DeskToolEffects, JsonSerializableValue } from '@/tools/types';
 import { weatherNowTool } from '@/tools/weather';
 import { clearDeskWeatherCache } from '@/weather/cache';
 
-function createTypedFetchMock(responseBody: unknown): typeof fetch {
+function createTypedFetchMock(responseBody: JsonSerializableValue): typeof fetch {
   const fetchHandler = async (
     _input: RequestInfo | URL,
     _init?: RequestInit,
@@ -18,7 +18,7 @@ function createTypedFetchMock(responseBody: unknown): typeof fetch {
 
   return Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 function createTypedFetchMockWithStatus(
@@ -32,7 +32,7 @@ function createTypedFetchMockWithStatus(
 
   return Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 function createRejectingFetchMock(error: Error): typeof fetch {
@@ -45,7 +45,7 @@ function createRejectingFetchMock(error: Error): typeof fetch {
 
   return Object.assign(fetchHandler, {
     preconnect: () => {},
-  }) as typeof fetch;
+  });
 }
 
 function createRecordingEffects(): DeskToolEffects & {
@@ -274,7 +274,7 @@ describe('intent tools', () => {
         );
       },
       { preconnect: () => {} },
-    ) as typeof fetch;
+    );
     try {
       const result = await weatherNowTool.handler(
         { locationQuery: 'Rosario' },

--- a/apps/agent/src/tools/__tests__/pending.spec.ts
+++ b/apps/agent/src/tools/__tests__/pending.spec.ts
@@ -9,12 +9,26 @@ import {
   savePendingToolConfirmation,
 } from '@/tools/pending';
 
-function createSingleRowSqlExecutor(row: Record<string, unknown>): MemorySqlExecutor {
-  const rowList: readonly Record<string, unknown>[] = [row];
+type StoredPendingConfirmationRow = {
+  readonly id?: string;
+  readonly tool_name?: string;
+  readonly args_json?: string;
+  readonly summary?: string;
+  readonly expires_at?: number;
+};
+
+function createSingleRowSqlExecutor(
+  row: StoredPendingConfirmationRow,
+): MemorySqlExecutor {
+  const rowList: readonly StoredPendingConfirmationRow[] = [row];
+  // SAFETY: the fake answers every select with the same canned row list no
+  // matter which row type the caller requests; the code under test validates
+  // every row with zod before trusting it, which is exactly what these tests
+  // exercise.
   return {
-    execute: <Row extends Record<string, unknown>>(query: string): readonly Row[] =>
-      query.includes('FROM pending_confirmations') ? (rowList as readonly Row[]) : [],
-  };
+    execute: (query: string) =>
+      query.includes('FROM pending_confirmations') ? rowList : [],
+  } as MemorySqlExecutor;
 }
 
 describe('pending tool confirmation store', () => {
@@ -96,12 +110,14 @@ describe('pending tool confirmation store', () => {
   });
 
   it('treats a row of the wrong shape as nothing pending', async () => {
-    const wrongShapeSqlExecutor = createSingleRowSqlExecutor({
+    const sqlExecutorReturningMalformedRows = createSingleRowSqlExecutor({
       id: 'confirm-1',
       summary: 'incompleto',
     });
 
-    expect(await readPendingToolConfirmation(wrongShapeSqlExecutor)).toBeUndefined();
+    expect(
+      await readPendingToolConfirmation(sqlExecutorReturningMalformedRows),
+    ).toBeUndefined();
   });
 });
 

--- a/apps/agent/src/tools/__tests__/recall.spec.ts
+++ b/apps/agent/src/tools/__tests__/recall.spec.ts
@@ -8,11 +8,10 @@ import { recallConversationTool, resumeConversationTool } from '@/tools/history'
 import type { ToolExecutionContext } from '@/tools/types';
 
 function buildContext(effects: ToolExecutionContext['effects']): ToolExecutionContext {
-  return {
-    environment: createFakeApolloEnvironment(),
-    nowMilliseconds: 1,
-    ...(effects === undefined ? {} : { effects }),
-  };
+  if (effects === undefined) {
+    return { environment: createFakeApolloEnvironment(), nowMilliseconds: 1 };
+  }
+  return { environment: createFakeApolloEnvironment(), nowMilliseconds: 1, effects };
 }
 
 describe('recall_conversation', () => {

--- a/apps/agent/src/tools/__tests__/timer.spec.ts
+++ b/apps/agent/src/tools/__tests__/timer.spec.ts
@@ -5,12 +5,8 @@ import {
   createStubDeskToolEffects,
 } from '@/configuration/testing';
 import { formatDurationForSpeech, setTimerTool, startPomodoroTool } from '@/tools/timer';
-import type { DeskToolEffects } from '@/tools/types';
 
-function createRecordingEffects(): {
-  readonly effects: DeskToolEffects;
-  readonly calls: string[];
-} {
+function createRecordingEffects() {
   const calls: string[] = [];
   return {
     calls,

--- a/apps/agent/src/tools/__tests__/translate.spec.ts
+++ b/apps/agent/src/tools/__tests__/translate.spec.ts
@@ -15,7 +15,7 @@ describe('translateTool', () => {
           { status: 200 },
         ),
       { preconnect: () => {} },
-    ) as typeof fetch;
+    );
 
     try {
       const result = await translateTool.handler(
@@ -49,7 +49,7 @@ describe('translateTool', () => {
           { status: 200 },
         ),
       { preconnect: () => {} },
-    ) as typeof fetch;
+    );
 
     try {
       const result = await translateTool.handler(

--- a/apps/agent/src/tools/__tests__/web.spec.ts
+++ b/apps/agent/src/tools/__tests__/web.spec.ts
@@ -3,18 +3,16 @@ import { describe, expect, it } from 'bun:test';
 import { createFakeApolloEnvironment } from '@/configuration/testing';
 import { webSearchTool } from '@/tools/web';
 
-function withMockedFetch(handler: (requestUrl: string) => Response): {
-  restore: () => void;
-} {
+function withMockedFetch(handler: (requestUrl: string) => Response) {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = Object.assign(
     async (input: RequestInfo | URL) => {
       const requestUrl =
-        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        input instanceof URL ? input.href : input instanceof Request ? input.url : input;
       return handler(requestUrl);
     },
     { preconnect: () => {} },
-  ) as typeof fetch;
+  );
   return {
     restore: () => {
       globalThis.fetch = originalFetch;

--- a/apps/agent/src/tools/device.ts
+++ b/apps/agent/src/tools/device.ts
@@ -74,10 +74,11 @@ function parseDeviceStatusSummary(
   deviceResult: ToolExecutionResult,
 ): ToolExecutionResult {
   try {
+    const parsedStatusData: unknown = JSON.parse(deviceResult.summary);
     return {
       ok: true,
       summary: 'Estado del dispositivo obtenido.',
-      data: JSON.parse(deviceResult.summary) as unknown,
+      data: parsedStatusData,
     };
   } catch {
     return deviceResult;

--- a/apps/agent/src/tools/list.ts
+++ b/apps/agent/src/tools/list.ts
@@ -131,11 +131,15 @@ export const removeFromListTool: ToolDefinition = {
     }
     const parsedArgs = parsedArgsResult.data;
     const listName = parsedArgs.listName ?? DEFAULT_LIST_NAME;
-    const removal = await context.effects.removeListItems({
-      listName,
-      ...(parsedArgs.item !== undefined ? { contentQuery: parsedArgs.item } : {}),
-      clearAll: parsedArgs.clearAll === true,
-    });
+    const removal = await context.effects.removeListItems(
+      parsedArgs.item === undefined
+        ? { listName, clearAll: parsedArgs.clearAll === true }
+        : {
+            listName,
+            contentQuery: parsedArgs.item,
+            clearAll: parsedArgs.clearAll === true,
+          },
+    );
     if (removal.removedCount === 0) {
       return {
         ok: false,

--- a/apps/agent/src/tools/pending.ts
+++ b/apps/agent/src/tools/pending.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 
 import type { MemorySqlExecutor } from '@/memory/store';
-import type { PendingToolConfirmation } from '@/tools/types';
+import {
+  jsonSerializableValueSchema,
+  type JsonSerializableValue,
+  type PendingToolConfirmation,
+} from '@/tools/types';
 
 const pendingToolConfirmationRowSchema = z.object({
   id: z.string().min(1),
@@ -32,7 +36,7 @@ export async function savePendingToolConfirmation(
 export async function readPendingToolConfirmation(
   sqlExecutor: MemorySqlExecutor,
 ): Promise<PendingToolConfirmation | undefined> {
-  const rows = sqlExecutor.execute<Record<string, unknown>>(
+  const rows = sqlExecutor.execute(
     'SELECT id, tool_name, args_json, summary, expires_at FROM pending_confirmations LIMIT 1',
   );
   const firstRow = rows[0];
@@ -46,9 +50,11 @@ export async function readPendingToolConfirmation(
   if (!parsedRow.success) {
     return undefined;
   }
-  let storedArguments: unknown;
+  let storedArguments: JsonSerializableValue;
   try {
-    storedArguments = JSON.parse(parsedRow.data.args_json);
+    storedArguments = jsonSerializableValueSchema.parse(
+      JSON.parse(parsedRow.data.args_json),
+    );
   } catch {
     return undefined;
   }

--- a/apps/agent/src/tools/router.ts
+++ b/apps/agent/src/tools/router.ts
@@ -1,5 +1,6 @@
 import {
   CONFIRM_TIMEOUT_MILLISECONDS,
+  type JsonSerializableValue,
   type PendingToolConfirmation,
   type ToolDefinition,
   type ToolExecutionContext,
@@ -23,7 +24,7 @@ export function isPendingConfirmationExpired(
 export async function executeToolByName(
   toolDefinitionMap: ReadonlyMap<string, ToolDefinition>,
   toolName: string,
-  toolArgs: unknown,
+  toolArgs: JsonSerializableValue | undefined,
   context: ToolExecutionContext,
   createConfirmationId: () => string = () => crypto.randomUUID(),
 ): Promise<ToolRouterOutcome> {

--- a/apps/agent/src/tools/sandbox.ts
+++ b/apps/agent/src/tools/sandbox.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod';
 
-import {
-  truncateSandboxOutputForToolResult,
-  type SandboxCodeLanguage,
-} from '@/sandbox/helpers';
+import { truncateSandboxOutputForToolResult } from '@/sandbox/helpers';
 import type { ToolDefinition } from '@/tools/types';
 
 const sandboxRunCodeArgsSchema = z.object({
@@ -44,7 +41,7 @@ export const sandboxRunCodeTool: ToolDefinition = {
       environment: context.environment,
       deviceId,
       code: parsedArgs.code,
-      language: parsedArgs.language as SandboxCodeLanguage,
+      language: parsedArgs.language,
     });
     return {
       ok: result.ok,

--- a/apps/agent/src/tools/types.ts
+++ b/apps/agent/src/tools/types.ts
@@ -1,7 +1,32 @@
+import { z } from 'zod';
+
 import type { ListItemRecord } from '@/lists/store';
 import type { ScheduledReminderRow } from '@/reminders/logic';
 
 export type ToolSafetyLevel = 'safe' | 'unsafe';
+
+export type JsonSerializableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonSerializableValue[]
+  | { readonly [propertyName: string]: JsonSerializableValue };
+
+export type ToolArgumentRecord = {
+  readonly [argumentName: string]: JsonSerializableValue;
+};
+
+export const jsonSerializableValueSchema: z.ZodType<JsonSerializableValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonSerializableValueSchema),
+    z.record(jsonSerializableValueSchema),
+  ]),
+);
 
 export type ToolExecutionResult = {
   readonly ok: boolean;
@@ -12,7 +37,7 @@ export type ToolExecutionResult = {
 export type PendingToolConfirmation = {
   readonly id: string;
   readonly toolName: string;
-  readonly args: unknown;
+  readonly args: JsonSerializableValue | undefined;
   readonly summary: string;
   readonly expiresAt: number;
 };
@@ -87,12 +112,12 @@ export type DeskToolEffects = {
   >;
   readonly callDeviceTool: (input: {
     readonly deviceToolName: string;
-    readonly argumentRecord: Record<string, unknown>;
+    readonly argumentRecord: ToolArgumentRecord;
   }) => Promise<ToolExecutionResult>;
   readonly callInstalledMcpTool: (input: {
     readonly serverId: string;
     readonly toolName: string;
-    readonly argumentRecord: Record<string, unknown>;
+    readonly argumentRecord: ToolArgumentRecord;
   }) => Promise<ToolExecutionResult>;
 };
 
@@ -104,7 +129,7 @@ export type ToolExecutionContext = {
 };
 
 export type ToolHandler = (
-  args: unknown,
+  args: JsonSerializableValue | undefined,
   context: ToolExecutionContext,
 ) => Promise<ToolExecutionResult>;
 
@@ -112,9 +137,9 @@ export type ToolDefinition = {
   readonly name: string;
   readonly safety: ToolSafetyLevel;
   readonly description: string;
-  readonly parameters: Record<string, unknown>;
+  readonly parameters: ToolArgumentRecord;
   readonly handler: ToolHandler;
-  readonly buildConfirmSummary?: (args: unknown) => string;
+  readonly buildConfirmSummary?: (args: JsonSerializableValue | undefined) => string;
 };
 
 export const CONFIRM_TIMEOUT_MILLISECONDS = 30_000;

--- a/apps/agent/src/turn/__tests__/run.spec.ts
+++ b/apps/agent/src/turn/__tests__/run.spec.ts
@@ -14,11 +14,8 @@ function createInMemorySqlExecutor(): MemorySqlExecutor {
     content: string;
     created_at: number;
   }> = [];
-  return {
-    execute<Row extends Record<string, unknown>>(
-      query: string,
-      ...bindValues: unknown[]
-    ): readonly Row[] {
+  const inMemorySqlExecutor = {
+    execute(query: string, ...bindValues: unknown[]) {
       if (query.startsWith('INSERT INTO memories')) {
         memoryRowList.push({
           id: String(bindValues[0]),
@@ -32,17 +29,28 @@ function createInMemorySqlExecutor(): MemorySqlExecutor {
         const limit = Number(bindValues[1]);
         return memoryRowList
           .filter((row) => row.content.toLowerCase().includes(likePattern.toLowerCase()))
-          .slice(0, limit) as unknown as readonly Row[];
+          .slice(0, limit);
       }
       if (query.startsWith('SELECT id, content')) {
         const limit = Number(bindValues[0]);
         return [...memoryRowList]
           .toSorted((left, right) => right.created_at - left.created_at)
-          .slice(0, limit) as unknown as readonly Row[];
+          .slice(0, limit);
       }
       return [];
     },
   };
+  // SAFETY: every query the memory store issues selects id, content, and
+  // created_at — exactly the row shape this fake stores — so the caller's
+  // Row type parameter always matches the rows returned here.
+  return inMemorySqlExecutor as MemorySqlExecutor;
+}
+
+function encodeTextAsFakeAudio(text: string): ArrayBuffer {
+  const encodedByteArray = new TextEncoder().encode(text);
+  const fakeAudioBuffer = new ArrayBuffer(encodedByteArray.byteLength);
+  new Uint8Array(fakeAudioBuffer).set(encodedByteArray);
+  return fakeAudioBuffer;
 }
 
 const fakeEnvironment = createFakeApolloEnvironment();
@@ -73,7 +81,7 @@ describe('runDeskTurn', () => {
             toolCallList: [],
           };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
 
@@ -89,7 +97,7 @@ describe('runDeskTurn', () => {
     let capturedSystemPrompt = '';
 
     const output = await runDeskTurn({
-      audioBuffer: new TextEncoder().encode('audio-crudo').buffer as ArrayBuffer,
+      audioBuffer: encodeTextAsFakeAudio('audio-crudo'),
       speechMode: 'default',
       focusState: createInactiveDeskFocusState(),
       sqlExecutor: createInMemorySqlExecutor(),
@@ -109,7 +117,7 @@ describe('runDeskTurn', () => {
             systemMessage?.role === 'system' ? systemMessage.content : '';
           return { text: 'Café cargado.', toolCallList: [] };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
 
@@ -139,7 +147,7 @@ describe('runDeskTurn', () => {
           capturedMessageList = messageList;
           return { text: 'Listo, te las mando.', toolCallList: [] };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
 
@@ -167,7 +175,7 @@ describe('runDeskTurn', () => {
     let didRecallSemanticMemory = false;
 
     const output = await runDeskTurn({
-      audioBuffer: new TextEncoder().encode('ruido').buffer as ArrayBuffer,
+      audioBuffer: encodeTextAsFakeAudio('ruido'),
       speechMode: 'default',
       focusState: createInactiveDeskFocusState(),
       sqlExecutor: createInMemorySqlExecutor(),
@@ -194,7 +202,7 @@ describe('runDeskTurn', () => {
     const semanticQueryTextList: string[] = [];
 
     const output = await runDeskTurn({
-      audioBuffer: new TextEncoder().encode('audio').buffer as ArrayBuffer,
+      audioBuffer: encodeTextAsFakeAudio('audio'),
       speechMode: 'default',
       focusState: createInactiveDeskFocusState(),
       sqlExecutor: createInMemorySqlExecutor(),
@@ -208,7 +216,7 @@ describe('runDeskTurn', () => {
       adapters: {
         stt: async () => '\n  qué hora es  \n',
         llm: async () => ({ text: 'Son las tres.', toolCallList: [] }),
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
 
@@ -220,7 +228,7 @@ describe('runDeskTurn', () => {
     let didRecallSemanticMemory = false;
 
     const output = await runDeskTurn({
-      audioBuffer: new TextEncoder().encode('silencio').buffer as ArrayBuffer,
+      audioBuffer: encodeTextAsFakeAudio('silencio'),
       speechMode: 'default',
       focusState: createInactiveDeskFocusState(),
       sqlExecutor: createInMemorySqlExecutor(),
@@ -318,7 +326,7 @@ describe('runDeskTurn', () => {
           capturedMessageList = messageList;
           return { text: 'Listo, ya arranqué con apollo.', toolCallList: [] };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
 
@@ -375,7 +383,7 @@ describe('runDeskTurn', () => {
           }
           return { text: 'Hay 18 grados.', toolCallList: [] };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
     expect(captionList[0]).toBe('Pensando…');
@@ -418,7 +426,7 @@ describe('runDeskTurn', () => {
             toolCallList: [],
           };
         },
-        tts: async (text) => new TextEncoder().encode(text).buffer as ArrayBuffer,
+        tts: async (text) => encodeTextAsFakeAudio(text),
       },
     });
     expect(callCount).toBe(2);
@@ -449,7 +457,7 @@ describe('runDeskTurn', () => {
         },
         tts: async (text) => {
           synthesizedTextList.push(text);
-          return new TextEncoder().encode(text).buffer as ArrayBuffer;
+          return encodeTextAsFakeAudio(text);
         },
       },
     });
@@ -500,7 +508,7 @@ describe('runDeskTurn', () => {
         },
         tts: async (text) => {
           synthesizedTextList.push(text);
-          return new TextEncoder().encode(text).buffer as ArrayBuffer;
+          return encodeTextAsFakeAudio(text);
         },
       },
     });
@@ -532,7 +540,7 @@ describe('runDeskTurn', () => {
         llm: async () => ({ text: longReply, toolCallList: [] }),
         tts: async (text) => {
           synthesizedTextList.push(text);
-          return new TextEncoder().encode(text).buffer as ArrayBuffer;
+          return encodeTextAsFakeAudio(text);
         },
       },
     });

--- a/apps/agent/src/turn/caption.ts
+++ b/apps/agent/src/turn/caption.ts
@@ -1,27 +1,27 @@
-const toolNameToThinkingCaptionMap: Readonly<Record<string, string>> = {
-  weather_now: 'Consultando clima…',
-  set_weather_location: 'Guardando ubicación…',
-  web_search: 'Buscando…',
-  start_research: 'Investigando…',
-  recall_memory: 'Recordando…',
-  translate: 'Traduciendo…',
-  remember_fact: 'Guardando…',
-  set_reminder: 'Recordatorios…',
-  list_reminders: 'Recordatorios…',
-  cancel_reminder: 'Recordatorios…',
-  set_timer: 'Timer…',
-  start_pomodoro: 'Pomodoro…',
-  add_to_list: 'Listas…',
-  read_list: 'Listas…',
-  remove_from_list: 'Listas…',
-  dollar_rate: 'Cotizaciones…',
-  send_email: 'Mandando mail…',
-  set_focus: 'Focus…',
-  clear_focus: 'Focus…',
-  sandbox_run_code: 'Ejecutando…',
-  sandbox_exec: 'Ejecutando…',
-};
+const toolNameToThinkingCaptionMap = new Map([
+  ['weather_now', 'Consultando clima…'],
+  ['set_weather_location', 'Guardando ubicación…'],
+  ['web_search', 'Buscando…'],
+  ['start_research', 'Investigando…'],
+  ['recall_memory', 'Recordando…'],
+  ['translate', 'Traduciendo…'],
+  ['remember_fact', 'Guardando…'],
+  ['set_reminder', 'Recordatorios…'],
+  ['list_reminders', 'Recordatorios…'],
+  ['cancel_reminder', 'Recordatorios…'],
+  ['set_timer', 'Timer…'],
+  ['start_pomodoro', 'Pomodoro…'],
+  ['add_to_list', 'Listas…'],
+  ['read_list', 'Listas…'],
+  ['remove_from_list', 'Listas…'],
+  ['dollar_rate', 'Cotizaciones…'],
+  ['send_email', 'Mandando mail…'],
+  ['set_focus', 'Focus…'],
+  ['clear_focus', 'Focus…'],
+  ['sandbox_run_code', 'Ejecutando…'],
+  ['sandbox_exec', 'Ejecutando…'],
+]);
 
 export function mapToolNameToThinkingCaption(toolName: string): string {
-  return toolNameToThinkingCaptionMap[toolName] ?? 'Trabajando…';
+  return toolNameToThinkingCaptionMap.get(toolName) ?? 'Trabajando…';
 }

--- a/apps/agent/src/turn/run.ts
+++ b/apps/agent/src/turn/run.ts
@@ -15,6 +15,7 @@ import {
   buildOpenRouterSystemPrompt,
   buildSemanticMemoryPromptNote,
   type OpenRouterChatMessage,
+  type OpenRouterToolCall,
 } from '@/voice/llm';
 import { sanitizeTextForSpeech } from '@/voice/sanitize';
 import {
@@ -24,25 +25,23 @@ import {
 
 const DEFAULT_MAX_TOOL_ROUND_COUNT = 3;
 
+export type LanguageModelToolDescriptor = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: ToolDefinition['parameters'];
+};
+
 export type VoiceAdapters = {
   readonly stt: (audioBuffer: ArrayBuffer) => Promise<string>;
   readonly llm: (input: {
     readonly messageList: readonly OpenRouterChatMessage[];
-    readonly toolDefinitionList: readonly {
-      readonly name: string;
-      readonly description: string;
-      readonly parameters: Record<string, unknown>;
-    }[];
+    readonly toolDefinitionList: readonly LanguageModelToolDescriptor[];
     // Optional streaming hook: adapters that support it push content deltas
     // as they arrive so the turn can start synthesizing speech early.
     readonly onTextDelta?: (deltaText: string) => void;
   }) => Promise<{
     readonly text: string;
-    readonly toolCallList: readonly {
-      readonly id: string;
-      readonly name: string;
-      readonly args: unknown;
-    }[];
+    readonly toolCallList: readonly OpenRouterToolCall[];
   }>;
   readonly tts: (text: string, voiceId: string) => Promise<ArrayBuffer>;
 };
@@ -94,11 +93,7 @@ export type TurnOutput = {
 
 function buildToolDefinitionListFromMap(
   toolDefinitionMap: ReadonlyMap<string, ToolDefinition>,
-): readonly {
-  readonly name: string;
-  readonly description: string;
-  readonly parameters: Record<string, unknown>;
-}[] {
+): readonly LanguageModelToolDescriptor[] {
   return [...toolDefinitionMap.values()].map((toolDefinition) => ({
     name: toolDefinition.name,
     description: toolDefinition.description,
@@ -108,11 +103,7 @@ function buildToolDefinitionListFromMap(
 
 function buildAssistantToolCallMessage(
   llmText: string,
-  toolCallList: readonly {
-    readonly id: string;
-    readonly name: string;
-    readonly args: unknown;
-  }[],
+  toolCallList: readonly OpenRouterToolCall[],
 ): OpenRouterChatMessage {
   return {
     role: 'assistant',
@@ -247,7 +238,7 @@ export async function runDeskTurn(input: TurnInput): Promise<TurnOutput> {
         {
           id: resolvedConfirmation.id,
           name: resolvedConfirmation.toolName,
-          args: resolvedConfirmation.args,
+          args: resolvedConfirmation.args ?? null,
         },
       ]),
       buildToolResultMessage(resolvedConfirmation.id, resolvedConfirmationResult),

--- a/apps/agent/src/voice/__tests__/elevenlabs.spec.ts
+++ b/apps/agent/src/voice/__tests__/elevenlabs.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import { synthesizeSpeechWithElevenLabs } from '@/voice/elevenlabs';
 
@@ -7,13 +8,17 @@ type CapturedFetchCall = {
   readonly init: RequestInit;
 };
 
-function createCapturingFetchMock(
-  audioArrayBuffer: ArrayBuffer,
-  status = 200,
-): {
-  readonly fetchImplementation: typeof fetch;
-  readonly callList: CapturedFetchCall[];
-} {
+const capturedSynthesisRequestBodySchema = z
+  .object({ text: z.string(), model_id: z.string() })
+  .passthrough();
+
+function parseCapturedSynthesisRequestBody(capturedCall: CapturedFetchCall) {
+  return capturedSynthesisRequestBodySchema.parse(
+    JSON.parse(String(capturedCall.init.body)),
+  );
+}
+
+function createCapturingFetchMock(audioArrayBuffer: ArrayBuffer, status = 200) {
   const callList: CapturedFetchCall[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -25,7 +30,7 @@ function createCapturingFetchMock(
   return {
     fetchImplementation: Object.assign(fetchHandler, {
       preconnect: () => {},
-    }) as typeof fetch,
+    }),
     callList,
   };
 }
@@ -55,10 +60,7 @@ describe('synthesizeSpeechWithElevenLabs', () => {
       'https://api.elevenlabs.io/v1/text-to-speech/voz-rioplatense?output_format=pcm_24000',
     );
     expect(callList[0].init.headers).toMatchObject({ 'xi-api-key': 'key-123' });
-    const requestBody = JSON.parse(callList[0].init.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = parseCapturedSynthesisRequestBody(callList[0]);
     expect(requestBody).toEqual({
       text: 'hola mundo',
       model_id: 'eleven_multilingual_v2',

--- a/apps/agent/src/voice/__tests__/llm.spec.ts
+++ b/apps/agent/src/voice/__tests__/llm.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import { buildOpenRouterSystemPrompt, chatWithOpenRouter } from '@/voice/llm';
 
@@ -7,13 +8,35 @@ type CapturedFetchCall = {
   readonly init: RequestInit;
 };
 
+type OpenRouterChatResponseFixture = {
+  readonly choices?: readonly {
+    readonly message: {
+      readonly content?: string | null;
+      readonly tool_calls?: readonly {
+        readonly id: string;
+        readonly function: {
+          readonly name: string;
+          readonly arguments: string;
+        };
+      }[];
+    };
+  }[];
+};
+
+const capturedChatRequestBodySchema = z.object({
+  model: z.string(),
+  stream: z.boolean().optional(),
+  tools: z.array(z.object({ function: z.object({ name: z.string() }) })).optional(),
+});
+
+function parseCapturedChatRequestBody(capturedCall: CapturedFetchCall) {
+  return capturedChatRequestBodySchema.parse(JSON.parse(String(capturedCall.init.body)));
+}
+
 function createCapturingFetchMock(
-  responseBody: unknown,
+  responseBody: OpenRouterChatResponseFixture,
   status = 200,
-): {
-  readonly fetchImplementation: typeof fetch;
-  readonly callList: CapturedFetchCall[];
-} {
+) {
   const callList: CapturedFetchCall[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -25,7 +48,24 @@ function createCapturingFetchMock(
   return {
     fetchImplementation: Object.assign(fetchHandler, {
       preconnect: () => {},
-    }) as typeof fetch,
+    }),
+    callList,
+  };
+}
+
+function createStreamingFetchMock(serverSentEventBody: string) {
+  const callList: CapturedFetchCall[] = [];
+  const fetchHandler = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    callList.push({ url: String(input), init: init ?? {} });
+    return new Response(serverSentEventBody, { status: 200 });
+  };
+  return {
+    fetchImplementation: Object.assign(fetchHandler, {
+      preconnect: () => {},
+    }),
     callList,
   };
 }
@@ -71,10 +111,7 @@ describe('chatWithOpenRouter', () => {
     expect(callList).toHaveLength(1);
     expect(callList[0].url).toBe('https://openrouter.ai/api/v1/chat/completions');
     expect(callList[0].init.headers).toMatchObject({ Authorization: 'Bearer key-123' });
-    const requestBody = JSON.parse(callList[0].init.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = parseCapturedChatRequestBody(callList[0]);
     expect(requestBody.model).toBe('deepseek/deepseek-v4-flash-0731');
     expect(requestBody.tools).toBeUndefined();
   });
@@ -94,9 +131,7 @@ describe('chatWithOpenRouter', () => {
       fetchImplementation,
     });
 
-    const requestBody = JSON.parse(callList[0].init.body as string) as {
-      tools?: readonly { function: { name: string } }[];
-    };
+    const requestBody = parseCapturedChatRequestBody(callList[0]);
     expect(requestBody.tools?.[0]?.function.name).toBe('weather_now');
   });
 
@@ -154,14 +189,7 @@ describe('chatWithOpenRouter', () => {
       'data: [DONE]',
       '',
     ].join('\n');
-    const callList: CapturedFetchCall[] = [];
-    const fetchImplementation = Object.assign(
-      async (input: string | URL | Request, init?: RequestInit) => {
-        callList.push({ url: String(input), init: init ?? {} });
-        return new Response(sseBody, { status: 200 });
-      },
-      { preconnect: () => {} },
-    ) as typeof fetch;
+    const { fetchImplementation, callList } = createStreamingFetchMock(sseBody);
 
     const deltaList: string[] = [];
     const result = await chatWithOpenRouter({
@@ -174,9 +202,7 @@ describe('chatWithOpenRouter', () => {
       fetchImplementation,
     });
 
-    const requestBody = JSON.parse(callList[0].init.body as string) as {
-      stream?: boolean;
-    };
+    const requestBody = parseCapturedChatRequestBody(callList[0]);
     expect(requestBody.stream).toBe(true);
     expect(deltaList).toEqual(['Hola ', 'mundo.']);
     expect(result.text).toBe('Hola mundo.');
@@ -189,10 +215,7 @@ describe('chatWithOpenRouter', () => {
       '',
       'data: {"choices":[{"delta":{"content":"mundo."}}]}',
     ].join('\n');
-    const fetchImplementation = Object.assign(
-      async () => new Response(sseBody, { status: 200 }),
-      { preconnect: () => {} },
-    ) as typeof fetch;
+    const { fetchImplementation } = createStreamingFetchMock(sseBody);
 
     const result = await chatWithOpenRouter({
       openRouterApiKey: 'key-123',
@@ -214,10 +237,7 @@ describe('chatWithOpenRouter', () => {
       'data: [DONE]',
       '',
     ].join('\n');
-    const fetchImplementation = Object.assign(
-      async () => new Response(sseBody, { status: 200 }),
-      { preconnect: () => {} },
-    ) as typeof fetch;
+    const { fetchImplementation } = createStreamingFetchMock(sseBody);
 
     const result = await chatWithOpenRouter({
       openRouterApiKey: 'key-123',

--- a/apps/agent/src/voice/__tests__/stream.spec.ts
+++ b/apps/agent/src/voice/__tests__/stream.spec.ts
@@ -11,19 +11,14 @@ function buildAudioBuffer(byteLength: number): ArrayBuffer {
   return new ArrayBuffer(byteLength);
 }
 
-function createRecordingSink(): {
-  readonly send: (chunk: ArrayBuffer) => void;
-  readonly wait: (milliseconds: number) => Promise<void>;
-  readonly sentByteLengthList: number[];
-  readonly waitMillisecondsList: number[];
-} {
+function createRecordingSink() {
   const sentByteLengthList: number[] = [];
   const waitMillisecondsList: number[] = [];
   return {
-    send: (chunk) => {
+    send: (chunk: ArrayBuffer): void => {
       sentByteLengthList.push(chunk.byteLength);
     },
-    wait: async (milliseconds) => {
+    wait: async (milliseconds: number): Promise<void> => {
       waitMillisecondsList.push(milliseconds);
     },
     sentByteLengthList,

--- a/apps/agent/src/voice/__tests__/stt.spec.ts
+++ b/apps/agent/src/voice/__tests__/stt.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
 import { transcribeAudioWithOpenRouter } from '@/voice/stt';
 
@@ -7,13 +8,25 @@ type CapturedFetchCall = {
   readonly init: RequestInit;
 };
 
+type TranscriptionResponseFixture = {
+  readonly text?: string | number;
+};
+
+const capturedTranscriptionRequestBodySchema = z.object({
+  language: z.string(),
+  input_audio: z.object({ data: z.string(), format: z.string() }),
+});
+
+function parseCapturedTranscriptionRequestBody(capturedCall: CapturedFetchCall) {
+  return capturedTranscriptionRequestBodySchema.parse(
+    JSON.parse(String(capturedCall.init.body)),
+  );
+}
+
 function createCapturingFetchMock(
-  responseBody: unknown,
+  responseBody: TranscriptionResponseFixture,
   status = 200,
-): {
-  readonly fetchImplementation: typeof fetch;
-  readonly callList: CapturedFetchCall[];
-} {
+) {
   const callList: CapturedFetchCall[] = [];
   const fetchHandler = async (
     input: string | URL | Request,
@@ -25,7 +38,7 @@ function createCapturingFetchMock(
   return {
     fetchImplementation: Object.assign(fetchHandler, {
       preconnect: () => {},
-    }) as typeof fetch,
+    }),
     callList,
   };
 }
@@ -45,10 +58,7 @@ describe('transcribeAudioWithOpenRouter', () => {
 
     expect(transcript).toBe('hola apolo');
     expect(callList[0].url).toBe('https://openrouter.ai/api/v1/audio/transcriptions');
-    const requestBody = JSON.parse(callList[0].init.body as string) as {
-      language: string;
-      input_audio: { data: string; format: string };
-    };
+    const requestBody = parseCapturedTranscriptionRequestBody(callList[0]);
     expect(requestBody.language).toBe('es');
     expect(requestBody.input_audio.format).toBe('wav');
     expect(requestBody.input_audio.data).toBe(btoa('\x01\x02\x03'));
@@ -66,10 +76,7 @@ describe('transcribeAudioWithOpenRouter', () => {
       fetchImplementation,
     });
 
-    const requestBody = JSON.parse(callList[0].init.body as string) as {
-      language: string;
-      input_audio: { format: string };
-    };
+    const requestBody = parseCapturedTranscriptionRequestBody(callList[0]);
     expect(requestBody.language).toBe('en');
     expect(requestBody.input_audio.format).toBe('mp3');
   });

--- a/apps/agent/src/voice/__tests__/ttscache.spec.ts
+++ b/apps/agent/src/voice/__tests__/ttscache.spec.ts
@@ -8,27 +8,34 @@ function buildArrayBuffer(byteList: readonly number[]): ArrayBuffer {
   return arrayBuffer;
 }
 
-function createFakeMediaBucket(): {
-  readonly bucket: R2Bucket;
-  readonly storedKeyList: string[];
-  readonly store: Map<string, ArrayBuffer>;
-} {
+const rejectCacheRead: R2Bucket['get'] = async () => {
+  throw new Error('R2 caído');
+};
+const rejectCacheWrite: R2Bucket['put'] = async () => {
+  throw new Error('R2 sin espacio');
+};
+const resolveCacheMiss: R2Bucket['get'] = async () => null;
+
+function createFakeMediaBucket() {
   const store = new Map<string, ArrayBuffer>();
   const storedKeyList: string[] = [];
+  // SAFETY: synthesizeSpeechThroughCache only calls get and put on the R2
+  // binding and only reads arrayBuffer from the stored object; the double
+  // covers exactly that surface.
   const bucket = {
-    get: async (key: string) => {
-      const stored = store.get(key);
+    get: async (objectKey: string) => {
+      const stored = store.get(objectKey);
       if (stored === undefined) {
         return null;
       }
       return { arrayBuffer: async () => stored };
     },
-    put: async (key: string, body: ArrayBuffer) => {
-      store.set(key, body);
-      storedKeyList.push(key);
+    put: async (objectKey: string, audioBody: ArrayBuffer) => {
+      store.set(objectKey, audioBody);
+      storedKeyList.push(objectKey);
       return {};
     },
-  } as unknown as R2Bucket;
+  } as R2Bucket;
   return { bucket, storedKeyList, store };
 }
 
@@ -79,14 +86,12 @@ describe('synthesizeSpeechThroughCache', () => {
   });
 
   it('degrades to direct synthesis when the cache read fails', async () => {
+    // SAFETY: synthesizeSpeechThroughCache only calls get and put on the R2
+    // binding; both members carry the real binding's signatures.
     const bucket = {
-      get: async () => {
-        throw new Error('R2 caído');
-      },
-      put: async () => {
-        throw new Error('R2 caído');
-      },
-    } as unknown as R2Bucket;
+      get: rejectCacheRead,
+      put: rejectCacheWrite,
+    } as R2Bucket;
 
     const audioBuffer = await synthesizeSpeechThroughCache({
       mediaBucket: bucket,
@@ -100,12 +105,12 @@ describe('synthesizeSpeechThroughCache', () => {
   });
 
   it('still returns audio when only the cache write fails', async () => {
+    // SAFETY: synthesizeSpeechThroughCache only calls get and put on the R2
+    // binding; both members carry the real binding's signatures.
     const bucket = {
-      get: async () => null,
-      put: async () => {
-        throw new Error('R2 sin espacio');
-      },
-    } as unknown as R2Bucket;
+      get: resolveCacheMiss,
+      put: rejectCacheWrite,
+    } as R2Bucket;
 
     const audioBuffer = await synthesizeSpeechThroughCache({
       mediaBucket: bucket,

--- a/apps/agent/src/voice/llm.ts
+++ b/apps/agent/src/voice/llm.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
 
+import {
+  jsonSerializableValueSchema,
+  type JsonSerializableValue,
+  type ToolDefinition,
+} from '@/tools/types';
+
 export type OpenRouterToolCall = {
   readonly id: string;
   readonly name: string;
-  readonly args: unknown;
+  readonly args: JsonSerializableValue;
 };
 
 export type OpenRouterChatMessage =
@@ -185,26 +191,34 @@ async function consumeOpenRouterStream(
 
   const toolCallList = [...partialToolCallMap.entries()]
     .toSorted(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
-    .map(([, partial]) => ({
-      id: partial.id,
-      name: partial.name,
-      args: JSON.parse(
-        partial.argumentsText === '' ? '{}' : partial.argumentsText,
-      ) as unknown,
-    }));
+    .map(([, partial]) => {
+      const parsedArguments = jsonSerializableValueSchema.parse(
+        JSON.parse(partial.argumentsText === '' ? '{}' : partial.argumentsText),
+      );
+      return { id: partial.id, name: partial.name, args: parsedArguments };
+    });
 
   return { text: fullText.trim(), toolCallList };
 }
+
+type OpenRouterChatRequestPayload = {
+  readonly model: string;
+  readonly messages: readonly OpenRouterChatMessage[];
+  tools?: readonly {
+    readonly type: 'function';
+    readonly function: Pick<ToolDefinition, 'name' | 'description' | 'parameters'>;
+  }[];
+  stream?: boolean;
+};
 
 export async function chatWithOpenRouter(input: {
   readonly openRouterApiKey: string;
   readonly modelId: string;
   readonly messageList: readonly OpenRouterChatMessage[];
-  readonly toolDefinitionList?: readonly {
-    readonly name: string;
-    readonly description: string;
-    readonly parameters: Record<string, unknown>;
-  }[];
+  readonly toolDefinitionList?: readonly Pick<
+    ToolDefinition,
+    'name' | 'description' | 'parameters'
+  >[];
   // When given, the request streams over SSE and every content delta lands here
   // as it arrives, so the caller can start speaking the first sentence while
   // the model is still writing the rest.
@@ -223,6 +237,17 @@ export async function chatWithOpenRouter(input: {
         }))
       : undefined;
 
+  const requestPayload: OpenRouterChatRequestPayload = {
+    model: input.modelId,
+    messages: input.messageList,
+  };
+  if (toolDefinitionPayloadList !== undefined) {
+    requestPayload.tools = toolDefinitionPayloadList;
+  }
+  if (input.onTextDelta !== undefined) {
+    requestPayload.stream = true;
+  }
+
   const fetchImplementation = input.fetchImplementation ?? globalThis.fetch;
   const response = await fetchImplementation(
     'https://openrouter.ai/api/v1/chat/completions',
@@ -232,14 +257,7 @@ export async function chatWithOpenRouter(input: {
         Authorization: `Bearer ${input.openRouterApiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        model: input.modelId,
-        messages: input.messageList,
-        ...(toolDefinitionPayloadList !== undefined
-          ? { tools: toolDefinitionPayloadList }
-          : {}),
-        ...(input.onTextDelta !== undefined ? { stream: true } : {}),
-      }),
+      body: JSON.stringify(requestPayload),
     },
   );
 
@@ -254,11 +272,12 @@ export async function chatWithOpenRouter(input: {
   const payload = openRouterChatResponseSchema.parse(await response.json());
   const message = payload.choices[0].message;
   const toolCallList =
-    message.tool_calls?.map((toolCall) => ({
-      id: toolCall.id,
-      name: toolCall.function.name,
-      args: JSON.parse(toolCall.function.arguments) as unknown,
-    })) ?? [];
+    message.tool_calls?.map((toolCall) => {
+      const parsedArguments = jsonSerializableValueSchema.parse(
+        JSON.parse(toolCall.function.arguments),
+      );
+      return { id: toolCall.id, name: toolCall.function.name, args: parsedArguments };
+    }) ?? [];
 
   return {
     text: message.content?.trim() ?? '',

--- a/apps/agent/src/weather/fetch.ts
+++ b/apps/agent/src/weather/fetch.ts
@@ -17,22 +17,22 @@ const openMeteoCurrentWeatherSchema = z.object({
   }),
 });
 
-const wmoWeatherCodeToSpanishLabelMap: Readonly<Record<number, string>> = {
-  0: 'Despejado',
-  1: 'Mayormente despejado',
-  2: 'Parcialmente nublado',
-  3: 'Nublado',
-  45: 'Niebla',
-  48: 'Niebla con escarcha',
-  51: 'Llovizna',
-  61: 'Lluvia',
-  71: 'Nieve',
-  80: 'Chubascos',
-  95: 'Tormenta',
-};
+const wmoWeatherCodeToSpanishLabelMap = new Map<number, string>([
+  [0, 'Despejado'],
+  [1, 'Mayormente despejado'],
+  [2, 'Parcialmente nublado'],
+  [3, 'Nublado'],
+  [45, 'Niebla'],
+  [48, 'Niebla con escarcha'],
+  [51, 'Llovizna'],
+  [61, 'Lluvia'],
+  [71, 'Nieve'],
+  [80, 'Chubascos'],
+  [95, 'Tormenta'],
+]);
 
 export function mapOpenMeteoWeatherCodeToSpanishLabel(weatherCode: number): string {
-  return wmoWeatherCodeToSpanishLabelMap[weatherCode] ?? 'Desconocido';
+  return wmoWeatherCodeToSpanishLabelMap.get(weatherCode) ?? 'Desconocido';
 }
 
 function buildOpenMeteoForecastUrl(latitude: number, longitude: number): string {

--- a/apps/agent/src/weather/location.ts
+++ b/apps/agent/src/weather/location.ts
@@ -22,7 +22,8 @@ export function parseStoredWeatherLocation(rawValue: string | null): DeskWeather
   }
 
   try {
-    return deskWeatherLocationSchema.parse(JSON.parse(rawValue) as unknown);
+    const storedLocationCandidate: unknown = JSON.parse(rawValue);
+    return deskWeatherLocationSchema.parse(storedLocationCandidate);
   } catch {
     return { ...DEFAULT_DESK_WEATHER_LOCATION };
   }

--- a/apps/agent/src/workflows/coding.ts
+++ b/apps/agent/src/workflows/coding.ts
@@ -4,6 +4,7 @@ import {
   type WorkflowStep,
 } from 'cloudflare:workers';
 import { getAgentByName } from 'agents';
+import type { z } from 'zod';
 
 import { runCodingAgent } from '@/coding/agent';
 import { buildCodingBranchName } from '@/coding/git';
@@ -35,6 +36,7 @@ import {
   redactSecretsFromText,
 } from '@/github/repository';
 import { chatWithOpenRouter } from '@/voice/llm';
+import type { notifyBackgroundResultInputSchema } from '@/agents/rpc';
 
 export type ApolloCodingParams = {
   readonly repository: string;
@@ -311,11 +313,16 @@ export class ApolloCoding extends WorkflowEntrypoint<Env, ApolloCodingParams> {
     documentKey?: string,
   ): Promise<void> {
     const apollo = await getAgentByName(this.env.Apollo, deviceId);
-    await apollo.notifyBackgroundResult({
+    const backgroundResultNotification: z.infer<
+      typeof notifyBackgroundResultInputSchema
+    > = {
       prompt: taskText,
       summary,
-      ...(documentKey !== undefined ? { documentKey } : {}),
-    });
+    };
+    if (documentKey !== undefined) {
+      backgroundResultNotification.documentKey = documentKey;
+    }
+    await apollo.notifyBackgroundResult(backgroundResultNotification);
   }
 }
 

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -4,9 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
-    <meta name="description" content="A personal desk agent." />
-    <meta property="og:title" content="Apollo Console" />
-    <meta property="og:description" content="A personal desk agent." />
+    <meta
+      name="description"
+      content="The management console for Apollo, a personal desk agent."
+    />
+    <meta property="og:title" content="Apollo | Console" />
+    <meta
+      property="og:description"
+      content="The management console for Apollo, a personal desk agent."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://apollo-console.galfre-vn.workers.dev" />
     <meta
@@ -19,7 +25,7 @@
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>Apollo Console</title>
+    <title>Apollo | Console</title>
   </head>
   <body>
     <!--

--- a/apps/console/src/agent/rpc.ts
+++ b/apps/console/src/agent/rpc.ts
@@ -16,13 +16,23 @@ import {
   weatherLocationSchema,
 } from '@/agent/schema';
 
-type AgentCall = (method: string, args?: unknown[]) => Promise<unknown>;
+type AgentWireValue =
+  | string
+  | number
+  | boolean
+  | null
+  | AgentWireValue[]
+  | { [key: string]: AgentWireValue | undefined };
+
+type AgentCall = (method: string, args?: AgentWireValue[]) => Promise<AgentWireValue>;
+
+type ConsoleCallPayload = Record<string, string | number | boolean | undefined>;
 
 export function createConsoleRpc(call: AgentCall, secret: string) {
   const invoke = async <Result>(
     method: string,
     resultSchema: z.ZodType<Result>,
-    payload?: Record<string, unknown>,
+    payload?: ConsoleCallPayload,
   ): Promise<Result> => {
     const rawResult = await call(method, [{ secret, ...payload }]);
     return resultSchema.parse(rawResult);

--- a/apps/console/src/blueprint/chip.tsx
+++ b/apps/console/src/blueprint/chip.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/components/utility';
 
 export type ChipTone = 'live' | 'idle' | 'busy' | 'down';
 
-const CHIP_TONE_CLASS_MAP: Record<ChipTone, { frame: string; dot: string }> = {
+const CHIP_TONE_CLASS_MAP = {
   live: {
     frame: 'border-border bg-accent text-foreground',
     dot: 'bg-foreground animate-[signal_2s_ease-in-out_infinite]',
@@ -19,7 +19,7 @@ const CHIP_TONE_CLASS_MAP: Record<ChipTone, { frame: string; dot: string }> = {
     frame: 'border-destructive/40 bg-transparent text-destructive',
     dot: 'bg-destructive',
   },
-};
+} satisfies Record<ChipTone, { readonly frame: string; readonly dot: string }>;
 
 export function Chip({
   tone,

--- a/apps/console/src/connection/screen.tsx
+++ b/apps/console/src/connection/screen.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { useConnection } from '@/connection/context';
 import { probeWorkerHealth } from '@/connection/probe';
 import { consoleConnectionSchema } from '@/connection/schema';
+import { useDocumentMetadata } from '@/router/metadata';
 
 const PROBE_ERROR_MESSAGE_MAP = {
   unreachable: 'Worker unreachable — check the URL and that the worker is deployed.',
@@ -15,6 +16,7 @@ const PROBE_ERROR_MESSAGE_MAP = {
 } as const;
 
 export function ConnectScreen() {
+  useDocumentMetadata(null);
   const { connect } = useConnection();
   const [workerUrl, setWorkerUrl] = useState('');
   const [deviceName, setDeviceName] = useState('desk');

--- a/apps/console/src/device/model.tsx
+++ b/apps/console/src/device/model.tsx
@@ -3,12 +3,20 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { useMemo, useRef } from 'react';
 import type { Mesh } from 'three';
 
-const SPEECH_MODE_ACCENT_MAP: Record<string, string> = {
+const SPEECH_MODE_ACCENT_MAP = {
   default: '#FFFFFF',
   nerd: '#F5C518',
   playful: '#C45C26',
   warm: '#B56B7A',
-};
+} satisfies Record<string, string>;
+
+type KnownSpeechModeId = keyof typeof SPEECH_MODE_ACCENT_MAP;
+
+function isKnownSpeechModeId(
+  candidateSpeechModeId: string,
+): candidateSpeechModeId is KnownSpeechModeId {
+  return candidateSpeechModeId in SPEECH_MODE_ACCENT_MAP;
+}
 
 const DEVICE_RADIUS = 1;
 const DEVICE_HEIGHT = 2;
@@ -238,7 +246,9 @@ export function DeviceModel({
   readonly speechModeId: string | undefined;
 }) {
   const accentColorHex =
-    SPEECH_MODE_ACCENT_MAP[speechModeId ?? 'default'] ?? SPEECH_MODE_ACCENT_MAP.default;
+    speechModeId !== undefined && isKnownSpeechModeId(speechModeId)
+      ? SPEECH_MODE_ACCENT_MAP[speechModeId]
+      : SPEECH_MODE_ACCENT_MAP.default;
   const prefersReducedMotion = useMemo(
     () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
     [],

--- a/apps/console/src/layout/nav.tsx
+++ b/apps/console/src/layout/nav.tsx
@@ -7,7 +7,7 @@ import { CONSOLE_ROUTE_LIST, navigateToRoute, useConsoleRoute } from '@/router/h
 import { ROUTE_LABEL_MAP } from '@/router/metadata';
 import type { ConsoleRoute } from '@/router/hash';
 
-export const ROUTE_ICON_MAP: Record<ConsoleRoute, IconType> = {
+export const ROUTE_ICON_MAP = {
   status: Icons.Status,
   device: Icons.Device,
   mcp: Icons.Mcp,
@@ -15,7 +15,7 @@ export const ROUTE_ICON_MAP: Record<ConsoleRoute, IconType> = {
   schedules: Icons.Schedules,
   history: Icons.History,
   jobs: Icons.Jobs,
-};
+} satisfies Record<ConsoleRoute, IconType>;
 
 function Rail({
   isExpanded,

--- a/apps/console/src/layout/nav.tsx
+++ b/apps/console/src/layout/nav.tsx
@@ -4,17 +4,8 @@ import { Icons } from '@/components/icons';
 import { cn } from '@/components/utility';
 import { useConnection } from '@/connection/context';
 import { CONSOLE_ROUTE_LIST, navigateToRoute, useConsoleRoute } from '@/router/hash';
+import { ROUTE_LABEL_MAP } from '@/router/metadata';
 import type { ConsoleRoute } from '@/router/hash';
-
-export const ROUTE_LABEL_MAP: Record<ConsoleRoute, string> = {
-  status: 'Status',
-  device: 'Device',
-  mcp: 'MCP',
-  memory: 'Memory',
-  schedules: 'Schedules',
-  history: 'History',
-  jobs: 'Jobs',
-};
 
 export const ROUTE_ICON_MAP: Record<ConsoleRoute, IconType> = {
   status: Icons.Status,

--- a/apps/console/src/layout/search.tsx
+++ b/apps/console/src/layout/search.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 
 import { Icons } from '@/components/icons';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-import { ROUTE_ICON_MAP, ROUTE_LABEL_MAP } from '@/layout/nav';
+import { ROUTE_ICON_MAP } from '@/layout/nav';
+import { ROUTE_LABEL_MAP } from '@/router/metadata';
 import { CONSOLE_ROUTE_LIST, navigateToRoute } from '@/router/hash';
 import type { ConsoleRoute } from '@/router/hash';
 

--- a/apps/console/src/layout/shell.tsx
+++ b/apps/console/src/layout/shell.tsx
@@ -14,6 +14,7 @@ import { Search } from '@/layout/search';
 import { McpPage } from '@/mcp/page';
 import { MemoryPage } from '@/memory/page';
 import { useConsoleRoute } from '@/router/hash';
+import { useDocumentMetadata } from '@/router/metadata';
 import { SchedulesPage } from '@/schedules/page';
 import { StatusPage } from '@/status/page';
 import type { ApolloAgentHandle } from '@/agent/hook';
@@ -39,6 +40,7 @@ export function Shell({ connection }: { readonly connection: ConsoleConnection }
   const { disconnect } = useConnection();
   const agent = useApolloAgent(connection);
   const activeRoute = useConsoleRoute();
+  useDocumentMetadata(activeRoute);
   const [isRailExpanded, setIsRailExpanded] = useState(false);
   const socketReadyState = useSocketReadyState(agent);
   const consoleRpc = useMemo(

--- a/apps/console/src/mcp/catalog.tsx
+++ b/apps/console/src/mcp/catalog.tsx
@@ -105,11 +105,11 @@ export const CONNECTOR_LIST: readonly ConnectorDefinition[] = [
   },
 ];
 
-const AUTH_HINT_LABEL_MAP: Record<ConnectorAuthKind, string | null> = {
+const AUTH_HINT_LABEL_MAP = {
   oauth: 'Sign in',
   token: 'Token',
   none: null,
-};
+} satisfies Record<ConnectorAuthKind, string | null>;
 
 export function ConnectorCatalog({
   installedUrlSet,

--- a/apps/console/src/router/metadata.ts
+++ b/apps/console/src/router/metadata.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+import type { ConsoleRoute } from '@/router/hash';
+
+export const ROUTE_LABEL_MAP: Record<ConsoleRoute, string> = {
+  status: 'Status',
+  device: 'Device',
+  mcp: 'MCP',
+  memory: 'Memory',
+  schedules: 'Schedules',
+  history: 'History',
+  jobs: 'Jobs',
+};
+
+export const ROUTE_DESCRIPTION_MAP: Record<ConsoleRoute, string> = {
+  status: 'Live agent status, device connectivity, and telemetry at a glance.',
+  device:
+    'The desk device in 3D, with mode, volume, brightness, and weather location controls.',
+  mcp: 'Installed MCP servers, their connection state, and per-tool enablement.',
+  memory: 'What the agent remembers — memories, owner facts, and lists.',
+  schedules: 'Scheduled reminders and running timers.',
+  history: 'Past conversations between the owner and the desk.',
+  jobs: 'Documents produced by research and coding runs.',
+};
+
+const BASE_DOCUMENT_TITLE = 'Apollo | Console';
+const BASE_DOCUMENT_DESCRIPTION =
+  'The management console for Apollo, a personal desk agent.';
+
+export function useDocumentMetadata(activeRoute: ConsoleRoute | null): void {
+  useEffect(() => {
+    document.title =
+      activeRoute === null
+        ? BASE_DOCUMENT_TITLE
+        : `${BASE_DOCUMENT_TITLE} | ${ROUTE_LABEL_MAP[activeRoute]}`;
+
+    const descriptionElement = document.querySelector('meta[name="description"]');
+    descriptionElement?.setAttribute(
+      'content',
+      activeRoute === null
+        ? BASE_DOCUMENT_DESCRIPTION
+        : ROUTE_DESCRIPTION_MAP[activeRoute],
+    );
+  }, [activeRoute]);
+}

--- a/apps/console/src/router/metadata.ts
+++ b/apps/console/src/router/metadata.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import type { ConsoleRoute } from '@/router/hash';
 
-export const ROUTE_LABEL_MAP: Record<ConsoleRoute, string> = {
+export const ROUTE_LABEL_MAP = {
   status: 'Status',
   device: 'Device',
   mcp: 'MCP',
@@ -10,9 +10,9 @@ export const ROUTE_LABEL_MAP: Record<ConsoleRoute, string> = {
   schedules: 'Schedules',
   history: 'History',
   jobs: 'Jobs',
-};
+} satisfies Record<ConsoleRoute, string>;
 
-export const ROUTE_DESCRIPTION_MAP: Record<ConsoleRoute, string> = {
+export const ROUTE_DESCRIPTION_MAP = {
   status: 'Live agent status, device connectivity, and telemetry at a glance.',
   device:
     'The desk device in 3D, with mode, volume, brightness, and weather location controls.',
@@ -21,7 +21,7 @@ export const ROUTE_DESCRIPTION_MAP: Record<ConsoleRoute, string> = {
   schedules: 'Scheduled reminders and running timers.',
   history: 'Past conversations between the owner and the desk.',
   jobs: 'Documents produced by research and coding runs.',
-};
+} satisfies Record<ConsoleRoute, string>;
 
 const BASE_DOCUMENT_TITLE = 'Apollo | Console';
 const BASE_DOCUMENT_DESCRIPTION =

--- a/apps/console/src/status/insights.tsx
+++ b/apps/console/src/status/insights.tsx
@@ -4,12 +4,22 @@ import { navigateToRoute } from '@/router/hash';
 import type { ApolloAgentState, ConsoleStatus } from '@/agent/schema';
 import type { ConsoleRoute } from '@/router/hash';
 
-type InsightSegment = string | { readonly label: string; readonly route?: ConsoleRoute };
+type InsightSegment =
+  | { readonly kind: 'plain'; readonly text: string }
+  | { readonly kind: 'highlight'; readonly label: string; readonly route?: ConsoleRoute };
 
 type Insight = {
   readonly id: string;
   readonly segmentList: readonly InsightSegment[];
 };
+
+function buildPlainSegment(text: string): InsightSegment {
+  return { kind: 'plain', text };
+}
+
+function buildHighlightSegment(label: string, route?: ConsoleRoute): InsightSegment {
+  return { kind: 'highlight', label, route };
+}
 
 function resolveGreetingLabel(hourOfDay: number): string {
   if (hourOfDay < 12) {
@@ -28,19 +38,24 @@ function buildInsightList(
   const insightList: Insight[] = [];
 
   if (status.isDeviceConnected) {
-    const deviceSegmentList: InsightSegment[] = ['The desk is ', { label: 'online' }];
+    const deviceSegmentList: InsightSegment[] = [
+      buildPlainSegment('The desk is '),
+      buildHighlightSegment('online'),
+    ];
     if (status.deviceConnectionCount > 1) {
-      deviceSegmentList.push(` with ${status.deviceConnectionCount} device links`);
+      deviceSegmentList.push(
+        buildPlainSegment(` with ${status.deviceConnectionCount} device links`),
+      );
     }
-    deviceSegmentList.push('.');
+    deviceSegmentList.push(buildPlainSegment('.'));
     insightList.push({ id: 'device', segmentList: deviceSegmentList });
   } else {
     insightList.push({
       id: 'device',
       segmentList: [
-        'The desk is ',
-        { label: 'offline' },
-        ' — telemetry pauses until it reconnects.',
+        buildPlainSegment('The desk is '),
+        buildHighlightSegment('offline'),
+        buildPlainSegment(' — telemetry pauses until it reconnects.'),
       ],
     });
   }
@@ -51,9 +66,11 @@ function buildInsightList(
     insightList.push({
       id: 'battery',
       segmentList: [
-        'Battery at ',
-        { label: `${batteryLevel}%` },
-        isCharging === undefined ? '.' : isCharging ? ', charging.' : ', on battery.',
+        buildPlainSegment('Battery at '),
+        buildHighlightSegment(`${batteryLevel}%`),
+        buildPlainSegment(
+          isCharging === undefined ? '.' : isCharging ? ', charging.' : ', on battery.',
+        ),
       ],
     });
   }
@@ -63,26 +80,34 @@ function buildInsightList(
     insightList.push({
       id: 'reminders',
       segmentList: [
-        'There ',
-        status.pendingReminderCount === 1 ? 'is ' : 'are ',
-        {
-          label: `${status.pendingReminderCount} ${reminderNoun}`,
-          route: 'schedules',
-        },
-        ' waiting to fire.',
+        buildPlainSegment('There '),
+        buildPlainSegment(status.pendingReminderCount === 1 ? 'is ' : 'are '),
+        buildHighlightSegment(
+          `${status.pendingReminderCount} ${reminderNoun}`,
+          'schedules',
+        ),
+        buildPlainSegment(' waiting to fire.'),
       ],
     });
   } else {
     insightList.push({
       id: 'reminders',
-      segmentList: ['Nothing on the ', { label: 'schedule', route: 'schedules' }, '.'],
+      segmentList: [
+        buildPlainSegment('Nothing on the '),
+        buildHighlightSegment('schedule', 'schedules'),
+        buildPlainSegment('.'),
+      ],
     });
   }
 
   if (agentState !== undefined && agentState.uiState !== 'idle') {
     insightList.push({
       id: 'agent',
-      segmentList: ['The agent is ', { label: agentState.uiState }, ' right now.'],
+      segmentList: [
+        buildPlainSegment('The agent is '),
+        buildHighlightSegment(agentState.uiState),
+        buildPlainSegment(' right now.'),
+      ],
     });
   }
 
@@ -90,8 +115,8 @@ function buildInsightList(
 }
 
 function InsightFragment({ segment }: { readonly segment: InsightSegment }) {
-  if (typeof segment === 'string') {
-    return segment;
+  if (segment.kind === 'plain') {
+    return segment.text;
   }
   const fragmentClass =
     'border-b border-dashed border-muted-foreground/40 text-foreground';

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,12 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "@oxlint/plugins": "1.78.0",
         "@types/bun": "latest",
         "@types/node": "^25.9.5",
         "lefthook": "^2.1.10",
         "oxfmt": "^0.47.0",
-        "oxlint": "^1.77.0",
+        "oxlint": "1.78.0",
         "turbo": "^2.5.0",
         "typescript": "^5.9.3",
       },
@@ -379,43 +380,45 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.47.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.78.0", "", { "os": "android", "cpu": "arm" }, "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.77.0", "", { "os": "android", "cpu": "arm64" }, "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.78.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.77.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.78.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.77.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.78.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.77.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.78.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.77.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.78.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.77.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.78.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.77.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.78.0", "", { "os": "none", "cpu": "arm64" }, "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.77.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.78.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.78.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.78.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.78.0", "", {}, "sha512-Ypt8KeRYw+4jUtlPirfcHWMrn5ms12VrrFPD+Mds477/7tJxG1Kcz2Yrg2nVcTQEUx/GdlhS+BUg1kmxNm04Ug=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -1363,7 +1366,7 @@
 
     "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 
-    "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
+    "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
 
     "p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,14 +20,15 @@
     "check": "bun run lint && bun run format:check && turbo run typecheck test"
   },
   "devDependencies": {
-    "turbo": "^2.5.0",
-    "typescript": "^5.9.3",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
+    "@oxlint/plugins": "1.78.0",
     "@types/bun": "latest",
     "@types/node": "^25.9.5",
     "lefthook": "^2.1.10",
     "oxfmt": "^0.47.0",
-    "oxlint": "^1.77.0"
+    "oxlint": "1.78.0",
+    "turbo": "^2.5.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { definePlugin } from '@oxlint/plugins';
+
+import { noChainedTypeAssertionsRule } from './rules/no-chained-type-assertions.ts';
+import { noConditionalEmptyObjectSpreadRule } from './rules/no-conditional-empty-object-spread.ts';
+import { noKnownValueWideningRule } from './rules/no-known-value-widening.ts';
+import { noModuleMockingRule } from './rules/no-module-mocking.ts';
+import { noObjectParametersRule } from './rules/no-object-parameters.ts';
+import { noReflectApplyRule } from './rules/no-reflect-apply.ts';
+import { noReflectGetRule } from './rules/no-reflect-get.ts';
+import { noRuntimeTypeofRule } from './rules/no-runtime-typeof.ts';
+import { noForbiddenTermInSymbolNamesRule } from './rules/no-shape-in-symbol-names.ts';
+import { noUnknownParametersRule } from './rules/no-unknown-parameters.ts';
+import { noUnknownReturnsRule } from './rules/no-unknown-returns.ts';
+import { noUnknownTypeAliasesRule } from './rules/no-unknown-type-aliases.ts';
+import { noUnsafeDictionaryTypeRule } from './rules/no-unsafe-dictionary-type.ts';
+import { noWidenThenAssertRule } from './rules/no-widen-then-assert.ts';
+import { requireSafetyCommentForTypeAssertionRule } from './rules/require-safety-comment-for-type-assertion.ts';
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = definePlugin({
+  meta: { name: 'anti-slop' },
+  rules: {
+    'no-chained-type-assertions': noChainedTypeAssertionsRule,
+    'no-conditional-empty-object-spread': noConditionalEmptyObjectSpreadRule,
+    'no-known-value-widening': noKnownValueWideningRule,
+    'no-module-mocking': noModuleMockingRule,
+    'no-object-parameters': noObjectParametersRule,
+    'no-reflect-apply': noReflectApplyRule,
+    'no-reflect-get': noReflectGetRule,
+    'no-runtime-typeof': noRuntimeTypeofRule,
+    'no-unsafe-dictionary-type': noUnsafeDictionaryTypeRule,
+    'no-shape-in-symbol-names': noForbiddenTermInSymbolNamesRule,
+    'no-unknown-parameters': noUnknownParametersRule,
+    'no-unknown-returns': noUnknownReturnsRule,
+    'no-unknown-type-aliases': noUnknownTypeAliasesRule,
+    'no-widen-then-assert': noWidenThenAssertRule,
+    'require-safety-comment-for-type-assertion': requireSafetyCommentForTypeAssertionRule,
+  },
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === 'TSAsExpression' || node.type === 'TSTypeAssertion';
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === 'ParenthesizedExpression') {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === 'TSTypeReference' &&
+    typeAnnotation.typeName.type === 'Identifier' &&
+    typeAnnotation.typeName.name === 'const'
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === 'ParenthesizedExpression' && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.',
+    },
+    messages: {
+      chained:
+        'This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.',
+    },
+  },
+  create(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: 'chained' });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === 'ParenthesizedExpression') {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === 'ObjectExpression' && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === 'ConditionalExpression' &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow object spreads that conditionally spread an empty object to omit fields.',
+    },
+    messages: {
+      avoid:
+        'This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.',
+    },
+  },
+  create(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== 'ObjectExpression') return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: 'avoid' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,255 @@
+import { defineRule } from '@oxlint/plugins';
+
+import {
+  classifyWideningTarget,
+  createTypeEnvironment,
+  isKnownEvidenceExpression,
+  type TypeEnvironment,
+  type WideningTarget,
+} from '../shared/dictionary-types.ts';
+
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSSatisfiesExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  if (variable.defs.length !== 1) return null;
+  const [definition] = variable.defs;
+  return definition?.type === 'Variable' && definition.node.type === 'VariableDeclarator'
+    ? definition.node
+    : null;
+}
+
+function isStableConstVariable(
+  variable: Variable,
+  declarator: ESTree.VariableDeclarator,
+): boolean {
+  return (
+    declarator.parent.type === 'VariableDeclaration' &&
+    declarator.parent.kind === 'const' &&
+    variable.references.every((reference) => reference.init || !reference.isWrite())
+  );
+}
+
+function hasKnownEvidence(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+  visitedVariables = new Set<Variable>(),
+): boolean {
+  if (isKnownEvidenceExpression(expression)) return true;
+  const unwrapped = unwrapExpression(expression);
+  if (unwrapped.type !== 'Identifier') return false;
+  const variable = resolveVariable(sourceCode, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return false;
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.init === null ||
+    !isStableConstVariable(variable, declarator)
+  ) {
+    return false;
+  }
+  visitedVariables.add(variable);
+  return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function annotationTarget(
+  annotation: ESTree.TSTypeAnnotation | null | undefined,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  return annotation === null || annotation === undefined
+    ? null
+    : classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (
+      current.type === 'ArrowFunctionExpression' ||
+      current.type === 'FunctionDeclaration' ||
+      current.type === 'FunctionExpression'
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+  if (key.type === 'Identifier' || key.type === 'PrivateIdentifier') return key.name;
+  if (key.type === 'Literal') return String(key.value);
+  return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+  if (owner === null) return 'anonymous function';
+  if (owner.id !== null) return owner.id.name;
+  const parent = owner.parent;
+  if (parent.type === 'VariableDeclarator' && parent.id.type === 'Identifier')
+    return parent.id.name;
+  if (parent.type === 'MethodDefinition') return sourceKeyName(sourceCode, parent.key);
+  return 'anonymous function';
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  return unwrapped.type === 'ObjectExpression' && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+  return (
+    destination.kind === 'open dictionary' || destination.kind === 'generic container'
+  );
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+  return (
+    node.parent?.type === 'TSAsExpression' || node.parent?.type === 'TSTypeAssertion'
+  );
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.',
+    },
+    messages: {
+      widening:
+        'The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.',
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+
+    const reportFlow = (
+      expression: ESTree.Expression,
+      destination: WideningTarget | null,
+      subject: string,
+    ) => {
+      if (destination === null) return;
+      if (
+        isDictionaryAccumulatorTarget(destination) &&
+        isEmptyObjectExpression(expression)
+      ) {
+        return;
+      }
+      if (!hasKnownEvidence(context.sourceCode, expression)) return;
+      context.report({
+        node: expression,
+        messageId: 'widening',
+        data: { subject, target: destination.kind },
+      });
+    };
+
+    const targetFromAnnotation = (
+      annotation: ESTree.TSTypeAnnotation | null | undefined,
+    ) => (environment === null ? null : annotationTarget(annotation, environment));
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      VariableDeclarator(node) {
+        if (node.init === null || node.id.type !== 'Identifier') return;
+        reportFlow(
+          node.init,
+          targetFromAnnotation(node.id.typeAnnotation),
+          `binding \`${node.id.name}\``,
+        );
+      },
+      PropertyDefinition(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AccessorProperty(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AssignmentExpression(node) {
+        if (node.operator !== '=' || node.left.type !== 'Identifier') return;
+        const variable = resolveVariable(context.sourceCode, node.left);
+        if (variable === null) return;
+        const declarator = variableDeclarator(variable);
+        if (declarator === null || declarator.id.type !== 'Identifier') return;
+        reportFlow(
+          node.right,
+          targetFromAnnotation(declarator.id.typeAnnotation),
+          `binding \`${declarator.id.name}\``,
+        );
+      },
+      ReturnStatement(node) {
+        if (node.argument === null) return;
+        const owner = enclosingFunction(node);
+        reportFlow(
+          node.argument,
+          targetFromAnnotation(owner?.returnType),
+          `return value of \`${functionName(context.sourceCode, owner)}\``,
+        );
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type === 'BlockStatement') return;
+        reportFlow(
+          node.body,
+          targetFromAnnotation(node.returnType),
+          `return value of \`${functionName(context.sourceCode, node)}\``,
+        );
+      },
+      TSAsExpression(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(
+          node.expression,
+          classifyWideningTarget(node.typeAnnotation, environment),
+          'assertion',
+        );
+      },
+      TSTypeAssertion(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(
+          node.expression,
+          classifyWideningTarget(node.typeAnnotation, environment),
+          'assertion',
+        );
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,99 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+const moduleMockMethods = new Set(['doMock', 'mock', 'unstable_mockModule']);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== 'ImportSpecifier') return null;
+  return node.imported.type === 'Identifier' ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== 'Identifier') return false;
+  if (
+    (expression.name === 'vi' || expression.name === 'jest') &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === 'vi' || expression.name === 'jest';
+  }
+  return variable.defs.some((definition) => {
+    if (
+      definition.type !== 'ImportBinding' ||
+      definition.parent?.type !== 'ImportDeclaration'
+    ) {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (
+      (source === 'vitest' && name === 'vi') ||
+      (source === '@jest/globals' && name === 'jest')
+    );
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!('property' in callee) || !('object' in callee) || !('computed' in callee))
+    return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === 'Literal' &&
+      (property.value === 'doMock' ||
+        property.value === 'mock' ||
+        property.value === 'unstable_mockModule')
+      ? property.value
+      : null
+    : property.type === 'Identifier'
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.',
+    },
+    messages: {
+      moduleMock:
+        'Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Super' || node.callee.type === 'V8IntrinsicExpression')
+          return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: 'moduleMock' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,141 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree, SourceCode } from '@oxlint/plugins';
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(
+  parameter: Parameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
+  return parameter.type === 'Identifier'
+    ? parameter.name
+    : sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, '');
+}
+
+function lexicalTypeParameterNames(node: ESTree.Node): ReadonlySet<string> {
+  const names = new Set<string>();
+  let current: ESTree.Node | null = node;
+  while (current !== null && current.type !== 'Program') {
+    if ('typeParameters' in current) {
+      for (const parameter of current.typeParameters?.params ?? []) {
+        names.add(parameter.name.name);
+      }
+    }
+    if (current.type === 'TSMappedType') names.add(current.key.name);
+    if (current.type === 'TSInferType') names.add(current.typeParameter.name.name);
+    current = current.parent;
+  }
+  return names;
+}
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.',
+    },
+    messages: {
+      objectParameter:
+        'Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.',
+    },
+  },
+  create(context) {
+    const aliases = new Map<string, ESTree.TSType>();
+
+    const resolvesToObject = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSObjectKeyword') return true;
+      if (type.type === 'TSParenthesizedType')
+        return resolvesToObject(type.typeAnnotation, shadowedAliases, visited);
+      if (type.type === 'TSUnionType') {
+        return type.types.some((member) =>
+          resolvesToObject(member, shadowedAliases, visited),
+        );
+      }
+      if (
+        type.type !== 'TSTypeReference' ||
+        type.typeName.type !== 'Identifier' ||
+        (type.typeArguments !== null &&
+          type.typeArguments !== undefined &&
+          type.typeArguments.params.length > 0) ||
+        visited.has(type.typeName.name) ||
+        shadowedAliases.has(type.typeName.name)
+      ) {
+        return false;
+      }
+      const alias = aliases.get(type.typeName.name);
+      if (alias === undefined) return false;
+      const nextVisited = new Set(visited);
+      nextVisited.add(type.typeName.name);
+      return resolvesToObject(alias, shadowedAliases, nextVisited);
+    };
+
+    const checkParameters = (node: ParameterOwner) => {
+      const shadowedAliases = lexicalTypeParameterNames(node);
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: 'objectParameter',
+          data: { parameter: parameterName(parameter, context.sourceCode) },
+        });
+      }
+    };
+
+    return {
+      Program(node) {
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === 'ExportNamedDeclaration'
+              ? statement.declaration
+              : statement;
+          if (
+            declaration?.type === 'TSTypeAliasDeclaration' &&
+            (declaration.typeParameters === null ||
+              declaration.typeParameters === undefined)
+          ) {
+            aliases.set(declaration.id.name, declaration.typeAnnotation);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,29 @@
+import { defineRule } from '@oxlint/plugins';
+
+import { isGlobalReflectMethodCall } from '../shared/reflect-method.ts';
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.',
+    },
+    messages: {
+      reflectApply:
+        'Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Super' || node.callee.type === 'V8IntrinsicExpression')
+          return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, 'apply')) {
+          context.report({ node, messageId: 'reflectApply' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,29 @@
+import { defineRule } from '@oxlint/plugins';
+
+import { isGlobalReflectMethodCall } from '../shared/reflect-method.ts';
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.',
+    },
+    messages: {
+      reflectGet:
+        'Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Super' || node.callee.type === 'V8IntrinsicExpression')
+          return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, 'get')) {
+          context.report({ node, messageId: 'reflectGet' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,25 @@
+import { defineRule } from '@oxlint/plugins';
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.',
+    },
+    messages: {
+      runtimeTypeof:
+        'A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.',
+    },
+  },
+  create(context) {
+    return {
+      UnaryExpression(node) {
+        if (node.operator === 'typeof') {
+          context.report({ node, messageId: 'runtimeTypeof' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,39 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+const FORBIDDEN_SYMBOL_NAME = 'shape';
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  create(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name)) return;
+      context.report({
+        node,
+        messageId: 'forbiddenSymbolName',
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,85 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(
+  parameter: Parameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceText: string): string {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterName(parameter.parameter, sourceText);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameterName(parameter.left, sourceText);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameterName(parameter.argument, sourceText);
+  }
+  return parameter.type === 'Identifier'
+    ? parameter.name
+    : sourceText.replace(/\s*:\s*unknown\s*$/u, '');
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.',
+    },
+    messages: {
+      unknownParameter:
+        'Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.',
+    },
+  },
+  create(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation?.typeAnnotation.type !== 'TSUnknownKeyword') continue;
+        const name = parameterName(parameter, context.sourceCode.getText(parameter));
+        if (name === 'cause') continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: 'unknownParameter',
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,123 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree } from '@oxlint/plugins';
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === 'TSParenthesizedType')
+    return referencedAliasName(type.typeAnnotation);
+  if (type.type !== 'TSTypeReference' || type.typeName.type !== 'Identifier') return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+function lexicalTypeParameterNames(node: ESTree.Node): ReadonlySet<string> {
+  const names = new Set<string>();
+  let current: ESTree.Node | null = node;
+  while (current !== null && current.type !== 'Program') {
+    if ('typeParameters' in current) {
+      for (const parameter of current.typeParameters?.params ?? []) {
+        names.add(parameter.name.name);
+      }
+    }
+    current = current.parent;
+  }
+  return names;
+}
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow functions whose explicit return contract is unknown or Promise<unknown>.',
+    },
+    messages: {
+      unknownReturn:
+        'This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.',
+    },
+  },
+  create(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSUnknownKeyword') return true;
+      if (type.type === 'TSParenthesizedType') {
+        return resolvesToUnknown(type.typeAnnotation, shadowedAliases, visited);
+      }
+      if (type.type === 'TSUnionType') {
+        return type.types.some((member) =>
+          resolvesToUnknown(member, shadowedAliases, visited),
+        );
+      }
+      if (
+        type.type === 'TSTypeReference' &&
+        type.typeName.type === 'Identifier' &&
+        (type.typeName.name === 'Promise' || type.typeName.name === 'PromiseLike')
+      ) {
+        const value = type.typeArguments?.params[0];
+        return value !== undefined && resolvesToUnknown(value, shadowedAliases, visited);
+      }
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name) || shadowedAliases.has(name)) return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, shadowedAliases, nextVisited);
+    };
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (!resolvesToUnknown(annotation.typeAnnotation, lexicalTypeParameterNames(node)))
+        return;
+      context.report({ node: annotation.typeAnnotation, messageId: 'unknownReturn' });
+    };
+
+    return {
+      Program(node) {
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === 'ExportNamedDeclaration'
+              ? statement.declaration
+              : statement;
+          if (declaration?.type === 'TSTypeAliasDeclaration') {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,76 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree } from '@oxlint/plugins';
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === 'TSParenthesizedType')
+    return referencedAliasName(type.typeAnnotation);
+  if (type.type !== 'TSTypeReference' || type.typeName.type !== 'Identifier') return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.',
+    },
+    messages: {
+      unknownAlias:
+        'Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.',
+    },
+  },
+  create(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSUnknownKeyword') return true;
+      if (type.type === 'TSParenthesizedType')
+        return resolvesToUnknown(type.typeAnnotation, visited);
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name)) return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, nextVisited);
+    };
+
+    return {
+      Program(node) {
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === 'ExportNamedDeclaration'
+              ? statement.declaration
+              : statement;
+          if (declaration?.type === 'TSTypeAliasDeclaration') {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+        for (const alias of aliases.values()) {
+          if (!resolvesToUnknown(alias.typeAnnotation, new Set([alias.id.name])))
+            continue;
+          context.report({
+            node: alias.id,
+            messageId: 'unknownAlias',
+            data: { alias: alias.id.name },
+          });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,139 @@
+import { defineRule } from '@oxlint/plugins';
+
+import {
+  classifyUnsafeDictionary,
+  classifyUnsafeDictionaryValue,
+  createTypeEnvironment,
+  type TypeEnvironment,
+} from '../shared/dictionary-types.ts';
+
+import type { ESTree } from '@oxlint/plugins';
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+  'JSDocNonNullableType',
+  'JSDocNullableType',
+  'JSDocUnknownType',
+  'TSAnyKeyword',
+  'TSArrayType',
+  'TSBigIntKeyword',
+  'TSBooleanKeyword',
+  'TSConditionalType',
+  'TSConstructorType',
+  'TSFunctionType',
+  'TSImportType',
+  'TSIndexedAccessType',
+  'TSInferType',
+  'TSIntersectionType',
+  'TSIntrinsicKeyword',
+  'TSLiteralType',
+  'TSMappedType',
+  'TSNamedTupleMember',
+  'TSNeverKeyword',
+  'TSNullKeyword',
+  'TSNumberKeyword',
+  'TSObjectKeyword',
+  'TSParenthesizedType',
+  'TSStringKeyword',
+  'TSSymbolKeyword',
+  'TSTemplateLiteralType',
+  'TSThisType',
+  'TSTupleType',
+  'TSTypeLiteral',
+  'TSTypeOperator',
+  'TSTypePredicate',
+  'TSTypeQuery',
+  'TSTypeReference',
+  'TSUndefinedKeyword',
+  'TSUnionType',
+  'TSUnknownKeyword',
+  'TSVoidKeyword',
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+  return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (current.type === 'TSTypeAliasDeclaration') return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function isPlainAliasConsumerUse(
+  node: ESTree.TSType,
+  environment: TypeEnvironment,
+): boolean {
+  if (node.type !== 'TSTypeReference' || node.typeArguments?.params.length) return false;
+  const name = typeReferenceName(node);
+  return (
+    name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node)
+  );
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+  if (isPlainAliasConsumerUse(node, environment)) return false;
+  if (classifyUnsafeDictionary(node, environment) === null) return false;
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+      return false;
+    current = current.parent;
+  }
+  return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.',
+    },
+    messages: {
+      unsafeDictionary:
+        "This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+    const report = (node: ESTree.Node, value: string) => {
+      context.report({ node, messageId: 'unsafeDictionary', data: { value } });
+    };
+    const reportIfUnsafe = (node: ESTree.TSType) => {
+      if (environment === null || !shouldReportType(node, environment)) return;
+      const unsafe = classifyUnsafeDictionary(node, environment);
+      if (unsafe === null) return;
+      report(node, unsafe.unsafeValue);
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      TSTypeReference: reportIfUnsafe,
+      TSTypeLiteral: reportIfUnsafe,
+      TSMappedType: reportIfUnsafe,
+      TSIndexSignature(node) {
+        if (
+          environment === null ||
+          node.typeAnnotation === null ||
+          node.parent.type === 'TSTypeLiteral'
+        )
+          return;
+        const unsafe = classifyUnsafeDictionaryValue(
+          node.typeAnnotation.typeAnnotation,
+          environment,
+        );
+        if (unsafe !== null) report(node, unsafe.unsafeValue);
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,386 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, Variable } from '@oxlint/plugins';
+
+type BroadTypeKind = 'top' | 'object' | 'record';
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'TSDeclareFunction',
+  'TSEmptyBodyFunctionExpression',
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === 'ParenthesizedExpression') current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === 'TSParenthesizedType') current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === 'TSUnknownKeyword' || unwrapped.type === 'TSAnyKeyword';
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === 'TSStringKeyword' ||
+    unwrapped.type === 'TSNumberKeyword' ||
+    unwrapped.type === 'TSSymbolKeyword'
+  ) {
+    return true;
+  }
+  if (unwrapped.type === 'TSUnionType')
+    return unwrapped.types.every(isBroadRecordKeyType);
+  return (
+    unwrapped.type === 'TSTypeReference' && typeReferenceName(unwrapped) === 'PropertyKey'
+  );
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === 'TSTypeReference') {
+    if (typeReferenceName(unwrapped) === 'Readonly') {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== 'Record') return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== 'TSTypeLiteral' || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === 'TSIndexSignature' ? member.parameters : [];
+  return (
+    member?.type === 'TSIndexSignature' &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === 'TSUnknownKeyword' || unwrapped.type === 'TSAnyKeyword')
+    return 'top';
+  if (unwrapped.type === 'TSObjectKeyword') return 'object';
+  return isBroadRecordType(unwrapped) ? 'record' : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === 'TSAsExpression' || unwrapped.type === 'TSTypeAssertion'
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, '');
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case 'TSArrayType':
+    case 'TSConstructorType':
+    case 'TSFunctionType':
+    case 'TSMappedType':
+    case 'TSObjectKeyword':
+    case 'TSTupleType':
+      return true;
+    case 'TSTypeLiteral':
+      return unwrapped.members.length > 0;
+    case 'TSIntersectionType':
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case 'TSTypeOperator':
+      return (
+        unwrapped.operator === 'readonly' &&
+        isDefinitelyObjectType(unwrapped.typeAnnotation)
+      );
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some((member) => member.type !== 'TSIndexSignature');
+  }
+
+  if (unwrapped.type !== 'TSTypeReference') return false;
+  if (typeReferenceName(unwrapped) === 'Readonly') {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== 'Record') return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 &&
+    parameters[1] !== undefined &&
+    !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === 'Variable' && definition.node.type === 'VariableDeclarator') {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === 'TSAsExpression' || unwrapped.type === 'TSTypeAssertion') {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === 'Literal' || unwrapped.type === 'TemplateLiteral') {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === 'ArrayExpression' ||
+    unwrapped.type === 'ArrowFunctionExpression' ||
+    unwrapped.type === 'ClassExpression' ||
+    unwrapped.type === 'FunctionExpression' ||
+    unwrapped.type === 'NewExpression' ||
+    unwrapped.type === 'ObjectExpression'
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== 'Identifier') return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) =>
+      identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (
+      functionBoundary(annotatedIdentifier) !== boundary ||
+      broadTypeKind(annotation) !== null
+    ) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== 'VariableDeclaration' ||
+    declarator.parent.kind !== 'const' ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== 'VariableDeclaration' ||
+    declarator.parent.kind !== 'const' ||
+    declarator.id.type !== 'Identifier' ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null
+      ? null
+      : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind =
+    declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(
+    originalExpression,
+    scopes,
+    boundary,
+    new Set([variable]),
+  );
+  return evidence === null
+    ? null
+    : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === 'top') return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === 'object') return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.',
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  create(context) {
+    const scopes = context.sourceCode.scopeManager.scopes;
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== 'Identifier') return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'widenThenAssert',
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,65 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree, SourceCode } from '@oxlint/plugins';
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const commentOwnerKinds = new Set([
+  'ExpressionStatement',
+  'PropertyDefinition',
+  'ReturnStatement',
+  'ThrowStatement',
+  'VariableDeclaration',
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === 'TSTypeReference' &&
+    node.typeAnnotation.typeName.type === 'Identifier' &&
+    node.typeAnnotation.typeName.name === 'const'
+  );
+}
+
+function hasSafetyComment(sourceCode: SourceCode, node: TypeAssertion): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (
+      sourceCode
+        .getCommentsBefore(current)
+        .some(
+          (comment) => comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value),
+        )
+    ) {
+      return true;
+    }
+    if (commentOwnerKinds.has(current.type) || current.parent.type === 'Program')
+      return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.',
+    },
+    messages: {
+      missingSafetyComment:
+        'This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.',
+    },
+  },
+  create(context) {
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node) || hasSafetyComment(context.sourceCode, node)) return;
+      context.report({ node, messageId: 'missingSafetyComment' });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,522 @@
+import type { ESTree } from '@oxlint/plugins';
+
+const BUILT_INS = new Set([
+  'Record',
+  'Readonly',
+  'Partial',
+  'Required',
+  'Pick',
+  'Omit',
+  'PropertyKey',
+  'NonNullable',
+]);
+const TRANSPARENT_WRAPPERS = new Set(['Readonly', 'Partial', 'Required', 'NonNullable']);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+  readonly type: ESTree.TSType;
+  readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+  readonly kind: 'unsafe-dictionary';
+  readonly unsafeValue: 'any' | 'empty-object' | 'object' | 'union' | 'unknown';
+};
+
+export type WideningTargetKind =
+  | 'anonymous object'
+  | 'generic container'
+  | 'object'
+  | 'open dictionary'
+  | 'unknown';
+
+export type WideningTarget = {
+  readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+  readonly aliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration>;
+  readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+  readonly shadowedBuiltIns: ReadonlySet<string>;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+  return statement.type === 'ExportNamedDeclaration' ||
+    statement.type === 'ExportDefaultDeclaration'
+    ? (statement.declaration ?? null)
+    : statement;
+}
+
+export function createTypeEnvironment(program: ESTree.Program): TypeEnvironment {
+  const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+  const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+  const shadowedBuiltIns = new Set<string>();
+
+  for (const statement of program.body) {
+    const declaration = declaredStatement(statement);
+    if (declaration?.type === 'ImportDeclaration') {
+      for (const specifier of declaration.specifiers) {
+        if (BUILT_INS.has(specifier.local.name))
+          shadowedBuiltIns.add(specifier.local.name);
+      }
+      continue;
+    }
+
+    if (declaration?.type === 'TSTypeAliasDeclaration') {
+      const existing = aliases.get(declaration.id.name);
+      if (existing === undefined) aliases.set(declaration.id.name, declaration);
+      else shadowedBuiltIns.add(declaration.id.name);
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === 'TSInterfaceDeclaration') {
+      const declarations = interfaces.get(declaration.id.name) ?? [];
+      declarations.push(declaration);
+      interfaces.set(declaration.id.name, declarations);
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === 'TSEnumDeclaration') {
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (
+      (declaration?.type === 'ClassDeclaration' ||
+        declaration?.type === 'FunctionDeclaration') &&
+      declaration.id !== null
+    ) {
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+    }
+  }
+
+  return { aliases, interfaces, shadowedBuiltIns };
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
+  return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  return (
+    unwrapped.type === 'TSTypeReference' &&
+    typeReferenceName(unwrapped) === name &&
+    (unwrapped.typeArguments === null ||
+      unwrapped.typeArguments === undefined ||
+      unwrapped.typeArguments.params.length === 0)
+  );
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (
+    current.type === 'TSParenthesizedType' ||
+    (current.type === 'TSTypeOperator' && current.operator === 'readonly')
+  ) {
+    current = current.typeAnnotation;
+  }
+  return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+  return unwrapTransparentType(type).type === 'TSNeverKeyword';
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+  return (
+    member.type === 'TSPropertySignature' &&
+    member.optional === true &&
+    member.typeAnnotation !== null &&
+    member.typeAnnotation !== undefined &&
+    isNeverType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+  return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+  declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+  if (declarations.length !== 1) return false;
+  const [type] = declarations;
+  return (
+    type !== undefined &&
+    type.extends.length === 0 &&
+    (type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+  );
+}
+
+function resolvedSubstitutionArgument(
+  type: ESTree.TSType,
+  base: TypeAliasEnvironment,
+  resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type !== 'TSTypeReference') return type;
+  const name = typeReferenceName(unwrapped);
+  if (name === null || resolving.has(name)) return type;
+  const substitution = base.get(name);
+  if (substitution === undefined) return type;
+  const nextResolving = new Set(resolving);
+  nextResolving.add(name);
+  return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+  alias: ESTree.TSTypeAliasDeclaration,
+  type: ESTree.TSTypeReference,
+  base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+  const parameters = alias.typeParameters?.params ?? [];
+  const arguments_ = type.typeArguments?.params ?? [];
+  const next = new Map(base);
+  for (const [index, parameter] of parameters.entries()) {
+    const argument = arguments_[index] ?? parameter.default;
+    if (argument === null || argument === undefined) return null;
+    next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+  }
+  return next;
+}
+
+function unsafeDirectValue(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary['unsafeValue'] | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return 'unknown';
+  if (unwrapped.type === 'TSAnyKeyword') return 'any';
+  if (unwrapped.type === 'TSObjectKeyword') return 'object';
+  if (unwrapped.type === 'TSTypeLiteral' && isEffectivelyEmptyTypeLiteral(unwrapped))
+    return 'empty-object';
+  if (unwrapped.type === 'TSUnionType') {
+    return unwrapped.types.some(
+      (member) =>
+        unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+    )
+      ? 'union'
+      : null;
+  }
+  if (unwrapped.type === 'TSIntersectionType') {
+    const unsafeMembers = unwrapped.types.map((member) =>
+      unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+    );
+    if (unsafeMembers.includes('any')) return 'any';
+    return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+      ? unsafeMembers[0]
+      : null;
+  }
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+  }
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+  }
+  const interfaceDeclarations = environment.interfaces.get(name);
+  if (interfaceDeclarations !== undefined) {
+    return isEffectivelyEmptyInterface(interfaceDeclarations) ? 'empty-object' : null;
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return unsafeDirectValue(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+function dictionaryValueTypes(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+  const unwrapped = unwrapTransparentType(type);
+
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+      member.type === 'TSIndexSignature' && member.typeAnnotation !== null
+        ? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+        : [],
+    );
+  }
+
+  if (unwrapped.type === 'TSMappedType') {
+    return unwrapped.typeAnnotation === null
+      ? []
+      : [{ type: unwrapped.typeAnnotation, substitutions }];
+  }
+
+  if (unwrapped.type !== 'TSTypeReference') return [];
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return [];
+
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? []
+      : dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+  }
+
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? []
+      : dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+  }
+
+  if (name === 'Record' && isBuiltIn(name, environment)) {
+    const value = unwrapped.typeArguments?.params[1] ?? null;
+    return value === null ? [] : [{ type: value, substitutions }];
+  }
+
+  if ((name === 'Pick' || name === 'Omit') && isBuiltIn(name, environment)) {
+    const source = unwrapped.typeArguments?.params[0];
+    return source === undefined
+      ? []
+      : dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+  }
+
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return [];
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return [];
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return dictionaryValueTypes(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+export function classifyUnsafeDictionaryValue(
+  valueType: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+  return unsafeValue === null ? null : { kind: 'unsafe-dictionary', unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+    const unsafeValue = unsafeDirectValue(
+      valueType.type,
+      environment,
+      valueType.substitutions,
+      new Set(),
+    );
+    if (unsafeValue !== null) return { kind: 'unsafe-dictionary', unsafeValue };
+  }
+  return null;
+}
+
+function resolvesToDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): boolean {
+  return (
+    dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0
+  );
+}
+
+export function classifyWideningTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return { kind: 'unknown' };
+  if (unwrapped.type === 'TSObjectKeyword') return { kind: 'object' };
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some((member) => member.type === 'TSIndexSignature')
+      ? { kind: 'open dictionary' }
+      : unwrapped.members.length > 0
+        ? { kind: 'anonymous object' }
+        : null;
+  }
+  if (unwrapped.type === 'TSMappedType') return { kind: 'open dictionary' };
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+  }
+  if (name === 'Record' && isBuiltIn(name, environment))
+    return { kind: 'open dictionary' };
+  const alias = environment.aliases.get(name);
+  if (alias === undefined) return null;
+  if ((alias.typeParameters?.params.length ?? 0) > 0) {
+    const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+    return substitutions !== null &&
+      resolvesToDictionary(
+        alias.typeAnnotation,
+        environment,
+        substitutions,
+        new Set([name]),
+      )
+      ? { kind: 'generic container' }
+      : null;
+  }
+  const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+  if (substitutions === null) return null;
+  const resolved = classifyAliasBroadTarget(
+    alias.typeAnnotation,
+    environment,
+    substitutions,
+    new Set([name]),
+  );
+  return resolved;
+}
+
+function isBroadMappedKey(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  if (
+    unwrapped.type === 'TSStringKeyword' ||
+    unwrapped.type === 'TSNumberKeyword' ||
+    unwrapped.type === 'TSSymbolKeyword'
+  ) {
+    return true;
+  }
+  if (unwrapped.type === 'TSUnionType') {
+    return unwrapped.types.every((member) =>
+      isBroadMappedKey(member, environment, substitutions),
+    );
+  }
+  if (unwrapped.type !== 'TSTypeReference') return false;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return false;
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+    return isBroadMappedKey(substitution, environment, substitutions);
+  }
+  return name === 'PropertyKey' && isBuiltIn(name, environment);
+}
+
+function classifyAliasBroadTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return { kind: 'unknown' };
+  if (unwrapped.type === 'TSObjectKeyword') return { kind: 'object' };
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some((member) => member.type === 'TSIndexSignature')
+      ? { kind: 'open dictionary' }
+      : null;
+  }
+  if (unwrapped.type === 'TSMappedType') {
+    return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+      ? { kind: 'open dictionary' }
+      : null;
+  }
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : classifyAliasBroadTarget(
+          substitution,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+  }
+  if (name === 'Record' && isBuiltIn(name, environment)) {
+    return { kind: 'open dictionary' };
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return classifyAliasBroadTarget(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current.type === 'ObjectExpression' && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression' ||
+    current.type === 'TSSatisfiesExpression'
+  ) {
+    current = current.expression;
+  }
+  if (current.type === 'ObjectExpression') return true;
+  return (
+    current.type === 'ArrayExpression' ||
+    current.type === 'ArrowFunctionExpression' ||
+    current.type === 'ClassExpression' ||
+    current.type === 'FunctionExpression' ||
+    current.type === 'NewExpression' ||
+    current.type === 'Literal' ||
+    current.type === 'TemplateLiteral' ||
+    current.type === 'UnaryExpression'
+  );
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,36 @@
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== 'Identifier' || expression.name !== 'Reflect') return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!('property' in callee) || !('object' in callee) || !('computed' in callee))
+    return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === 'Literal' && property.value === methodName
+    : property.type === 'Identifier' && property.name === methodName;
+}


### PR DESCRIPTION
## Summary

- Vendors the **anti-slop** Oxlint jsPlugin at `tools/oxlint/anti-slop/` and enables all 15 rules at `error` in `.oxlintrc.json`; upgrades `oxlint` and `@oxlint/plugins` to 1.78.0.
- Fixes **all 346 findings** across both workspaces — no suppressions, no disable comments, no `any`:
  - LLM/MCP tool arguments are now parsed at the boundary into a `JsonSerializableValue`/`ToolArgumentRecord` contract owned by `apps/agent/src/tools/types.ts`; `ToolHandler`, `ToolDefinition`, the router, and `callInstalledMcpTool` carry concrete types instead of `unknown`. The MCP adapter's argument schema stays deliberately shallow so the self-referencing-record guard keeps working.
  - `Record<string, unknown>` dictionaries became named or schema-derived contracts (SQL row types, fixture types, wire types); test doubles are concretely typed, with only a handful of irreducible assertions left, each carrying a `SAFETY:` invariant.
  - Conditional empty-object spreads became stepwise-built typed locals; runtime `typeof` narrowing became schema parses, `instanceof`, or presence checks; widened annotations became inference + `satisfies`.
- Also carries the route-aware console document titles/descriptions commit.

Supersedes #48, which contained only the `apps/agent/src/tools/` slice of this work.

## Verification

`bun run check` passes end to end: zero lint findings repo-wide, formatting clean, both workspaces typecheck, 572 agent tests + 15 console tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmwFXWf4EJMGXNE2Czw4sF