### PR TITLE
feat: migrate to heyapollo.dev and style the landing static pre-render

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -11,7 +11,7 @@ import { ApolloCoding } from '@/workflows/coding';
 
 export { Apollo, ApolloBackground, ApolloCoding, Sandbox };
 
-// The console at console.apollodevice.com probes /health cross-origin before
+// The console at heyapollo.dev/console probes /health cross-origin before
 // opening the agent WebSocket; auth is the query token, never a cookie, so a
 // wildcard origin does not widen what the token already gates.
 const CONSOLE_CORS_HEADER_MAP = {

--- a/apps/agent/wrangler.jsonc
+++ b/apps/agent/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-08-05",
   "compatibility_flags": ["nodejs_compat"],
+  "routes": [{ "pattern": "agent.heyapollo.dev", "custom_domain": true }],
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,

--- a/apps/agent/wrangler.jsonc
+++ b/apps/agent/wrangler.jsonc
@@ -5,6 +5,9 @@
   "compatibility_date": "2026-08-05",
   "compatibility_flags": ["nodejs_compat"],
   "routes": [{ "pattern": "agent.heyapollo.dev", "custom_domain": true }],
+  // Keep the workers.dev host alive until every device has reconnected through
+  // the custom domain; flashed firmware carries the old wss URL until then.
+  "workers_dev": true,
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -10,22 +10,10 @@
       name="description"
       content="El cerebro open source para dispositivos agénticos físicos: voz, memoria, agenda y herramientas, corriendo en tu propia cuenta de Cloudflare."
     />
-    <link rel="canonical" href="https://apollo-console.galfre-vn.workers.dev/" />
-    <link
-      rel="alternate"
-      hreflang="es"
-      href="https://apollo-console.galfre-vn.workers.dev/"
-    />
-    <link
-      rel="alternate"
-      hreflang="en"
-      href="https://apollo-console.galfre-vn.workers.dev/en"
-    />
-    <link
-      rel="alternate"
-      hreflang="x-default"
-      href="https://apollo-console.galfre-vn.workers.dev/"
-    />
+    <link rel="canonical" href="https://heyapollo.dev/" />
+    <link rel="alternate" hreflang="es" href="https://heyapollo.dev/" />
+    <link rel="alternate" hreflang="en" href="https://heyapollo.dev/en" />
+    <link rel="alternate" hreflang="x-default" href="https://heyapollo.dev/" />
     <meta property="og:site_name" content="Apollo" />
     <meta property="og:locale" content="es_LA" />
     <meta property="og:locale:alternate" content="en_US" />
@@ -35,11 +23,8 @@
       content="Tu agente personal de escritorio. Un cerebro en tu cuenta de Cloudflare, un cuerpo en tu escritorio, nada en el medio."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://apollo-console.galfre-vn.workers.dev/" />
-    <meta
-      property="og:image"
-      content="https://apollo-console.galfre-vn.workers.dev/og.png"
-    />
+    <meta property="og:url" content="https://heyapollo.dev/" />
+    <meta property="og:image" content="https://heyapollo.dev/og.png" />
     <meta property="og:image:width" content="2400" />
     <meta property="og:image:height" content="1260" />
     <meta
@@ -52,10 +37,7 @@
       name="twitter:description"
       content="Tu agente personal de escritorio. Un cerebro en tu cuenta de Cloudflare, un cuerpo en tu escritorio, nada en el medio."
     />
-    <meta
-      name="twitter:image"
-      content="https://apollo-console.galfre-vn.workers.dev/og.png"
-    />
+    <meta name="twitter:image" content="https://heyapollo.dev/og.png" />
     <meta
       name="twitter:image:alt"
       content="La cara de Apollo: dos ojos de cápsula sobre una pantalla oscura."
@@ -85,29 +67,29 @@
         "@graph": [
           {
             "@type": "WebSite",
-            "@id": "https://apollo-console.galfre-vn.workers.dev/#website",
-            "url": "https://apollo-console.galfre-vn.workers.dev/",
+            "@id": "https://heyapollo.dev/#website",
+            "url": "https://heyapollo.dev/",
             "name": "Apollo",
             "inLanguage": ["es", "en"]
           },
           {
             "@type": "SoftwareApplication",
-            "@id": "https://apollo-console.galfre-vn.workers.dev/#software",
+            "@id": "https://heyapollo.dev/#software",
             "name": "Apollo",
             "description": "El cerebro open source para dispositivos agénticos físicos: voz, memoria, agenda y herramientas, corriendo en tu propia cuenta de Cloudflare.",
-            "url": "https://apollo-console.galfre-vn.workers.dev/",
-            "image": "https://apollo-console.galfre-vn.workers.dev/og.png",
+            "url": "https://heyapollo.dev/",
+            "image": "https://heyapollo.dev/og.png",
             "applicationCategory": "DeveloperApplication",
             "operatingSystem": "Cloudflare Workers",
             "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
             "license": "https://github.com/galfrevn/apollo/blob/main/LICENSE",
             "sameAs": ["https://github.com/galfrevn/apollo"],
             "featureList": "Turnos de voz, Memoria, Recordatorios, Respuestas en vivo, Agente de código, Tus herramientas",
-            "author": { "@id": "https://apollo-console.galfre-vn.workers.dev/#author" }
+            "author": { "@id": "https://heyapollo.dev/#author" }
           },
           {
             "@type": "Person",
-            "@id": "https://apollo-console.galfre-vn.workers.dev/#author",
+            "@id": "https://heyapollo.dev/#author",
             "name": "Valentín Galfre",
             "url": "https://github.com/galfrevn"
           }

--- a/apps/console/public/llms.txt
+++ b/apps/console/public/llms.txt
@@ -17,8 +17,8 @@ Apollo tiene licencia MIT y es gratis. El cerebro se despliega con un comando a 
 
 - [Repositorio](https://github.com/galfrevn/apollo)
 - [Documentación](https://github.com/galfrevn/apollo/tree/main/documentation)
-- [Landing en español](https://apollo-console.galfre-vn.workers.dev/)
-- [Consola](https://apollo-console.galfre-vn.workers.dev/console)
+- [Landing en español](https://heyapollo.dev/)
+- [Consola](https://heyapollo.dev/console)
 
 ## English
 
@@ -28,4 +28,4 @@ Apollo is MIT licensed and free. The brain deploys with one command to your own 
 
 Capabilities: voice turns tuned for a desk device, memory recalled by meaning (Vectorize), reminders that fire on the device itself, live answers condensed from web research, a sandboxed coding agent for repository work, and your own services connected over MCP.
 
-- [English landing](https://apollo-console.galfre-vn.workers.dev/en)
+- [English landing](https://heyapollo.dev/en)

--- a/apps/console/public/robots.txt
+++ b/apps/console/public/robots.txt
@@ -26,4 +26,4 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
-Sitemap: https://apollo-console.galfre-vn.workers.dev/sitemap.xml
+Sitemap: https://heyapollo.dev/sitemap.xml

--- a/apps/console/public/sitemap.xml
+++ b/apps/console/public/sitemap.xml
@@ -4,41 +4,41 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml"
 >
   <url>
-    <loc>https://apollo-console.galfre-vn.workers.dev/</loc>
+    <loc>https://heyapollo.dev/</loc>
     <lastmod>2026-08-13</lastmod>
     <xhtml:link
       rel="alternate"
       hreflang="es"
-      href="https://apollo-console.galfre-vn.workers.dev/"
+      href="https://heyapollo.dev/"
     />
     <xhtml:link
       rel="alternate"
       hreflang="en"
-      href="https://apollo-console.galfre-vn.workers.dev/en"
+      href="https://heyapollo.dev/en"
     />
     <xhtml:link
       rel="alternate"
       hreflang="x-default"
-      href="https://apollo-console.galfre-vn.workers.dev/"
+      href="https://heyapollo.dev/"
     />
   </url>
   <url>
-    <loc>https://apollo-console.galfre-vn.workers.dev/en</loc>
+    <loc>https://heyapollo.dev/en</loc>
     <lastmod>2026-08-13</lastmod>
     <xhtml:link
       rel="alternate"
       hreflang="es"
-      href="https://apollo-console.galfre-vn.workers.dev/"
+      href="https://heyapollo.dev/"
     />
     <xhtml:link
       rel="alternate"
       hreflang="en"
-      href="https://apollo-console.galfre-vn.workers.dev/en"
+      href="https://heyapollo.dev/en"
     />
     <xhtml:link
       rel="alternate"
       hreflang="x-default"
-      href="https://apollo-console.galfre-vn.workers.dev/"
+      href="https://heyapollo.dev/"
     />
   </url>
 </urlset>

--- a/apps/console/scripts/discovery.ts
+++ b/apps/console/scripts/discovery.ts
@@ -1,17 +1,40 @@
-import { mkdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 
+import {
+  collectLandingPreloadPathList,
+  injectModulePreloadLinkList,
+  LANDING_PAGE_MANIFEST_KEY,
+  parseBuildManifest,
+} from '@/landing/preload';
 import { buildConsoleDocument, buildLandingDocument } from '@/landing/static';
 import { CONSOLE_ROUTE_LIST } from '@/router/route';
 
 const distDirectoryUrl = new URL('../dist/', import.meta.url);
 const templateFileUrl = new URL('index.html', distDirectoryUrl);
+const manifestDirectoryUrl = new URL('.vite/', distDirectoryUrl);
 
 const templateHtml = await Bun.file(templateFileUrl).text();
+const buildManifest = parseBuildManifest(
+  await Bun.file(new URL('manifest.json', manifestDirectoryUrl)).json(),
+);
+const landingPreloadPathList = collectLandingPreloadPathList(
+  buildManifest,
+  LANDING_PAGE_MANIFEST_KEY,
+);
 
-await Bun.write(templateFileUrl, buildLandingDocument(templateHtml, 'es'));
+await Bun.write(
+  templateFileUrl,
+  injectModulePreloadLinkList(
+    buildLandingDocument(templateHtml, 'es'),
+    landingPreloadPathList,
+  ),
+);
 await Bun.write(
   new URL('en.html', distDirectoryUrl),
-  buildLandingDocument(templateHtml, 'en'),
+  injectModulePreloadLinkList(
+    buildLandingDocument(templateHtml, 'en'),
+    landingPreloadPathList,
+  ),
 );
 
 const consoleDocumentHtml = buildConsoleDocument(templateHtml);
@@ -23,6 +46,8 @@ for (const consoleRoute of CONSOLE_ROUTE_LIST) {
     consoleDocumentHtml,
   );
 }
+
+await rm(manifestDirectoryUrl, { recursive: true, force: true });
 
 process.stdout.write(
   `discovery: wrote index.html, en.html, and ${CONSOLE_ROUTE_LIST.length + 1} console shells\n`,

--- a/apps/console/src/landing/__tests__/discovery.spec.ts
+++ b/apps/console/src/landing/__tests__/discovery.spec.ts
@@ -91,19 +91,21 @@ describe('landing document generation', () => {
     for (const locale of ['es', 'en'] as const) {
       const staticBlock = renderLandingStaticBlock(locale);
       const landingMessages = LANDING_MESSAGE_CATALOG[locale];
-      expect(staticBlock).toContain('<h1>');
+      expect(staticBlock).toContain('<h1 ');
+      expect(staticBlock).toContain('font-serif');
       expect(staticBlock).toContain(landingMessages.hero.subhead);
       expect(staticBlock).toContain(landingMessages.showcase.actTitle);
       expect(staticBlock).toContain(landingMessages.architecture.actTitle);
       expect(staticBlock).toContain(landingMessages.capabilities.actTitle);
       expect(staticBlock).toContain(landingMessages.yours.actTitle);
       for (const capabilityRow of landingMessages.capabilities.capabilityRowList) {
-        expect(staticBlock).toContain(`<h3>${capabilityRow.name}</h3>`);
+        expect(staticBlock).toContain(`${capabilityRow.name}</h3>`);
         expect(staticBlock).toContain(capabilityRow.description);
       }
       for (const ownershipCard of landingMessages.yours.ownershipCardList) {
-        expect(staticBlock).toContain(`<h3>${ownershipCard.label}</h3>`);
+        expect(staticBlock).toContain(`${ownershipCard.label}</h3>`);
       }
+      expect(staticBlock).toContain('<h3 class=');
       expect(staticBlock).toContain(LANDING_REPOSITORY_URL);
     }
   });
@@ -127,7 +129,7 @@ describe('landing document generation', () => {
     const consoleDocument = buildConsoleDocument(templateHtml);
     expect(consoleDocument).toContain('<meta name="robots" content="noindex" />');
     expect(consoleDocument).not.toContain(LANDING_STATIC_OPEN_MARKER);
-    expect(consoleDocument).not.toContain('<h1>');
+    expect(consoleDocument).not.toContain('<h1');
   });
 });
 

--- a/apps/console/src/landing/__tests__/preload.spec.ts
+++ b/apps/console/src/landing/__tests__/preload.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  collectLandingPreloadPathList,
+  injectModulePreloadLinkList,
+  parseBuildManifest,
+} from '@/landing/preload';
+
+const fakeBuildManifest = parseBuildManifest({
+  'src/landing/page.tsx': {
+    file: 'assets/page-abc123.js',
+    imports: ['_shared-def456.js', '_motion-ghi789.js'],
+  },
+  '_shared-def456.js': {
+    file: 'assets/shared-def456.js',
+    imports: ['_motion-ghi789.js'],
+  },
+  '_motion-ghi789.js': {
+    file: 'assets/motion-ghi789.js',
+  },
+  'src/main.tsx': {
+    file: 'assets/index-entry00.js',
+    imports: ['_shared-def456.js'],
+  },
+});
+
+describe('landing preload path collection', () => {
+  it('walks imports transitively from the landing entry without duplicates', () => {
+    const preloadPathList = collectLandingPreloadPathList(
+      fakeBuildManifest,
+      'src/landing/page.tsx',
+    );
+    expect(preloadPathList).toEqual([
+      '/assets/page-abc123.js',
+      '/assets/shared-def456.js',
+      '/assets/motion-ghi789.js',
+    ]);
+  });
+
+  it('throws when the landing entry is missing from the manifest', () => {
+    expect(() =>
+      collectLandingPreloadPathList(fakeBuildManifest, 'src/landing/missing.tsx'),
+    ).toThrow('Build manifest drift');
+  });
+});
+
+describe('modulepreload injection', () => {
+  it('inserts links for unreferenced paths before the head close tag', () => {
+    const documentHtml = '<html><head><title>Apollo</title></head><body></body></html>';
+    const injectedDocument = injectModulePreloadLinkList(documentHtml, [
+      '/assets/page-abc123.js',
+    ]);
+    expect(injectedDocument).toContain(
+      '<link rel="modulepreload" crossorigin href="/assets/page-abc123.js" /></head>',
+    );
+  });
+
+  it('skips paths the document already references', () => {
+    const documentHtml =
+      '<html><head><link rel="modulepreload" href="/assets/shared-def456.js" /></head><body></body></html>';
+    const injectedDocument = injectModulePreloadLinkList(documentHtml, [
+      '/assets/shared-def456.js',
+      '/assets/page-abc123.js',
+    ]);
+    expect(injectedDocument).toContain('href="/assets/page-abc123.js"');
+    expect(injectedDocument.match(/shared-def456\.js/g)).toHaveLength(1);
+  });
+
+  it('throws when the document has no head close tag', () => {
+    expect(() => injectModulePreloadLinkList('<html><body></body></html>', [])).toThrow(
+      'Discovery template drift',
+    );
+  });
+});

--- a/apps/console/src/landing/origin.ts
+++ b/apps/console/src/landing/origin.ts
@@ -1,3 +1,3 @@
-export const LANDING_PUBLIC_ORIGIN = 'https://apollo-console.galfre-vn.workers.dev';
+export const LANDING_PUBLIC_ORIGIN = 'https://heyapollo.dev';
 
 export const LANDING_REPOSITORY_URL = 'https://github.com/galfrevn/apollo';

--- a/apps/console/src/landing/preload.ts
+++ b/apps/console/src/landing/preload.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+export const LANDING_PAGE_MANIFEST_KEY = 'src/landing/page.tsx';
+
+const buildManifestChunkSchema = z.object({
+  file: z.string(),
+  imports: z.array(z.string()).optional(),
+});
+
+const buildManifestSchema = z.record(z.string(), buildManifestChunkSchema);
+
+export type BuildManifest = z.infer<typeof buildManifestSchema>;
+
+export function parseBuildManifest(rawManifest: unknown): BuildManifest {
+  return buildManifestSchema.parse(rawManifest);
+}
+
+export function collectLandingPreloadPathList(
+  buildManifest: BuildManifest,
+  entryManifestKey: string,
+): readonly string[] {
+  const landingEntryChunk = buildManifest[entryManifestKey];
+  if (landingEntryChunk === undefined) {
+    throw new Error(`Build manifest drift: missing entry "${entryManifestKey}"`);
+  }
+  const visitedManifestKeySet = new Set<string>();
+  const preloadPathList: string[] = [];
+  const pendingManifestKeyList = [entryManifestKey];
+  while (pendingManifestKeyList.length > 0) {
+    const currentManifestKey = pendingManifestKeyList.shift();
+    if (
+      currentManifestKey === undefined ||
+      visitedManifestKeySet.has(currentManifestKey)
+    ) {
+      continue;
+    }
+    visitedManifestKeySet.add(currentManifestKey);
+    const currentChunk = buildManifest[currentManifestKey];
+    if (currentChunk === undefined) {
+      continue;
+    }
+    preloadPathList.push(`/${currentChunk.file}`);
+    pendingManifestKeyList.push(...(currentChunk.imports ?? []));
+  }
+  return preloadPathList;
+}
+
+export function injectModulePreloadLinkList(
+  documentHtml: string,
+  preloadPathList: readonly string[],
+): string {
+  const headCloseTag = '</head>';
+  if (!documentHtml.includes(headCloseTag)) {
+    throw new Error('Discovery template drift: missing </head>');
+  }
+  const missingPathList = preloadPathList.filter(
+    (preloadPath) => !documentHtml.includes(preloadPath),
+  );
+  if (missingPathList.length === 0) {
+    return documentHtml;
+  }
+  const preloadLinkList = missingPathList
+    .map(
+      (preloadPath) => `<link rel="modulepreload" crossorigin href="${preloadPath}" />`,
+    )
+    .join('');
+  return documentHtml.replace(headCloseTag, `${preloadLinkList}${headCloseTag}`);
+}

--- a/apps/console/src/landing/static.ts
+++ b/apps/console/src/landing/static.ts
@@ -44,37 +44,37 @@ function renderEmphasizedParagraph(paragraph: {
   const leadText = escapeHtmlText(paragraph.lead);
   const emphasisText = escapeHtmlText(paragraph.emphasis);
   const trailText = escapeHtmlText(paragraph.trail);
-  return `<p>${leadText}<em>${emphasisText}</em>${trailText}</p>`;
+  return `<p class="mt-4 leading-relaxed text-muted-foreground">${leadText}<em class="not-italic text-foreground">${emphasisText}</em>${trailText}</p>`;
 }
 
 function renderCapabilityList(landingMessages: LandingMessages): string {
   const capabilityItemList = landingMessages.capabilities.capabilityRowList.map(
     (capabilityRow) =>
-      `<li><h3>${escapeHtmlText(capabilityRow.name)}</h3><p>${escapeHtmlText(capabilityRow.description)}</p></li>`,
+      `<li><h3 class="text-base">${escapeHtmlText(capabilityRow.name)}</h3><p class="mt-1 text-sm text-muted-foreground">${escapeHtmlText(capabilityRow.description)}</p></li>`,
   );
-  return `<ul>${capabilityItemList.join('')}</ul>`;
+  return `<ul class="mt-6 space-y-5">${capabilityItemList.join('')}</ul>`;
 }
 
 function renderOwnershipList(landingMessages: LandingMessages): string {
   const ownershipItemList = landingMessages.yours.ownershipCardList.map(
     (ownershipCard) =>
-      `<li><h3>${escapeHtmlText(ownershipCard.label)}</h3><p>${escapeHtmlText(ownershipCard.description)}</p></li>`,
+      `<li><h3 class="text-base">${escapeHtmlText(ownershipCard.label)}</h3><p class="mt-1 text-sm text-muted-foreground">${escapeHtmlText(ownershipCard.description)}</p></li>`,
   );
-  const docsItem = `<li><h3>${escapeHtmlText(landingMessages.yours.docsCardLabel)}</h3><p>${escapeHtmlText(landingMessages.yours.docsCardDescription)}</p><p><a href="${LANDING_LINK_MAP.documentation}">${escapeHtmlText(landingMessages.yours.docsCardAction)}</a></p></li>`;
-  const consoleItem = `<li><h3>${escapeHtmlText(landingMessages.yours.consoleCardLabel)}</h3><p>${escapeHtmlText(landingMessages.yours.consoleCardDescription)}</p><p><a href="${LANDING_LINK_MAP.console}">${escapeHtmlText(landingMessages.yours.consoleCardAction)}</a></p></li>`;
-  return `<ul>${ownershipItemList.join('')}${docsItem}${consoleItem}</ul>`;
+  const docsItem = `<li><h3 class="text-base">${escapeHtmlText(landingMessages.yours.docsCardLabel)}</h3><p class="mt-1 text-sm text-muted-foreground">${escapeHtmlText(landingMessages.yours.docsCardDescription)}</p><p class="mt-1 text-sm"><a class="underline underline-offset-4" href="${LANDING_LINK_MAP.documentation}">${escapeHtmlText(landingMessages.yours.docsCardAction)}</a></p></li>`;
+  const consoleItem = `<li><h3 class="text-base">${escapeHtmlText(landingMessages.yours.consoleCardLabel)}</h3><p class="mt-1 text-sm text-muted-foreground">${escapeHtmlText(landingMessages.yours.consoleCardDescription)}</p><p class="mt-1 text-sm"><a class="underline underline-offset-4" href="${LANDING_LINK_MAP.console}">${escapeHtmlText(landingMessages.yours.consoleCardAction)}</a></p></li>`;
+  return `<ul class="mt-6 space-y-5">${ownershipItemList.join('')}${docsItem}${consoleItem}</ul>`;
 }
 
 export function renderLandingStaticBlock(locale: Locale): string {
   const landingMessages = LANDING_MESSAGE_CATALOG[locale];
   const heroHeading = `${escapeHtmlText(landingMessages.hero.lineOne)} ${escapeHtmlText(landingMessages.hero.lineTwo)}`;
-  const navigation = `<nav aria-label="Apollo"><a href="${LANDING_LINK_MAP.github}">${escapeHtmlText(landingMessages.nav.githubLabel)}</a> <a href="${LANDING_LINK_MAP.documentation}">${escapeHtmlText(landingMessages.nav.docsLabel)}</a> <a href="${LANDING_LINK_MAP.console}">${escapeHtmlText(landingMessages.nav.openConsoleLabel)}</a></nav>`;
-  const hero = `<header><h1>${heroHeading}</h1><p>${escapeHtmlText(landingMessages.hero.subhead)}</p></header>`;
-  const showcaseSection = `<section><h2>${escapeHtmlText(landingMessages.showcase.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.showcase.intro)}</section>`;
-  const architectureSection = `<section><h2>${escapeHtmlText(landingMessages.architecture.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.architecture.intro)}<p>${escapeHtmlText(landingMessages.architecture.bodyNodeHeadline)} ${escapeHtmlText(landingMessages.architecture.brainNodeHeadline)}</p></section>`;
-  const capabilitiesSection = `<section><h2>${escapeHtmlText(landingMessages.capabilities.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.capabilities.intro)}${renderCapabilityList(landingMessages)}</section>`;
-  const yoursSection = `<section><h2>${escapeHtmlText(landingMessages.yours.actTitle)}</h2><p>${escapeHtmlText(landingMessages.yours.introLead)}<em>${escapeHtmlText(landingMessages.yours.introEmphasis)}</em></p>${renderOwnershipList(landingMessages)}</section>`;
-  const footer = `<footer><p>${escapeHtmlText(landingMessages.footer.echoWordList.join(' '))}. ${escapeHtmlText(landingMessages.footer.wakePhrase)}</p><p>${escapeHtmlText(landingMessages.footer.builtByPrefix)}<a href="https://github.com/galfrevn">Valentín Galfre</a></p></footer>`;
+  const navigation = `<nav aria-label="Apollo" class="flex flex-wrap gap-6 text-sm text-muted-foreground"><a class="underline underline-offset-4" href="${LANDING_LINK_MAP.github}">${escapeHtmlText(landingMessages.nav.githubLabel)}</a> <a class="underline underline-offset-4" href="${LANDING_LINK_MAP.documentation}">${escapeHtmlText(landingMessages.nav.docsLabel)}</a> <a class="underline underline-offset-4" href="${LANDING_LINK_MAP.console}">${escapeHtmlText(landingMessages.nav.openConsoleLabel)}</a></nav>`;
+  const hero = `<header class="mt-14"><h1 class="font-serif text-5xl leading-[1.05] tracking-[-0.02em]">${heroHeading}</h1><p class="mt-6 max-w-[44ch] text-sm text-muted-foreground">${escapeHtmlText(landingMessages.hero.subhead)}</p></header>`;
+  const showcaseSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.showcase.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.showcase.intro)}</section>`;
+  const architectureSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.architecture.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.architecture.intro)}<p class="mt-4 leading-relaxed text-muted-foreground">${escapeHtmlText(landingMessages.architecture.bodyNodeHeadline)} ${escapeHtmlText(landingMessages.architecture.brainNodeHeadline)}</p></section>`;
+  const capabilitiesSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.capabilities.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.capabilities.intro)}${renderCapabilityList(landingMessages)}</section>`;
+  const yoursSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.yours.actTitle)}</h2><p class="mt-4 leading-relaxed text-muted-foreground">${escapeHtmlText(landingMessages.yours.introLead)}<em class="not-italic text-foreground">${escapeHtmlText(landingMessages.yours.introEmphasis)}</em></p>${renderOwnershipList(landingMessages)}</section>`;
+  const footer = `<footer class="mt-20 border-t pt-8 text-sm text-muted-foreground"><p>${escapeHtmlText(landingMessages.footer.echoWordList.join(' '))}. ${escapeHtmlText(landingMessages.footer.wakePhrase)}</p><p class="mt-2">${escapeHtmlText(landingMessages.footer.builtByPrefix)}<a class="underline underline-offset-4" href="https://github.com/galfrevn">Valentín Galfre</a></p></footer>`;
   return `<div class="mx-auto max-w-3xl px-6 py-16">${navigation}<main>${hero}${showcaseSection}${architectureSection}${capabilitiesSection}${yoursSection}</main>${footer}</div>`;
 }
 

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -5,6 +5,9 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  build: {
+    manifest: true,
+  },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/apps/console/wrangler.jsonc
+++ b/apps/console/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "apollo-console",
   "compatibility_date": "2026-08-05",
+  "routes": [{ "pattern": "heyapollo.dev", "custom_domain": true }],
   "assets": {
     "directory": "./dist",
     "not_found_handling": "404-page",

--- a/apps/console/wrangler.jsonc
+++ b/apps/console/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "apollo-console",
   "compatibility_date": "2026-08-05",
   "routes": [{ "pattern": "heyapollo.dev", "custom_domain": true }],
+  "workers_dev": true,
   "assets": {
     "directory": "./dist",
     "not_found_handling": "404-page",

--- a/documentation/console/product.md
+++ b/documentation/console/product.md
@@ -8,7 +8,7 @@ web
 
 ## Stack
 
-Vite + React 19, Tailwind v4 + shadcn/ui, deployed as an assets-only Cloudflare Worker at apollo-console.galfre-vn.workers.dev. (console.apollodevice.com is the planned domain once it is acquired; the social meta in `index.html` and the discovery files point at the workers.dev host until then — the origin is pinned in `src/landing/origin.ts` and the discovery spec enumerates every touchpoint for the migration.) Discovery infrastructure — prerendered bilingual landing documents, robots/sitemap/llms.txt, structured data, real 404s — is documented in [Landing](landing.md).
+Vite + React 19, Tailwind v4 + shadcn/ui, deployed as an assets-only Cloudflare Worker at heyapollo.dev (the agent worker lives at agent.heyapollo.dev; the origin is pinned in `src/landing/origin.ts` and the discovery spec enumerates every touchpoint, so a future migration starts there). Discovery infrastructure — prerendered bilingual landing documents, robots/sitemap/llms.txt, structured data, real 404s — is documented in [Landing](landing.md).
 
 ## Users
 


### PR DESCRIPTION
## Domain migration

- `agent.heyapollo.dev` → agent worker, `heyapollo.dev` → console worker (landing at `/`, console stays at `/console`), via `custom_domain` routes in both `wrangler.jsonc` files.
- Every pinned origin follows: `LANDING_PUBLIC_ORIGIN`, `index.html` (canonical, hreflang, og/twitter, JSON-LD), `sitemap.xml`, `robots.txt`, `llms.txt`, plus the stale CORS comment and `documentation/console/product.md`.
- The `apollo.example.workers.dev` placeholder in the connect screen is untouched on purpose — it describes a self-hoster's own worker URL.

## Landing FOUC fix

The unstyled first paint was the crawler-readable static block rendering classless under Tailwind Preflight until React finished a two-hop JS waterfall.

- `src/landing/static.ts` now emits the block fully styled — first paint is a clean typographic pre-render of the landing.
- New `src/landing/preload.ts` + `build.manifest: true`: the discovery script walks the Vite manifest from the landing chunk and injects `modulepreload` links into the landing documents only, removing the second network hop. `dist/.vite/` is deleted after so the manifest is never served.
- Discovery spec updated for the classed markup; new `preload.spec.ts` covers the manifest walk and head injection.

## Deploy notes

The domain was purchased on Cloudflare Registrar, so the zone is already active — `wrangler deploy` provisions both custom domains and certs on the first deploy after merge. Post-merge, out-of-repo: update the firmware repo's `APOLLO_SERVER_URL` secret to `wss://agent.heyapollo.dev` (old workers.dev host keeps working until devices reconnect once through the new domain), re-register MCP OAuth redirect URIs, add the Search Console property, and re-scrape social cards.

## Verification

- `bun run check` green (lint, format, typecheck, tests)
- `bun run build` in `apps/console`: styled static block and `page-*`/`icons-*` preloads present in `dist/index.html` + `dist/en.html`; console shells unchanged; no `dist/.vite/`
- `wrangler deploy --dry-run` accepts both configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsLoJsijoJacvLi91aYfbu

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates Apollo’s public landing and agent endpoints to `heyapollo.dev` and improves the landing page’s initial static render.
- Adds Cloudflare custom-domain routes while retaining workers.dev compatibility.
- Updates canonical, discovery, social, and documentation URLs.
- Styles the static landing markup and injects module preloads derived from Vite’s manifest.
- Adds focused tests for manifest traversal and preload injection.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20galfrevn%2Fapollo%20PR%20%2353%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=galfrevn%2Fapollo&pr=53&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix: keep workers.dev hosts enabled duri..."](https://github.com/galfrevn/apollo/commit/4cb0f8ca2fad189000ce969c40c1063710f95218) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52975830)</sub>

<!-- /greptile_comment -->