### PR TITLE
fix(console): hide the landing pre-render from scripted browsers

### DIFF
--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -2,6 +2,11 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
+    <!-- Stamped before first paint so the crawler-facing static block stays
+         visible only when scripting is unavailable; see index.css. -->
+    <script>
+      document.documentElement.setAttribute('data-scripting', '');
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <meta name="theme-color" content="#0d0d0d" />

--- a/apps/console/src/index.css
+++ b/apps/console/src/index.css
@@ -53,6 +53,13 @@
     color-scheme: dark;
   }
 
+  /* Crawlers and no-JS readers get the prerendered landing block; humans with
+     scripting see a quiet background until React mounts, never a content swap.
+     main.tsx removes the attribute if the landing chunk fails to load. */
+  html[data-scripting] [data-landing-static] {
+    display: none;
+  }
+
   body {
     background-color: var(--color-background);
     color: var(--color-foreground);

--- a/apps/console/src/landing/__tests__/discovery.spec.ts
+++ b/apps/console/src/landing/__tests__/discovery.spec.ts
@@ -59,6 +59,7 @@ describe('landing discovery template', () => {
     expect(templateHtml).toContain(LANDING_SOCIAL_DESCRIPTION_MAP.es);
     expect(templateHtml).toContain(LANDING_STATIC_OPEN_MARKER);
     expect(templateHtml).toContain(LANDING_STATIC_CLOSE_MARKER);
+    expect(templateHtml).toContain("setAttribute('data-scripting', '')");
     expect(templateHtml).not.toContain('THESIS:');
   });
 
@@ -92,6 +93,7 @@ describe('landing document generation', () => {
       const staticBlock = renderLandingStaticBlock(locale);
       const landingMessages = LANDING_MESSAGE_CATALOG[locale];
       expect(staticBlock).toContain('<h1 ');
+      expect(staticBlock).toContain('data-landing-static');
       expect(staticBlock).toContain('font-serif');
       expect(staticBlock).toContain(landingMessages.hero.subhead);
       expect(staticBlock).toContain(landingMessages.showcase.actTitle);

--- a/apps/console/src/landing/static.ts
+++ b/apps/console/src/landing/static.ts
@@ -75,7 +75,7 @@ export function renderLandingStaticBlock(locale: Locale): string {
   const capabilitiesSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.capabilities.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.capabilities.intro)}${renderCapabilityList(landingMessages)}</section>`;
   const yoursSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.yours.actTitle)}</h2><p class="mt-4 leading-relaxed text-muted-foreground">${escapeHtmlText(landingMessages.yours.introLead)}<em class="not-italic text-foreground">${escapeHtmlText(landingMessages.yours.introEmphasis)}</em></p>${renderOwnershipList(landingMessages)}</section>`;
   const footer = `<footer class="mt-20 border-t pt-8 text-sm text-muted-foreground"><p>${escapeHtmlText(landingMessages.footer.echoWordList.join(' '))}. ${escapeHtmlText(landingMessages.footer.wakePhrase)}</p><p class="mt-2">${escapeHtmlText(landingMessages.footer.builtByPrefix)}<a class="underline underline-offset-4" href="https://github.com/galfrevn">Valentín Galfre</a></p></footer>`;
-  return `<div class="mx-auto max-w-3xl px-6 py-16">${navigation}<main>${hero}${showcaseSection}${architectureSection}${capabilitiesSection}${yoursSection}</main>${footer}</div>`;
+  return `<div data-landing-static class="mx-auto max-w-3xl px-6 py-16">${navigation}<main>${hero}${showcaseSection}${architectureSection}${capabilitiesSection}${yoursSection}</main>${footer}</div>`;
 }
 
 function replaceExactlyOnce(

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -14,13 +14,20 @@ const surface = resolveSurfaceFromLocation(
   window.location.hash,
 );
 
-// The template ships crawler-readable landing markup inside #root; mounting only
-// after the surface module resolves keeps that markup visible until React can
-// replace it with the live tree.
+// The template ships crawler-readable landing markup inside #root, hidden by
+// index.css whenever the data-scripting attribute is present; if the landing
+// chunk never arrives, dropping the attribute reveals that markup as fallback.
 if (surface.kind === 'redirect') {
   window.location.replace(surface.targetUrl);
 } else if (surface.kind === 'landing') {
-  const { LandingPage } = await import('@/landing/page');
+  let landingModule: typeof import('@/landing/page');
+  try {
+    landingModule = await import('@/landing/page');
+  } catch (importFailure) {
+    document.documentElement.removeAttribute('data-scripting');
+    throw importFailure;
+  }
+  const { LandingPage } = landingModule;
   createRoot(rootElement).render(
     <LocaleProvider
       localeOverride={surface.localeOverride}


### PR DESCRIPTION
The styled static block from #53 removed the *unstyled* flash but still produced a visible content swap: the typographic pre-render painted first, then React replaced it with the animated landing.

This eliminates the swap for humans while keeping the markup for crawlers:

- A tiny inline script in `<head>` stamps `data-scripting` on `<html>` before first paint.
- `index.css` hides `[data-landing-static]` (the pre-render wrapper) whenever that stamp is present, so scripted browsers see the quiet dark background until React mounts — one appearance, no swap. The landing's scroll reveals make the entrance read as intentional.
- Crawlers, LLM bots, and no-JS readers never run the script, so they keep the fully styled prerendered content.
- If the landing chunk fails to load, `main.tsx` removes the stamp and the pre-render reappears as a functional fallback.

Verified: `bun run check` green; built `dist/index.html` carries the stamp script + `data-landing-static` hook and the hiding rule is in the CSS bundle; console shells unaffected.

Merging auto-deploys via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsLoJsijoJacvLi91aYfbu

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents the crawler-facing static landing content from flashing before React mounts while preserving it for no-JS clients and restoring it when the landing module fails to load.

- Stamps scripted documents before first paint and hides the marked static landing block through CSS.
- Marks generated prerender wrappers and restores their visibility after landing-module import failure.
- Adds discovery assertions for the script stamp and static wrapper marker.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The visibility marker, CSS selector, generated wrapper, and import-failure recovery form a consistent contract, while console and no-JS behavior remain intact.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20galfrevn%2Fapollo%20PR%20%2354%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=galfrevn%2Fapollo&pr=54&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["fix(console): hide the landing pre-rende..."](https://github.com/galfrevn/apollo/commit/fd349a4a4f771f8ee0b605bf575ad1a676774263) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52980471)</sub>

<!-- /greptile_comment -->