### PR TITLE
feat: console broadcast — owner messages spoken through the desk

### DIFF
--- a/apps/agent/src/agents/apollo.ts
+++ b/apps/agent/src/agents/apollo.ts
@@ -28,6 +28,20 @@ import {
 } from '@/agents/rpc';
 import { concatenateArrayBufferList, executeApolloTurn } from '@/agents/runtime';
 import {
+  deliverBroadcastAudio,
+  deliverBroadcastText,
+  replayPendingBroadcast,
+  sweepExpiredBroadcasts,
+} from '@/broadcast/deliver';
+import {
+  appendBroadcastUploadChunk,
+  assembleBroadcastUploadAudio,
+  createBroadcastUploadSession,
+  isBroadcastUploadSessionExpired,
+  type BroadcastDeliveryOutcome,
+  type BroadcastUploadSession,
+} from '@/broadcast/logic';
+import {
   DEVICE_CONNECTION_TAG,
   hasDeviceConnectionTag,
   resolveApolloConnectionRole,
@@ -52,6 +66,10 @@ import {
 import {
   consoleAddListItemInputSchema,
   consoleAddMemoryInputSchema,
+  consoleBroadcastTextInputSchema,
+  consoleBroadcastUploadBeginInputSchema,
+  consoleBroadcastUploadChunkInputSchema,
+  consoleBroadcastUploadCommitInputSchema,
   consoleCancelReminderInputSchema,
   consoleCreateReminderInputSchema,
   consoleDeleteMemoryInputSchema,
@@ -233,6 +251,16 @@ type ConsoleSecretInput = z.infer<typeof consoleSecretInputSchema>;
 type ConsoleMemoryBrowseInput = z.infer<typeof consoleMemoryBrowseInputSchema>;
 type ConsoleCancelReminderInput = z.infer<typeof consoleCancelReminderInputSchema>;
 type ConsoleCreateReminderInput = z.infer<typeof consoleCreateReminderInputSchema>;
+type ConsoleBroadcastTextInput = z.infer<typeof consoleBroadcastTextInputSchema>;
+type ConsoleBroadcastUploadBeginInput = z.infer<
+  typeof consoleBroadcastUploadBeginInputSchema
+>;
+type ConsoleBroadcastUploadChunkInput = z.infer<
+  typeof consoleBroadcastUploadChunkInputSchema
+>;
+type ConsoleBroadcastUploadCommitInput = z.infer<
+  typeof consoleBroadcastUploadCommitInputSchema
+>;
 type ConsoleDeviceVolumeInput = z.infer<typeof consoleDeviceVolumeInputSchema>;
 type ConsoleDeviceBrightnessInput = z.infer<typeof consoleDeviceBrightnessInputSchema>;
 type ConsoleAddMemoryInput = z.infer<typeof consoleAddMemoryInputSchema>;
@@ -313,6 +341,7 @@ export class Apollo extends Agent<Env, ApolloState> {
   #isDeliveringInitiative = false;
   #isConsolidatingMemory = false;
   #deviceMcpRequestRegistry = createDeviceMcpRequestRegistry();
+  #broadcastUploadSessionMap = new Map<string, BroadcastUploadSession>();
   #ttsSequence = 0;
   #lastPlaybackAck: {
     readonly sequence: number;
@@ -869,6 +898,97 @@ export class Apollo extends Agent<Env, ApolloState> {
       });
     }
     return this.#listConsoleReminderRowList();
+  }
+
+  @callable()
+  async sendConsoleBroadcastText(
+    rawInput: ConsoleBroadcastTextInput,
+  ): Promise<{ readonly outcome: BroadcastDeliveryOutcome }> {
+    const input = consoleBroadcastTextInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const outcome = await deliverBroadcastText({
+      message: input.message,
+      connectionList: [...this.getConnections(DEVICE_CONNECTION_TAG)],
+      sqlExecutor: this.#sqlExecutor(),
+      environment: this.env,
+      ttsVoiceId: APOLLO_TTS_VOICE,
+      isMockVoice: this.env.MOCK_VOICE === '1',
+      playChimeEffect: () => this.#broadcastPlayEffect('chime'),
+    });
+    return { outcome };
+  }
+
+  @callable()
+  async beginConsoleBroadcastAudioUpload(
+    rawInput: ConsoleBroadcastUploadBeginInput,
+  ): Promise<{ readonly uploadId: string }> {
+    const input = consoleBroadcastUploadBeginInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    this.#evictExpiredBroadcastUploadSessions();
+    const uploadId = crypto.randomUUID();
+    this.#broadcastUploadSessionMap.set(
+      uploadId,
+      createBroadcastUploadSession({
+        totalBytes: input.totalBytes,
+        expectedChunkCount: input.chunkCount,
+        nowMilliseconds: Date.now(),
+      }),
+    );
+    return { uploadId };
+  }
+
+  @callable()
+  async appendConsoleBroadcastAudioChunk(
+    rawInput: ConsoleBroadcastUploadChunkInput,
+  ): Promise<{ readonly receivedChunkCount: number }> {
+    const input = consoleBroadcastUploadChunkInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const uploadSession = this.#requireBroadcastUploadSession(input.uploadId);
+    const receivedChunkCount = appendBroadcastUploadChunk(
+      uploadSession,
+      input.chunkIndex,
+      input.base64Chunk,
+    );
+    return { receivedChunkCount };
+  }
+
+  @callable()
+  async commitConsoleBroadcastAudioUpload(
+    rawInput: ConsoleBroadcastUploadCommitInput,
+  ): Promise<{ readonly outcome: BroadcastDeliveryOutcome }> {
+    const input = consoleBroadcastUploadCommitInputSchema.parse(rawInput);
+    await this.#assertDashboardSecret(input.secret);
+    const uploadSession = this.#requireBroadcastUploadSession(input.uploadId);
+    const audioBuffer = assembleBroadcastUploadAudio(uploadSession);
+    this.#broadcastUploadSessionMap.delete(input.uploadId);
+    const outcome = await deliverBroadcastAudio({
+      audioBuffer,
+      broadcastId: crypto.randomUUID(),
+      connectionList: [...this.getConnections(DEVICE_CONNECTION_TAG)],
+      sqlExecutor: this.#sqlExecutor(),
+      mediaBucket: this.env.MEDIA,
+      playChimeEffect: () => this.#broadcastPlayEffect('chime'),
+    });
+    return { outcome };
+  }
+
+  #requireBroadcastUploadSession(uploadId: string): BroadcastUploadSession {
+    const uploadSession = this.#broadcastUploadSessionMap.get(uploadId);
+    if (uploadSession === undefined) {
+      // The map is in-memory: a Durable Object restart mid-upload loses it and
+      // the console has to start the upload over from the first chunk.
+      throw new Error('La subida expiró; volvé a enviar el audio');
+    }
+    return uploadSession;
+  }
+
+  #evictExpiredBroadcastUploadSessions(): void {
+    const nowMilliseconds = Date.now();
+    for (const [uploadId, uploadSession] of this.#broadcastUploadSessionMap) {
+      if (isBroadcastUploadSessionExpired(uploadSession, nowMilliseconds)) {
+        this.#broadcastUploadSessionMap.delete(uploadId);
+      }
+    }
   }
 
   @callable()
@@ -1697,13 +1817,35 @@ export class Apollo extends Agent<Env, ApolloState> {
   }
 
   async #flushPendingDeviceMessages(connection: Connection): Promise<void> {
-    const pendingMessageList = await listPendingDeviceMessages(this.#sqlExecutor());
+    const pendingMessageList = await sweepExpiredBroadcasts({
+      pendingMessageList: await listPendingDeviceMessages(this.#sqlExecutor()),
+      sqlExecutor: this.#sqlExecutor(),
+      mediaBucket: this.env.MEDIA,
+      nowMilliseconds: Date.now(),
+    });
     for (const pendingMessage of pendingMessageList) {
-      connection.send(
-        encodeServerToDeviceMessage(
-          parsePendingDeviceMessageAsNotification(pendingMessage),
-        ),
-      );
+      if (
+        pendingMessage.type === 'broadcast_text' ||
+        pendingMessage.type === 'broadcast_audio'
+      ) {
+        // Queued broadcasts replay with sound: the owner left a message for
+        // whoever is near the desk, not a silent card.
+        await replayPendingBroadcast({
+          pendingMessage,
+          connectionList: [connection],
+          mediaBucket: this.env.MEDIA,
+          environment: this.env,
+          ttsVoiceId: APOLLO_TTS_VOICE,
+          isMockVoice: this.env.MOCK_VOICE === '1',
+          playChimeEffect: () => this.#broadcastPlayEffect('chime'),
+        });
+      } else {
+        connection.send(
+          encodeServerToDeviceMessage(
+            parsePendingDeviceMessageAsNotification(pendingMessage),
+          ),
+        );
+      }
       await deletePendingDeviceMessage(this.#sqlExecutor(), pendingMessage.id);
     }
   }

--- a/apps/agent/src/agents/notify.ts
+++ b/apps/agent/src/agents/notify.ts
@@ -74,7 +74,7 @@ function extractNotificationSpokenText(notification: DeskDeviceNotification): st
   return notification.type === 'reminder' ? notification.message : notification.summary;
 }
 
-function encodeMockSpeechAudio(spokenText: string): ArrayBuffer {
+export function encodeMockSpeechAudio(spokenText: string): ArrayBuffer {
   const encodedSpokenTextBytes = new TextEncoder().encode(spokenText);
   const mockSpeechAudioBuffer = new ArrayBuffer(encodedSpokenTextBytes.byteLength);
   new Uint8Array(mockSpeechAudioBuffer).set(encodedSpokenTextBytes);
@@ -135,10 +135,25 @@ async function announceNotificationWithTts(input: {
         voiceId: input.ttsVoiceId,
       });
 
+  await announcePcmToConnections({
+    audioBuffer: ttsAudio,
+    connectionList: input.connectionList,
+  });
+}
+
+// Structurally just `send` so broadcast tests can stand in a plain recorder
+// object for a live WebSocket connection.
+export type AnnounceableConnection = Pick<Connection, 'send'>;
+
+export async function announcePcmToConnections(input: {
+  readonly audioBuffer: ArrayBuffer;
+  readonly connectionList: readonly AnnounceableConnection[];
+  readonly wait?: (milliseconds: number) => Promise<void>;
+}): Promise<void> {
   const ttsStartMessage = encodeServerToDeviceMessage({
     type: 'tts_start',
     format: 'pcm',
-    bytes: ttsAudio.byteLength,
+    bytes: input.audioBuffer.byteLength,
     sampleRate: TTS_PCM_SAMPLE_RATE_HZ,
     channels: TTS_PCM_CHANNEL_COUNT,
   });
@@ -150,9 +165,10 @@ async function announceNotificationWithTts(input: {
   // the same announcement at the same time. Open-loop on purpose — a broadcast
   // has no single device whose acks could steer it.
   await streamAudioChunksAtPlaybackPace({
-    audioBuffer: ttsAudio,
+    audioBuffer: input.audioBuffer,
     sampleRateHz: TTS_PCM_SAMPLE_RATE_HZ,
     channelCount: TTS_PCM_CHANNEL_COUNT,
+    wait: input.wait,
     send: (audioChunk) => {
       for (const connection of input.connectionList) {
         connection.send(audioChunk);

--- a/apps/agent/src/broadcast/__tests__/deliver.spec.ts
+++ b/apps/agent/src/broadcast/__tests__/deliver.spec.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  deliverBroadcastAudio,
+  deliverBroadcastText,
+  replayPendingBroadcast,
+  sweepExpiredBroadcasts,
+} from '@/broadcast/deliver';
+import type { BroadcastMediaBucket } from '@/broadcast/deliver';
+import { BROADCAST_PENDING_TTL_MILLISECONDS } from '@/broadcast/logic';
+import { createFakeApolloEnvironment } from '@/configuration/testing';
+import { listPendingDeviceMessages } from '@/memory/pending';
+import type {
+  PendingDeviceMessagePayload,
+  PendingDeviceMessageType,
+} from '@/memory/pending';
+import type { MemorySqlExecutor, MemorySqlRow } from '@/memory/store';
+
+type RecordedFrame = string | ArrayBuffer;
+
+function createFrameRecordingConnection(): {
+  connection: { send: (frame: RecordedFrame) => void };
+  frameList: RecordedFrame[];
+} {
+  const frameList: RecordedFrame[] = [];
+  return {
+    connection: { send: (frame: RecordedFrame) => frameList.push(frame) },
+    frameList,
+  };
+}
+
+function createInMemorySqlExecutor(): MemorySqlExecutor {
+  const pendingRowList: Array<{
+    id: string;
+    type: string;
+    payload_json: string;
+    created_at: number;
+  }> = [];
+
+  function executeFakeQuery(
+    query: string,
+    ...bindValues: unknown[]
+  ): readonly MemorySqlRow[] {
+    if (query.startsWith('INSERT INTO pending_device_messages')) {
+      pendingRowList.push({
+        id: String(bindValues[0]),
+        type: String(bindValues[1]),
+        payload_json: String(bindValues[2]),
+        created_at: Number(bindValues[3]),
+      });
+      return [];
+    }
+    if (
+      query.startsWith(
+        'SELECT id, type, payload_json, created_at FROM pending_device_messages',
+      )
+    ) {
+      return pendingRowList.map((row) => ({ ...row }));
+    }
+    if (query.startsWith('DELETE FROM pending_device_messages WHERE id = ?')) {
+      const identifierToDelete = String(bindValues[0]);
+      const rowIndex = pendingRowList.findIndex((row) => row.id === identifierToDelete);
+      if (rowIndex >= 0) {
+        pendingRowList.splice(rowIndex, 1);
+      }
+      return [];
+    }
+    throw new Error(`Unsupported query in fake: ${query}`);
+  }
+
+  // SAFETY: every branch of the fake returns rows carrying exactly the columns
+  // the matched production query selects, so the caller's Row type argument
+  // always matches the rows handed back.
+  return { execute: executeFakeQuery as MemorySqlExecutor['execute'] };
+}
+
+function createInMemoryMediaBucket(): BroadcastMediaBucket & {
+  storedObjectMap: Map<string, ArrayBuffer>;
+} {
+  const storedObjectMap = new Map<string, ArrayBuffer>();
+  return {
+    storedObjectMap,
+    put: async (objectKey, value) => {
+      storedObjectMap.set(objectKey, value);
+    },
+    get: async (objectKey) => {
+      const storedBuffer = storedObjectMap.get(objectKey);
+      if (storedBuffer === undefined) {
+        return null;
+      }
+      return { arrayBuffer: async () => storedBuffer };
+    },
+    delete: async (objectKey) => {
+      storedObjectMap.delete(objectKey);
+    },
+  };
+}
+
+function parseJsonFrameList(frameList: readonly RecordedFrame[]): unknown[] {
+  return frameList
+    .filter((frame): frame is string => typeof frame === 'string')
+    .map((frame) => JSON.parse(frame));
+}
+
+const fakeEnvironment = createFakeApolloEnvironment();
+const immediateWait = async () => {};
+
+function buildTestPcmBuffer(byteLength: number): ArrayBuffer {
+  return new Uint8Array(byteLength).fill(7).buffer;
+}
+
+describe('deliverBroadcastText', () => {
+  it('queues a pending row when no device is connected', async () => {
+    const sqlExecutor = createInMemorySqlExecutor();
+    const outcome = await deliverBroadcastText({
+      message: 'vuelvo a las ocho',
+      connectionList: [],
+      sqlExecutor,
+      environment: fakeEnvironment,
+      ttsVoiceId: 'voice',
+      isMockVoice: true,
+      playChimeEffect: () => {},
+      wait: immediateWait,
+    });
+    expect(outcome).toBe('queued');
+    const pendingList = await listPendingDeviceMessages(sqlExecutor);
+    expect(pendingList).toHaveLength(1);
+    expect(pendingList[0]?.type).toBe('broadcast_text');
+    expect(pendingList[0]?.payload).toEqual({ message: 'vuelvo a las ocho' });
+  });
+
+  it('plays chime, sends the card, and streams the full speech run when connected', async () => {
+    const { connection, frameList } = createFrameRecordingConnection();
+    let chimeCount = 0;
+    const outcome = await deliverBroadcastText({
+      message: 'vuelvo a las ocho',
+      connectionList: [connection],
+      sqlExecutor: createInMemorySqlExecutor(),
+      environment: fakeEnvironment,
+      ttsVoiceId: 'voice',
+      isMockVoice: true,
+      playChimeEffect: () => {
+        chimeCount += 1;
+      },
+      wait: immediateWait,
+    });
+    expect(outcome).toBe('delivered');
+    expect(chimeCount).toBe(1);
+    const jsonFrameList = parseJsonFrameList(frameList) as Array<{
+      type: string;
+      [fieldName: string]: unknown;
+    }>;
+    expect(jsonFrameList.map((frame) => frame.type)).toEqual([
+      'reminder',
+      'tts_start',
+      'tts_end',
+      'turn_end',
+    ]);
+    const ttsStartFrame = jsonFrameList[1];
+    expect(ttsStartFrame?.format).toBe('pcm');
+    expect(ttsStartFrame?.sampleRate).toBe(24_000);
+    expect(ttsStartFrame?.channels).toBe(1);
+    const binaryByteCount = frameList
+      .filter((frame): frame is ArrayBuffer => typeof frame !== 'string')
+      .reduce((total, frame) => total + frame.byteLength, 0);
+    expect(binaryByteCount).toBe(Number(ttsStartFrame?.bytes));
+    const turnEndFrame = jsonFrameList[3];
+    expect(turnEndFrame?.expectsReply).toBe(false);
+  });
+});
+
+describe('deliverBroadcastAudio', () => {
+  it('stores the audio in r2 and queues a row when no device is connected', async () => {
+    const sqlExecutor = createInMemorySqlExecutor();
+    const mediaBucket = createInMemoryMediaBucket();
+    const outcome = await deliverBroadcastAudio({
+      audioBuffer: buildTestPcmBuffer(9_000),
+      broadcastId: 'abc',
+      connectionList: [],
+      sqlExecutor,
+      mediaBucket,
+      playChimeEffect: () => {},
+      wait: immediateWait,
+    });
+    expect(outcome).toBe('queued');
+    expect(mediaBucket.storedObjectMap.has('broadcast-audio/abc.pcm')).toBe(true);
+    const pendingList = await listPendingDeviceMessages(sqlExecutor);
+    expect(pendingList[0]?.type).toBe('broadcast_audio');
+    expect(pendingList[0]?.payload).toEqual({
+      audioKey: 'broadcast-audio/abc.pcm',
+      byteLength: 9_000,
+    });
+  });
+
+  it('streams the uploaded pcm directly when connected', async () => {
+    const { connection, frameList } = createFrameRecordingConnection();
+    const outcome = await deliverBroadcastAudio({
+      audioBuffer: buildTestPcmBuffer(20_000),
+      broadcastId: 'abc',
+      connectionList: [connection],
+      sqlExecutor: createInMemorySqlExecutor(),
+      mediaBucket: createInMemoryMediaBucket(),
+      playChimeEffect: () => {},
+      wait: immediateWait,
+    });
+    expect(outcome).toBe('delivered');
+    const jsonFrameList = parseJsonFrameList(frameList) as Array<{
+      type: string;
+      bytes?: number;
+    }>;
+    expect(jsonFrameList.map((frame) => frame.type)).toEqual([
+      'tts_start',
+      'tts_end',
+      'turn_end',
+    ]);
+    expect(jsonFrameList[0]?.bytes).toBe(20_000);
+    const binaryByteCount = frameList
+      .filter((frame): frame is ArrayBuffer => typeof frame !== 'string')
+      .reduce((total, frame) => total + frame.byteLength, 0);
+    expect(binaryByteCount).toBe(20_000);
+  });
+});
+
+describe('replayPendingBroadcast', () => {
+  it('speaks a queued audio broadcast and deletes its r2 object', async () => {
+    const { connection, frameList } = createFrameRecordingConnection();
+    const mediaBucket = createInMemoryMediaBucket();
+    await mediaBucket.put('broadcast-audio/abc.pcm', buildTestPcmBuffer(10_000));
+    await replayPendingBroadcast({
+      pendingMessage: {
+        type: 'broadcast_audio',
+        payload: { audioKey: 'broadcast-audio/abc.pcm', byteLength: 10_000 },
+      },
+      connectionList: [connection],
+      mediaBucket,
+      environment: fakeEnvironment,
+      ttsVoiceId: 'voice',
+      isMockVoice: true,
+      playChimeEffect: () => {},
+      wait: immediateWait,
+    });
+    const jsonFrameList = parseJsonFrameList(frameList) as Array<{ type: string }>;
+    expect(jsonFrameList.map((frame) => frame.type)).toEqual([
+      'tts_start',
+      'tts_end',
+      'turn_end',
+    ]);
+    expect(mediaBucket.storedObjectMap.has('broadcast-audio/abc.pcm')).toBe(false);
+  });
+
+  it('skips silently when the r2 object is gone', async () => {
+    const { connection, frameList } = createFrameRecordingConnection();
+    await replayPendingBroadcast({
+      pendingMessage: {
+        type: 'broadcast_audio',
+        payload: { audioKey: 'broadcast-audio/missing.pcm', byteLength: 10_000 },
+      },
+      connectionList: [connection],
+      mediaBucket: createInMemoryMediaBucket(),
+      environment: fakeEnvironment,
+      ttsVoiceId: 'voice',
+      isMockVoice: true,
+      playChimeEffect: () => {},
+      wait: immediateWait,
+    });
+    expect(frameList).toHaveLength(0);
+  });
+
+  it('speaks a queued text broadcast with its card', async () => {
+    const { connection, frameList } = createFrameRecordingConnection();
+    await replayPendingBroadcast({
+      pendingMessage: {
+        type: 'broadcast_text',
+        payload: { message: 'ya llegué' },
+      },
+      connectionList: [connection],
+      mediaBucket: createInMemoryMediaBucket(),
+      environment: fakeEnvironment,
+      ttsVoiceId: 'voice',
+      isMockVoice: true,
+      playChimeEffect: () => {},
+      wait: immediateWait,
+    });
+    const jsonFrameList = parseJsonFrameList(frameList) as Array<{ type: string }>;
+    expect(jsonFrameList.map((frame) => frame.type)).toEqual([
+      'reminder',
+      'tts_start',
+      'tts_end',
+      'turn_end',
+    ]);
+  });
+});
+
+describe('sweepExpiredBroadcasts', () => {
+  it('deletes expired broadcast rows and their audio objects, keeping everything else', async () => {
+    const sqlExecutor = createInMemorySqlExecutor();
+    const mediaBucket = createInMemoryMediaBucket();
+    await mediaBucket.put('broadcast-audio/old.pcm', buildTestPcmBuffer(2));
+    const pendingMessageList: Array<{
+      id: string;
+      type: PendingDeviceMessageType;
+      payload: PendingDeviceMessagePayload;
+      createdAtMilliseconds: number;
+    }> = [
+      {
+        id: 'old-audio',
+        type: 'broadcast_audio' as const,
+        payload: { audioKey: 'broadcast-audio/old.pcm', byteLength: 2 },
+        createdAtMilliseconds: 0,
+      },
+      {
+        id: 'old-text',
+        type: 'broadcast_text' as const,
+        payload: { message: 'viejo' },
+        createdAtMilliseconds: 0,
+      },
+      {
+        id: 'old-reminder',
+        type: 'reminder' as const,
+        payload: { message: 'los reminders no vencen' },
+        createdAtMilliseconds: 0,
+      },
+      {
+        id: 'fresh-text',
+        type: 'broadcast_text' as const,
+        payload: { message: 'nuevo' },
+        createdAtMilliseconds: BROADCAST_PENDING_TTL_MILLISECONDS,
+      },
+    ];
+    const survivingMessageList = await sweepExpiredBroadcasts({
+      pendingMessageList,
+      sqlExecutor,
+      mediaBucket,
+      nowMilliseconds: BROADCAST_PENDING_TTL_MILLISECONDS + 1,
+    });
+    expect(survivingMessageList.map((message) => message.id)).toEqual([
+      'old-reminder',
+      'fresh-text',
+    ]);
+    expect(mediaBucket.storedObjectMap.has('broadcast-audio/old.pcm')).toBe(false);
+  });
+});

--- a/apps/agent/src/broadcast/__tests__/logic.spec.ts
+++ b/apps/agent/src/broadcast/__tests__/logic.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  appendBroadcastUploadChunk,
+  assembleBroadcastUploadAudio,
+  BROADCAST_MAX_AUDIO_BYTES,
+  BROADCAST_PENDING_TTL_MILLISECONDS,
+  BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH,
+  BROADCAST_UPLOAD_SESSION_TTL_MILLISECONDS,
+  broadcastAudioPendingPayloadSchema,
+  broadcastTextPendingPayloadSchema,
+  buildBroadcastAudioObjectKey,
+  createBroadcastUploadSession,
+  isBroadcastUploadSessionExpired,
+  isPendingBroadcastExpired,
+} from '@/broadcast/logic';
+
+function encodeBytesToBase64(bytes: Uint8Array): string {
+  let binaryString = '';
+  for (const byteValue of bytes) {
+    binaryString += String.fromCharCode(byteValue);
+  }
+  return btoa(binaryString);
+}
+
+function buildSequentialBytes(byteLength: number): Uint8Array<ArrayBuffer> {
+  const bytes = new Uint8Array(byteLength);
+  for (let byteIndex = 0; byteIndex < byteLength; byteIndex += 1) {
+    bytes[byteIndex] = byteIndex % 251;
+  }
+  return bytes;
+}
+
+describe('broadcast upload session', () => {
+  it('assembles a multi-chunk upload back into the original bytes', () => {
+    const totalBytes = BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH + 2_000;
+    const sourceBytes = buildSequentialBytes(totalBytes);
+    const session = createBroadcastUploadSession({
+      totalBytes,
+      expectedChunkCount: 2,
+      nowMilliseconds: 0,
+    });
+    appendBroadcastUploadChunk(
+      session,
+      0,
+      encodeBytesToBase64(sourceBytes.slice(0, BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH)),
+    );
+    const receivedChunkCount = appendBroadcastUploadChunk(
+      session,
+      1,
+      encodeBytesToBase64(sourceBytes.slice(BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH)),
+    );
+    expect(receivedChunkCount).toBe(2);
+    const assembledBytes = new Uint8Array(assembleBroadcastUploadAudio(session));
+    expect(assembledBytes).toEqual(sourceBytes);
+  });
+
+  it('rejects a total size above the thirty second cap', () => {
+    expect(() =>
+      createBroadcastUploadSession({
+        totalBytes: BROADCAST_MAX_AUDIO_BYTES + 2,
+        expectedChunkCount: 8,
+        nowMilliseconds: 0,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects an odd byte count because s16le samples are two bytes', () => {
+    expect(() =>
+      createBroadcastUploadSession({
+        totalBytes: 48_001,
+        expectedChunkCount: 1,
+        nowMilliseconds: 0,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a chunk count that does not match the total size', () => {
+    expect(() =>
+      createBroadcastUploadSession({
+        totalBytes: 48_000,
+        expectedChunkCount: 2,
+        nowMilliseconds: 0,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects out-of-range and duplicate chunk indexes', () => {
+    const session = createBroadcastUploadSession({
+      totalBytes: 48_000,
+      expectedChunkCount: 1,
+      nowMilliseconds: 0,
+    });
+    expect(() => appendBroadcastUploadChunk(session, 1, 'aaaa')).toThrow();
+    expect(() => appendBroadcastUploadChunk(session, -1, 'aaaa')).toThrow();
+    appendBroadcastUploadChunk(
+      session,
+      0,
+      encodeBytesToBase64(buildSequentialBytes(48_000)),
+    );
+    expect(() => appendBroadcastUploadChunk(session, 0, 'aaaa')).toThrow();
+  });
+
+  it('rejects assembly when a chunk is missing', () => {
+    const session = createBroadcastUploadSession({
+      totalBytes: BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH * 2,
+      expectedChunkCount: 2,
+      nowMilliseconds: 0,
+    });
+    appendBroadcastUploadChunk(
+      session,
+      0,
+      encodeBytesToBase64(buildSequentialBytes(BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH)),
+    );
+    expect(() => assembleBroadcastUploadAudio(session)).toThrow();
+  });
+
+  it('rejects assembly when the decoded bytes do not match the announced total', () => {
+    const session = createBroadcastUploadSession({
+      totalBytes: 48_000,
+      expectedChunkCount: 1,
+      nowMilliseconds: 0,
+    });
+    appendBroadcastUploadChunk(
+      session,
+      0,
+      encodeBytesToBase64(buildSequentialBytes(46_000)),
+    );
+    expect(() => assembleBroadcastUploadAudio(session)).toThrow();
+  });
+
+  it('rejects a chunk that is not valid base64', () => {
+    const session = createBroadcastUploadSession({
+      totalBytes: 48_000,
+      expectedChunkCount: 1,
+      nowMilliseconds: 0,
+    });
+    appendBroadcastUploadChunk(session, 0, '@@@not-base64@@@');
+    expect(() => assembleBroadcastUploadAudio(session)).toThrow();
+  });
+
+  it('expires an upload session past its ttl', () => {
+    const session = createBroadcastUploadSession({
+      totalBytes: 48_000,
+      expectedChunkCount: 1,
+      nowMilliseconds: 1_000,
+    });
+    expect(isBroadcastUploadSessionExpired(session, 1_000)).toBe(false);
+    expect(
+      isBroadcastUploadSessionExpired(
+        session,
+        1_000 + BROADCAST_UPLOAD_SESSION_TTL_MILLISECONDS,
+      ),
+    ).toBe(false);
+    expect(
+      isBroadcastUploadSessionExpired(
+        session,
+        1_001 + BROADCAST_UPLOAD_SESSION_TTL_MILLISECONDS,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('broadcast pending helpers', () => {
+  it('builds the r2 object key from the broadcast id', () => {
+    expect(buildBroadcastAudioObjectKey('abc-123')).toBe('broadcast-audio/abc-123.pcm');
+  });
+
+  it('expires a pending broadcast strictly after the ttl', () => {
+    expect(isPendingBroadcastExpired(0, BROADCAST_PENDING_TTL_MILLISECONDS)).toBe(false);
+    expect(isPendingBroadcastExpired(0, BROADCAST_PENDING_TTL_MILLISECONDS + 1)).toBe(
+      true,
+    );
+  });
+
+  it('parses pending payloads and rejects malformed ones', () => {
+    expect(
+      broadcastTextPendingPayloadSchema.parse({ message: 'vuelvo a las ocho' }),
+    ).toEqual({ message: 'vuelvo a las ocho' });
+    expect(() => broadcastTextPendingPayloadSchema.parse({ message: '' })).toThrow();
+    expect(
+      broadcastAudioPendingPayloadSchema.parse({
+        audioKey: 'broadcast-audio/x.pcm',
+        byteLength: 2,
+      }),
+    ).toEqual({ audioKey: 'broadcast-audio/x.pcm', byteLength: 2 });
+    expect(() =>
+      broadcastAudioPendingPayloadSchema.parse({ audioKey: '', byteLength: 0 }),
+    ).toThrow();
+  });
+});

--- a/apps/agent/src/broadcast/deliver.ts
+++ b/apps/agent/src/broadcast/deliver.ts
@@ -1,0 +1,194 @@
+import { announcePcmToConnections, encodeMockSpeechAudio } from '@/agents/notify';
+import type { AnnounceableConnection } from '@/agents/notify';
+import {
+  broadcastAudioPendingPayloadSchema,
+  broadcastTextPendingPayloadSchema,
+  buildBroadcastAudioObjectKey,
+  isPendingBroadcastExpired,
+} from '@/broadcast/logic';
+import type { BroadcastDeliveryOutcome } from '@/broadcast/logic';
+import {
+  deletePendingDeviceMessage,
+  enqueuePendingDeviceMessage,
+} from '@/memory/pending';
+import type {
+  PendingDeviceMessagePayload,
+  PendingDeviceMessageType,
+} from '@/memory/pending';
+import type { MemorySqlExecutor } from '@/memory/store';
+import { encodeServerToDeviceMessage } from '@/protocol/schema';
+import { sanitizeTextForSpeech } from '@/voice/sanitize';
+import { synthesizeApolloSpeech } from '@/voice/synthesize';
+
+// The subset of R2Bucket the broadcast path touches, kept structural so the
+// spec can substitute an in-memory bucket.
+export type BroadcastMediaBucket = {
+  put(objectKey: string, value: ArrayBuffer): Promise<unknown>;
+  get(objectKey: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> } | null>;
+  delete(objectKey: string): Promise<void>;
+};
+
+type StoredPendingMessage = {
+  readonly id: string;
+  readonly type: PendingDeviceMessageType;
+  readonly payload: PendingDeviceMessagePayload;
+  readonly createdAtMilliseconds: number;
+};
+
+export async function deliverBroadcastText(input: {
+  readonly message: string;
+  readonly connectionList: readonly AnnounceableConnection[];
+  readonly sqlExecutor: MemorySqlExecutor;
+  readonly environment: Env;
+  readonly ttsVoiceId: string;
+  readonly isMockVoice: boolean;
+  readonly playChimeEffect: () => void;
+  readonly wait?: (milliseconds: number) => Promise<void>;
+}): Promise<BroadcastDeliveryOutcome> {
+  if (input.connectionList.length === 0) {
+    await enqueuePendingDeviceMessage(input.sqlExecutor, {
+      type: 'broadcast_text',
+      payload: { message: input.message },
+    });
+    return 'queued';
+  }
+
+  input.playChimeEffect();
+  const reminderCardMessage = encodeServerToDeviceMessage({
+    type: 'reminder',
+    message: input.message,
+  });
+  for (const connection of input.connectionList) {
+    connection.send(reminderCardMessage);
+  }
+  await speakBroadcastText(input);
+  return 'delivered';
+}
+
+export async function deliverBroadcastAudio(input: {
+  readonly audioBuffer: ArrayBuffer;
+  readonly broadcastId: string;
+  readonly connectionList: readonly AnnounceableConnection[];
+  readonly sqlExecutor: MemorySqlExecutor;
+  readonly mediaBucket: BroadcastMediaBucket;
+  readonly playChimeEffect: () => void;
+  readonly wait?: (milliseconds: number) => Promise<void>;
+}): Promise<BroadcastDeliveryOutcome> {
+  if (input.connectionList.length === 0) {
+    const audioObjectKey = buildBroadcastAudioObjectKey(input.broadcastId);
+    await input.mediaBucket.put(audioObjectKey, input.audioBuffer);
+    await enqueuePendingDeviceMessage(input.sqlExecutor, {
+      type: 'broadcast_audio',
+      payload: { audioKey: audioObjectKey, byteLength: input.audioBuffer.byteLength },
+    });
+    return 'queued';
+  }
+
+  input.playChimeEffect();
+  await announcePcmToConnections({
+    audioBuffer: input.audioBuffer,
+    connectionList: input.connectionList,
+    ...(input.wait === undefined ? {} : { wait: input.wait }),
+  });
+  return 'delivered';
+}
+
+export async function replayPendingBroadcast(input: {
+  readonly pendingMessage: Pick<StoredPendingMessage, 'type' | 'payload'>;
+  readonly connectionList: readonly AnnounceableConnection[];
+  readonly mediaBucket: BroadcastMediaBucket;
+  readonly environment: Env;
+  readonly ttsVoiceId: string;
+  readonly isMockVoice: boolean;
+  readonly playChimeEffect: () => void;
+  readonly wait?: (milliseconds: number) => Promise<void>;
+}): Promise<void> {
+  if (input.pendingMessage.type === 'broadcast_text') {
+    const textPayload = broadcastTextPendingPayloadSchema.parse(
+      input.pendingMessage.payload,
+    );
+    input.playChimeEffect();
+    const reminderCardMessage = encodeServerToDeviceMessage({
+      type: 'reminder',
+      message: textPayload.message,
+    });
+    for (const connection of input.connectionList) {
+      connection.send(reminderCardMessage);
+    }
+    await speakBroadcastText({ ...input, message: textPayload.message });
+    return;
+  }
+
+  const audioPayload = broadcastAudioPendingPayloadSchema.parse(
+    input.pendingMessage.payload,
+  );
+  const storedAudioObject = await input.mediaBucket.get(audioPayload.audioKey);
+  if (storedAudioObject === null) {
+    return;
+  }
+  const audioBuffer = await storedAudioObject.arrayBuffer();
+  input.playChimeEffect();
+  await announcePcmToConnections({
+    audioBuffer,
+    connectionList: input.connectionList,
+    ...(input.wait === undefined ? {} : { wait: input.wait }),
+  });
+  await input.mediaBucket.delete(audioPayload.audioKey);
+}
+
+export async function sweepExpiredBroadcasts(input: {
+  readonly pendingMessageList: readonly StoredPendingMessage[];
+  readonly sqlExecutor: MemorySqlExecutor;
+  readonly mediaBucket: BroadcastMediaBucket;
+  readonly nowMilliseconds: number;
+}): Promise<readonly StoredPendingMessage[]> {
+  const survivingMessageList: StoredPendingMessage[] = [];
+  for (const pendingMessage of input.pendingMessageList) {
+    const isBroadcast =
+      pendingMessage.type === 'broadcast_text' ||
+      pendingMessage.type === 'broadcast_audio';
+    if (
+      !isBroadcast ||
+      !isPendingBroadcastExpired(
+        pendingMessage.createdAtMilliseconds,
+        input.nowMilliseconds,
+      )
+    ) {
+      survivingMessageList.push(pendingMessage);
+      continue;
+    }
+    if (pendingMessage.type === 'broadcast_audio') {
+      const audioPayload = broadcastAudioPendingPayloadSchema.safeParse(
+        pendingMessage.payload,
+      );
+      if (audioPayload.success) {
+        await input.mediaBucket.delete(audioPayload.data.audioKey);
+      }
+    }
+    await deletePendingDeviceMessage(input.sqlExecutor, pendingMessage.id);
+  }
+  return survivingMessageList;
+}
+
+async function speakBroadcastText(input: {
+  readonly message: string;
+  readonly connectionList: readonly AnnounceableConnection[];
+  readonly environment: Env;
+  readonly ttsVoiceId: string;
+  readonly isMockVoice: boolean;
+  readonly wait?: (milliseconds: number) => Promise<void>;
+}): Promise<void> {
+  const spokenText = sanitizeTextForSpeech(input.message);
+  const speechAudio = input.isMockVoice
+    ? encodeMockSpeechAudio(spokenText)
+    : await synthesizeApolloSpeech({
+        environment: input.environment,
+        text: spokenText,
+        voiceId: input.ttsVoiceId,
+      });
+  await announcePcmToConnections({
+    audioBuffer: speechAudio,
+    connectionList: input.connectionList,
+    ...(input.wait === undefined ? {} : { wait: input.wait }),
+  });
+}

--- a/apps/agent/src/broadcast/logic.ts
+++ b/apps/agent/src/broadcast/logic.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+
+// 30 seconds of s16le mono at 24 kHz — the firmware's playback format. The cap
+// keeps a full upload at 8 chunks and bounds what a reconnect replay can speak.
+export const BROADCAST_MAX_AUDIO_BYTES = 1_440_000;
+export const BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH = 180_000;
+// Base64 inflates 3 raw bytes to 4 characters; the encoded chunk plus the
+// JSON-RPC envelope must stay well under Cloudflare's ~1 MB WebSocket frame cap.
+export const BROADCAST_UPLOAD_CHUNK_MAX_BASE64_LENGTH = 240_000;
+export const BROADCAST_UPLOAD_MAX_CHUNK_COUNT = 8;
+export const BROADCAST_PENDING_TTL_MILLISECONDS = 86_400_000;
+export const BROADCAST_UPLOAD_SESSION_TTL_MILLISECONDS = 120_000;
+
+export type BroadcastDeliveryOutcome = 'delivered' | 'queued';
+
+export type BroadcastUploadSession = {
+  readonly totalBytes: number;
+  readonly expectedChunkCount: number;
+  readonly receivedChunkList: (string | undefined)[];
+  readonly createdAtMilliseconds: number;
+};
+
+export const broadcastTextPendingPayloadSchema = z.object({
+  message: z.string().min(1),
+});
+export const broadcastAudioPendingPayloadSchema = z.object({
+  audioKey: z.string().min(1),
+  byteLength: z.number().int().positive(),
+});
+
+export type BroadcastTextPendingPayload = z.infer<
+  typeof broadcastTextPendingPayloadSchema
+>;
+export type BroadcastAudioPendingPayload = z.infer<
+  typeof broadcastAudioPendingPayloadSchema
+>;
+
+export function createBroadcastUploadSession(input: {
+  readonly totalBytes: number;
+  readonly expectedChunkCount: number;
+  readonly nowMilliseconds: number;
+}): BroadcastUploadSession {
+  if (input.totalBytes <= 0 || input.totalBytes > BROADCAST_MAX_AUDIO_BYTES) {
+    throw new Error('El audio supera los 30 segundos permitidos');
+  }
+  if (input.totalBytes % 2 !== 0) {
+    throw new Error('El audio debe tener una cantidad par de bytes (PCM s16le)');
+  }
+  const requiredChunkCount = Math.ceil(
+    input.totalBytes / BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH,
+  );
+  if (
+    input.expectedChunkCount !== requiredChunkCount ||
+    input.expectedChunkCount > BROADCAST_UPLOAD_MAX_CHUNK_COUNT
+  ) {
+    throw new Error('La cantidad de partes no coincide con el tamaño del audio');
+  }
+  return {
+    totalBytes: input.totalBytes,
+    expectedChunkCount: input.expectedChunkCount,
+    receivedChunkList: Array.from<string | undefined>({
+      length: input.expectedChunkCount,
+    }),
+    createdAtMilliseconds: input.nowMilliseconds,
+  };
+}
+
+export function appendBroadcastUploadChunk(
+  session: BroadcastUploadSession,
+  chunkIndex: number,
+  base64Chunk: string,
+): number {
+  if (
+    !Number.isInteger(chunkIndex) ||
+    chunkIndex < 0 ||
+    chunkIndex >= session.expectedChunkCount
+  ) {
+    throw new Error('El índice de la parte está fuera de rango');
+  }
+  if (session.receivedChunkList[chunkIndex] !== undefined) {
+    throw new Error('Esa parte del audio ya fue recibida');
+  }
+  if (base64Chunk.length > BROADCAST_UPLOAD_CHUNK_MAX_BASE64_LENGTH) {
+    throw new Error('La parte del audio supera el tamaño permitido');
+  }
+  session.receivedChunkList[chunkIndex] = base64Chunk;
+  return session.receivedChunkList.filter((chunk) => chunk !== undefined).length;
+}
+
+export function assembleBroadcastUploadAudio(
+  session: BroadcastUploadSession,
+): ArrayBuffer {
+  const assembledBytes = new Uint8Array(session.totalBytes);
+  let writeOffset = 0;
+  for (let chunkIndex = 0; chunkIndex < session.expectedChunkCount; chunkIndex += 1) {
+    const base64Chunk = session.receivedChunkList[chunkIndex];
+    if (base64Chunk === undefined) {
+      throw new Error('Faltan partes del audio para armar la difusión');
+    }
+    const decodedChunk = decodeBase64Chunk(base64Chunk);
+    if (writeOffset + decodedChunk.byteLength > session.totalBytes) {
+      throw new Error('El audio recibido no coincide con el tamaño anunciado');
+    }
+    assembledBytes.set(decodedChunk, writeOffset);
+    writeOffset += decodedChunk.byteLength;
+  }
+  if (writeOffset !== session.totalBytes) {
+    throw new Error('El audio recibido no coincide con el tamaño anunciado');
+  }
+  return assembledBytes.buffer;
+}
+
+function decodeBase64Chunk(base64Chunk: string): Uint8Array {
+  let binaryString: string;
+  try {
+    binaryString = atob(base64Chunk);
+  } catch {
+    throw new Error('Una parte del audio no es base64 válido');
+  }
+  const decodedBytes = new Uint8Array(binaryString.length);
+  for (let byteIndex = 0; byteIndex < binaryString.length; byteIndex += 1) {
+    decodedBytes[byteIndex] = binaryString.charCodeAt(byteIndex);
+  }
+  return decodedBytes;
+}
+
+export function isBroadcastUploadSessionExpired(
+  session: BroadcastUploadSession,
+  nowMilliseconds: number,
+): boolean {
+  return (
+    nowMilliseconds - session.createdAtMilliseconds >
+    BROADCAST_UPLOAD_SESSION_TTL_MILLISECONDS
+  );
+}
+
+export function buildBroadcastAudioObjectKey(broadcastId: string): string {
+  return `broadcast-audio/${broadcastId}.pcm`;
+}
+
+export function isPendingBroadcastExpired(
+  createdAtMilliseconds: number,
+  nowMilliseconds: number,
+): boolean {
+  return nowMilliseconds - createdAtMilliseconds > BROADCAST_PENDING_TTL_MILLISECONDS;
+}

--- a/apps/agent/src/console/rpc.ts
+++ b/apps/agent/src/console/rpc.ts
@@ -1,7 +1,36 @@
 import { z } from 'zod';
 
+import {
+  BROADCAST_MAX_AUDIO_BYTES,
+  BROADCAST_UPLOAD_CHUNK_MAX_BASE64_LENGTH,
+  BROADCAST_UPLOAD_MAX_CHUNK_COUNT,
+} from '@/broadcast/logic';
+
 export const consoleSecretInputSchema = z.object({
   secret: z.string().min(1),
+});
+
+export const consoleBroadcastTextInputSchema = consoleSecretInputSchema.extend({
+  message: z.string().min(1).max(500),
+});
+
+export const consoleBroadcastUploadBeginInputSchema = consoleSecretInputSchema.extend({
+  totalBytes: z.number().int().positive().max(BROADCAST_MAX_AUDIO_BYTES),
+  chunkCount: z.number().int().min(1).max(BROADCAST_UPLOAD_MAX_CHUNK_COUNT),
+});
+
+export const consoleBroadcastUploadChunkInputSchema = consoleSecretInputSchema.extend({
+  uploadId: z.string().min(1),
+  chunkIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(BROADCAST_UPLOAD_MAX_CHUNK_COUNT - 1),
+  base64Chunk: z.string().min(1).max(BROADCAST_UPLOAD_CHUNK_MAX_BASE64_LENGTH),
+});
+
+export const consoleBroadcastUploadCommitInputSchema = consoleSecretInputSchema.extend({
+  uploadId: z.string().min(1),
 });
 
 export const consoleMemoryBrowseInputSchema = consoleSecretInputSchema.extend({

--- a/apps/agent/src/memory/__tests__/pending.spec.ts
+++ b/apps/agent/src/memory/__tests__/pending.spec.ts
@@ -28,13 +28,18 @@ function createInMemorySqlExecutor(): MemorySqlExecutor {
       });
       return [];
     }
-    if (query.startsWith('SELECT id, type, payload_json FROM pending_device_messages')) {
+    if (
+      query.startsWith(
+        'SELECT id, type, payload_json, created_at FROM pending_device_messages',
+      )
+    ) {
       return [...pendingRowList]
         .toSorted((left, right) => left.created_at - right.created_at)
         .map((row) => ({
           id: row.id,
           type: row.type,
           payload_json: row.payload_json,
+          created_at: row.created_at,
         }));
     }
     if (query.startsWith('DELETE FROM pending_device_messages WHERE id = ?')) {
@@ -69,7 +74,29 @@ describe('pending device messages', () => {
         id: 'pending-1',
         type: 'reminder',
         payload: { message: 'tomá agua' },
+        createdAtMilliseconds: 1000,
       },
+    ]);
+  });
+
+  it('round-trips the broadcast message types', async () => {
+    const sqlExecutor = createInMemorySqlExecutor();
+    await enqueuePendingDeviceMessage(sqlExecutor, {
+      type: 'broadcast_text',
+      payload: { message: 'vuelvo a las ocho' },
+      nowMilliseconds: 1000,
+      createIdentifier: () => 'broadcast-text-1',
+    });
+    await enqueuePendingDeviceMessage(sqlExecutor, {
+      type: 'broadcast_audio',
+      payload: { audioKey: 'broadcast-audio/abc.pcm', byteLength: 48_000 },
+      nowMilliseconds: 2000,
+      createIdentifier: () => 'broadcast-audio-1',
+    });
+    const pendingList = await listPendingDeviceMessages(sqlExecutor);
+    expect(pendingList.map((message) => message.type)).toEqual([
+      'broadcast_text',
+      'broadcast_audio',
     ]);
   });
 

--- a/apps/agent/src/memory/pending.ts
+++ b/apps/agent/src/memory/pending.ts
@@ -2,7 +2,11 @@ import { z } from 'zod';
 
 import type { MemorySqlExecutor } from '@/memory/store';
 
-export type PendingDeviceMessageType = 'background_result' | 'reminder';
+export type PendingDeviceMessageType =
+  | 'background_result'
+  | 'reminder'
+  | 'broadcast_text'
+  | 'broadcast_audio';
 
 export type PendingDeviceMessagePayloadValue =
   | string
@@ -17,7 +21,12 @@ export type PendingDeviceMessagePayload = Record<
   PendingDeviceMessagePayloadValue
 >;
 
-const pendingDeviceMessageTypeSchema = z.enum(['background_result', 'reminder']);
+const pendingDeviceMessageTypeSchema = z.enum([
+  'background_result',
+  'reminder',
+  'broadcast_text',
+  'broadcast_audio',
+]);
 const pendingDeviceMessagePayloadValueSchema: z.ZodType<PendingDeviceMessagePayloadValue> =
   z.lazy(() =>
     z.union([
@@ -59,19 +68,22 @@ export async function listPendingDeviceMessages(sqlExecutor: MemorySqlExecutor):
     id: string;
     type: PendingDeviceMessageType;
     payload: PendingDeviceMessagePayload;
+    createdAtMilliseconds: number;
   }[]
 > {
   const rows = sqlExecutor.execute<{
     id: string;
     type: string;
     payload_json: string;
+    created_at: number;
   }>(
-    'SELECT id, type, payload_json FROM pending_device_messages ORDER BY created_at ASC',
+    'SELECT id, type, payload_json, created_at FROM pending_device_messages ORDER BY created_at ASC',
   );
   return rows.map((row) => ({
     id: row.id,
     type: pendingDeviceMessageTypeSchema.parse(row.type),
     payload: pendingDeviceMessagePayloadSchema.parse(JSON.parse(row.payload_json)),
+    createdAtMilliseconds: row.created_at,
   }));
 }
 

--- a/apps/console/src/agent/__tests__/rpc.spec.ts
+++ b/apps/console/src/agent/__tests__/rpc.spec.ts
@@ -36,4 +36,53 @@ describe('console rpc wrapper', () => {
     const consoleRpc = createConsoleRpc(async () => ({ nonsense: true }), 's');
     await expect(consoleRpc.getStatus()).rejects.toThrow();
   });
+
+  it('sends broadcast calls with the secret and parses their outcomes', async () => {
+    const invokedCallList: Array<{ method: string; args?: unknown[] }> = [];
+    const resultByMethod: Record<string, Record<string, string | number>> = {
+      sendConsoleBroadcastText: { outcome: 'delivered' },
+      beginConsoleBroadcastAudioUpload: { uploadId: 'upload-1' },
+      appendConsoleBroadcastAudioChunk: { receivedChunkCount: 1 },
+      commitConsoleBroadcastAudioUpload: { outcome: 'queued' },
+    };
+    const consoleRpc = createConsoleRpc(async (method, args) => {
+      invokedCallList.push({ method, args });
+      return resultByMethod[method] ?? null;
+    }, 'dashboard-secret');
+
+    const textResult = await consoleRpc.sendBroadcastText('vuelvo a las ocho');
+    const beginResult = await consoleRpc.beginBroadcastAudioUpload(48_000, 1);
+    const chunkResult = await consoleRpc.appendBroadcastAudioChunk('upload-1', 0, 'abcd');
+    const commitResult = await consoleRpc.commitBroadcastAudioUpload('upload-1');
+
+    expect(textResult.outcome).toBe('delivered');
+    expect(beginResult.uploadId).toBe('upload-1');
+    expect(chunkResult.receivedChunkCount).toBe(1);
+    expect(commitResult.outcome).toBe('queued');
+    expect(invokedCallList).toEqual([
+      {
+        method: 'sendConsoleBroadcastText',
+        args: [{ secret: 'dashboard-secret', message: 'vuelvo a las ocho' }],
+      },
+      {
+        method: 'beginConsoleBroadcastAudioUpload',
+        args: [{ secret: 'dashboard-secret', totalBytes: 48_000, chunkCount: 1 }],
+      },
+      {
+        method: 'appendConsoleBroadcastAudioChunk',
+        args: [
+          {
+            secret: 'dashboard-secret',
+            uploadId: 'upload-1',
+            chunkIndex: 0,
+            base64Chunk: 'abcd',
+          },
+        ],
+      },
+      {
+        method: 'commitConsoleBroadcastAudioUpload',
+        args: [{ secret: 'dashboard-secret', uploadId: 'upload-1' }],
+      },
+    ]);
+  });
 });

--- a/apps/console/src/agent/rpc.ts
+++ b/apps/console/src/agent/rpc.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 import {
   apolloStateSchema,
+  broadcastResultSchema,
+  broadcastUploadBeginSchema,
+  broadcastUploadChunkSchema,
   consoleStatusSchema,
   deviceCommandResultSchema,
   historyTurnListSchema,
@@ -56,6 +59,25 @@ export function createConsoleRpc(call: AgentCall, secret: string) {
         delaySeconds,
         isTimer,
       }),
+    sendBroadcastText: (message: string) =>
+      invoke('sendConsoleBroadcastText', broadcastResultSchema, { message }),
+    beginBroadcastAudioUpload: (totalBytes: number, chunkCount: number) =>
+      invoke('beginConsoleBroadcastAudioUpload', broadcastUploadBeginSchema, {
+        totalBytes,
+        chunkCount,
+      }),
+    appendBroadcastAudioChunk: (
+      uploadId: string,
+      chunkIndex: number,
+      base64Chunk: string,
+    ) =>
+      invoke('appendConsoleBroadcastAudioChunk', broadcastUploadChunkSchema, {
+        uploadId,
+        chunkIndex,
+        base64Chunk,
+      }),
+    commitBroadcastAudioUpload: (uploadId: string) =>
+      invoke('commitConsoleBroadcastAudioUpload', broadcastResultSchema, { uploadId }),
     setDeviceVolume: (volume: number) =>
       invoke('setConsoleDeviceVolume', deviceCommandResultSchema, { volume }),
     setSpeechMode: (speechModeId: string) =>

--- a/apps/console/src/agent/schema.ts
+++ b/apps/console/src/agent/schema.ts
@@ -174,3 +174,17 @@ export const jobDocumentContentSchema = z.object({
 });
 
 export type JobDocumentContent = z.infer<typeof jobDocumentContentSchema>;
+
+export const broadcastResultSchema = z.object({
+  outcome: z.enum(['delivered', 'queued']),
+});
+
+export type BroadcastResult = z.infer<typeof broadcastResultSchema>;
+
+export const broadcastUploadBeginSchema = z.object({
+  uploadId: z.string(),
+});
+
+export const broadcastUploadChunkSchema = z.object({
+  receivedChunkCount: z.number(),
+});

--- a/apps/console/src/broadcast/__tests__/recorder.spec.ts
+++ b/apps/console/src/broadcast/__tests__/recorder.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  computeRecordingDurationSeconds,
+  convertFloat32ToInt16Pcm,
+  encodePcmToBase64ChunkList,
+  wrapPcmInWavHeader,
+} from '@/broadcast/recorder';
+
+describe('convertFloat32ToInt16Pcm', () => {
+  it('scales and clamps float samples into signed sixteen bit', () => {
+    const pcmSampleList = convertFloat32ToInt16Pcm(
+      new Float32Array([0, 1, -1, 0.5, 2, -2]),
+    );
+    expect(Array.from(pcmSampleList)).toEqual([
+      0, 32_767, -32_767, 16_384, 32_767, -32_767,
+    ]);
+  });
+
+  it('stores samples little-endian', () => {
+    const pcmSampleList = convertFloat32ToInt16Pcm(new Float32Array([1]));
+    const pcmBytes = new Uint8Array(pcmSampleList.buffer);
+    expect(Array.from(pcmBytes)).toEqual([0xff, 0x7f]);
+  });
+});
+
+describe('encodePcmToBase64ChunkList', () => {
+  it('splits into chunks and round-trips through base64', () => {
+    const sourceBytes = new Uint8Array(10);
+    for (let byteIndex = 0; byteIndex < sourceBytes.length; byteIndex += 1) {
+      sourceBytes[byteIndex] = byteIndex;
+    }
+    const base64ChunkList = encodePcmToBase64ChunkList(sourceBytes, 4);
+    expect(base64ChunkList).toHaveLength(3);
+    const decodedBytes = base64ChunkList.flatMap((base64Chunk) =>
+      Array.from(atob(base64Chunk), (character) => character.charCodeAt(0)),
+    );
+    expect(decodedBytes).toEqual(Array.from(sourceBytes));
+  });
+
+  it('computes the chunk count the upload begin call announces', () => {
+    const thirtySecondByteLength = 1_440_000;
+    const base64ChunkList = encodePcmToBase64ChunkList(
+      new Uint8Array(thirtySecondByteLength),
+    );
+    expect(base64ChunkList).toHaveLength(8);
+  });
+});
+
+describe('computeRecordingDurationSeconds', () => {
+  it('derives seconds from the wire byte rate', () => {
+    expect(computeRecordingDurationSeconds(48_000)).toBe(1);
+    expect(computeRecordingDurationSeconds(1_440_000)).toBe(30);
+  });
+});
+
+describe('wrapPcmInWavHeader', () => {
+  it('writes a canonical forty-four byte mono header', async () => {
+    const pcmBytes = new Uint8Array([1, 2, 3, 4]);
+    const wavBlob = wrapPcmInWavHeader(pcmBytes);
+    const wavBytes = new Uint8Array(await wavBlob.arrayBuffer());
+    const headerView = new DataView(wavBytes.buffer);
+    expect(wavBytes.length).toBe(48);
+    expect(String.fromCharCode(...wavBytes.subarray(0, 4))).toBe('RIFF');
+    expect(String.fromCharCode(...wavBytes.subarray(8, 12))).toBe('WAVE');
+    expect(headerView.getUint32(24, true)).toBe(24_000);
+    expect(headerView.getUint16(22, true)).toBe(1);
+    expect(headerView.getUint16(34, true)).toBe(16);
+    expect(headerView.getUint32(40, true)).toBe(4);
+    expect(Array.from(wavBytes.subarray(44))).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/apps/console/src/broadcast/copy.ts
+++ b/apps/console/src/broadcast/copy.ts
@@ -1,0 +1,88 @@
+import type { Locale } from '@/locale/detect';
+
+interface BroadcastMessages {
+  readonly pageTitle: string;
+  readonly pageDescription: string;
+  readonly textPanelTitle: string;
+  readonly textPlaceholder: string;
+  readonly textInputAriaLabel: string;
+  readonly sendTextLabel: string;
+  readonly sendingLabel: string;
+  readonly textMissingError: string;
+  readonly sendFallbackError: string;
+  readonly audioPanelTitle: string;
+  readonly recordLabel: string;
+  readonly stopLabel: string;
+  readonly recordingLabel: (elapsedSeconds: number) => string;
+  readonly maxDurationHint: string;
+  readonly previewAriaLabel: string;
+  readonly discardLabel: string;
+  readonly sendRecordingLabel: string;
+  readonly uploadProgressLabel: (
+    sentChunkCount: number,
+    totalChunkCount: number,
+  ) => string;
+  readonly deliveredFeedback: string;
+  readonly queuedFeedback: string;
+  readonly deviceOfflineHint: string;
+  readonly micDeniedError: string;
+  readonly micUnsupportedError: string;
+}
+
+export const BROADCAST_MESSAGE_CATALOG: Record<Locale, BroadcastMessages> = {
+  es: {
+    pageTitle: 'Difusión',
+    pageDescription: 'Deja un mensaje sonando en el escritorio, estés donde estés',
+    textPanelTitle: 'Mensaje escrito',
+    textPlaceholder: 'Vuelvo a las ocho…',
+    textInputAriaLabel: 'Mensaje para difundir',
+    sendTextLabel: 'Enviar',
+    sendingLabel: 'Enviando…',
+    textMissingError: 'Escribe el mensaje.',
+    sendFallbackError: 'No se pudo enviar — reintenta.',
+    audioPanelTitle: 'Mensaje de voz',
+    recordLabel: 'Grabar',
+    stopLabel: 'Detener',
+    recordingLabel: (elapsedSeconds) => `Grabando… ${elapsedSeconds}s`,
+    maxDurationHint: 'Hasta 30 segundos',
+    previewAriaLabel: 'Escuchar la grabación antes de enviarla',
+    discardLabel: 'Descartar',
+    sendRecordingLabel: 'Enviar grabación',
+    uploadProgressLabel: (sentChunkCount, totalChunkCount) =>
+      `Subiendo ${sentChunkCount}/${totalChunkCount}…`,
+    deliveredFeedback: 'Sonando en el escritorio',
+    queuedFeedback: 'El escritorio está desconectado — se reproducirá al reconectar',
+    deviceOfflineHint:
+      'El dispositivo está desconectado: lo que envíes queda guardado y suena cuando vuelva.',
+    micDeniedError:
+      'El navegador bloqueó el micrófono. Permite el acceso y vuelve a intentar.',
+    micUnsupportedError: 'Este navegador no soporta grabación de audio.',
+  },
+  en: {
+    pageTitle: 'Broadcast',
+    pageDescription: 'Leave a message playing on the desk, wherever you are',
+    textPanelTitle: 'Written message',
+    textPlaceholder: 'Back at eight…',
+    textInputAriaLabel: 'Message to broadcast',
+    sendTextLabel: 'Send',
+    sendingLabel: 'Sending…',
+    textMissingError: 'Write the message.',
+    sendFallbackError: 'Sending failed — try again.',
+    audioPanelTitle: 'Voice message',
+    recordLabel: 'Record',
+    stopLabel: 'Stop',
+    recordingLabel: (elapsedSeconds) => `Recording… ${elapsedSeconds}s`,
+    maxDurationHint: 'Up to 30 seconds',
+    previewAriaLabel: 'Listen to the recording before sending it',
+    discardLabel: 'Discard',
+    sendRecordingLabel: 'Send recording',
+    uploadProgressLabel: (sentChunkCount, totalChunkCount) =>
+      `Uploading ${sentChunkCount}/${totalChunkCount}…`,
+    deliveredFeedback: 'Playing on the desk',
+    queuedFeedback: 'The desk is offline — it will play on reconnect',
+    deviceOfflineHint:
+      'The device is offline: whatever you send is stored and plays when it comes back.',
+    micDeniedError: 'The browser blocked the microphone. Allow access and try again.',
+    micUnsupportedError: 'This browser does not support audio recording.',
+  },
+};

--- a/apps/console/src/broadcast/page.tsx
+++ b/apps/console/src/broadcast/page.tsx
@@ -92,6 +92,21 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
     [previewUrl],
   );
 
+  useEffect(
+    () => () => {
+      // Navigating away mid-recording must release the microphone, not just
+      // remove the controls.
+      const abandonedRecorderHandle = recorderHandleRef.current;
+      if (abandonedRecorderHandle !== null) {
+        recorderHandleRef.current = null;
+        abandonedRecorderHandle.stop().catch(() => {
+          // Releasing an already-torn-down graph has nothing left to report.
+        });
+      }
+    },
+    [],
+  );
+
   async function handleSendText(event: FormEvent) {
     event.preventDefault();
     const trimmedMessage = textMessage.trim();

--- a/apps/console/src/broadcast/page.tsx
+++ b/apps/console/src/broadcast/page.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useRef, useState } from 'react';
+import type { FormEvent } from 'react';
+
+import { Chip } from '@/blueprint/chip';
+import { Heading } from '@/blueprint/heading';
+import { Panel } from '@/blueprint/panel';
+import { BROADCAST_MESSAGE_CATALOG } from '@/broadcast/copy';
+import {
+  BROADCAST_MAX_RECORDING_SECONDS,
+  computeRecordingDurationSeconds,
+  convertFloat32ToInt16Pcm,
+  isRecordingSupported,
+  resampleToTargetRate,
+  startBroadcastRecording,
+  wrapPcmInWavHeader,
+} from '@/broadcast/recorder';
+import { uploadBroadcastAudio } from '@/broadcast/upload';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useMessages } from '@/locale/context';
+import type { ConsoleRpc } from '@/agent/rpc';
+import type { BroadcastResult } from '@/agent/schema';
+import type { BroadcastRecorderHandle } from '@/broadcast/recorder';
+
+type RecorderPhase = 'idle' | 'recording' | 'recorded' | 'uploading';
+
+export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc }) {
+  const broadcastMessages = useMessages(BROADCAST_MESSAGE_CATALOG);
+  const [isDeviceConnected, setIsDeviceConnected] = useState<boolean | null>(null);
+  const [feedbackOutcome, setFeedbackOutcome] = useState<
+    BroadcastResult['outcome'] | null
+  >(null);
+
+  const [textMessage, setTextMessage] = useState('');
+  const [isSendingText, setIsSendingText] = useState(false);
+  const [textErrorMessage, setTextErrorMessage] = useState<string | null>(null);
+
+  const [recorderPhase, setRecorderPhase] = useState<RecorderPhase>('idle');
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<readonly [number, number] | null>(
+    null,
+  );
+  const [audioErrorMessage, setAudioErrorMessage] = useState<string | null>(null);
+  const recorderHandleRef = useRef<BroadcastRecorderHandle | null>(null);
+  const recordedPcmRef = useRef<Uint8Array | null>(null);
+  const stopRecordingRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    let isMounted = true;
+    const probeDeviceConnectivity = async () => {
+      try {
+        const status = await consoleRpc.getStatus();
+        if (isMounted) {
+          setIsDeviceConnected(status.isDeviceConnected);
+        }
+      } catch {
+        // The offline hint is best-effort; a failed probe just hides it.
+      }
+    };
+    void probeDeviceConnectivity();
+    return () => {
+      isMounted = false;
+    };
+  }, [consoleRpc]);
+
+  useEffect(() => {
+    if (recorderPhase !== 'recording') {
+      return;
+    }
+    const intervalId = window.setInterval(() => {
+      setElapsedSeconds((previousSeconds) => previousSeconds + 1);
+    }, 1_000);
+    return () => window.clearInterval(intervalId);
+  }, [recorderPhase]);
+
+  useEffect(() => {
+    if (
+      recorderPhase === 'recording' &&
+      elapsedSeconds >= BROADCAST_MAX_RECORDING_SECONDS
+    ) {
+      stopRecordingRef.current();
+    }
+  }, [elapsedSeconds, recorderPhase]);
+
+  useEffect(
+    () => () => {
+      if (previewUrl !== null) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    },
+    [previewUrl],
+  );
+
+  async function handleSendText(event: FormEvent) {
+    event.preventDefault();
+    const trimmedMessage = textMessage.trim();
+    if (trimmedMessage.length === 0) {
+      setTextErrorMessage(broadcastMessages.textMissingError);
+      return;
+    }
+    setIsSendingText(true);
+    setTextErrorMessage(null);
+    setFeedbackOutcome(null);
+    try {
+      const { outcome } = await consoleRpc.sendBroadcastText(trimmedMessage);
+      setFeedbackOutcome(outcome);
+      setTextMessage('');
+    } catch (error) {
+      setTextErrorMessage(
+        error instanceof Error ? error.message : broadcastMessages.sendFallbackError,
+      );
+    } finally {
+      setIsSendingText(false);
+    }
+  }
+
+  async function handleStartRecording() {
+    if (!isRecordingSupported()) {
+      setAudioErrorMessage(broadcastMessages.micUnsupportedError);
+      return;
+    }
+    setAudioErrorMessage(null);
+    setFeedbackOutcome(null);
+    try {
+      recorderHandleRef.current = await startBroadcastRecording();
+      setElapsedSeconds(0);
+      setRecorderPhase('recording');
+    } catch (error) {
+      setAudioErrorMessage(
+        error instanceof Error && error.name === 'NotAllowedError'
+          ? broadcastMessages.micDeniedError
+          : broadcastMessages.sendFallbackError,
+      );
+    }
+  }
+
+  async function handleStopRecording() {
+    const recorderHandle = recorderHandleRef.current;
+    if (recorderHandle === null) {
+      return;
+    }
+    recorderHandleRef.current = null;
+    const { sampleList, sourceSampleRateHz } = await recorderHandle.stop();
+    const resampledSampleList = await resampleToTargetRate(
+      sampleList,
+      sourceSampleRateHz,
+    );
+    if (resampledSampleList.length === 0) {
+      setRecorderPhase('idle');
+      return;
+    }
+    const pcmSampleList = convertFloat32ToInt16Pcm(resampledSampleList);
+    const pcmBytes = new Uint8Array(
+      pcmSampleList.buffer,
+      pcmSampleList.byteOffset,
+      pcmSampleList.byteLength,
+    );
+    recordedPcmRef.current = pcmBytes;
+    setPreviewUrl(URL.createObjectURL(wrapPcmInWavHeader(pcmBytes)));
+    setRecorderPhase('recorded');
+  }
+
+  stopRecordingRef.current = () => void handleStopRecording();
+
+  function handleDiscardRecording() {
+    recordedPcmRef.current = null;
+    if (previewUrl !== null) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setPreviewUrl(null);
+    setElapsedSeconds(0);
+    setRecorderPhase('idle');
+  }
+
+  async function handleSendRecording() {
+    const pcmBytes = recordedPcmRef.current;
+    if (pcmBytes === null) {
+      return;
+    }
+    setRecorderPhase('uploading');
+    setAudioErrorMessage(null);
+    setFeedbackOutcome(null);
+    try {
+      const outcome = await uploadBroadcastAudio(consoleRpc, pcmBytes, (sent, total) =>
+        setUploadProgress([sent, total]),
+      );
+      setFeedbackOutcome(outcome);
+      handleDiscardRecording();
+    } catch (error) {
+      setAudioErrorMessage(
+        error instanceof Error ? error.message : broadcastMessages.sendFallbackError,
+      );
+      setRecorderPhase('recorded');
+    } finally {
+      setUploadProgress(null);
+    }
+  }
+
+  const recordedDurationSeconds =
+    recordedPcmRef.current === null
+      ? 0
+      : Math.round(computeRecordingDurationSeconds(recordedPcmRef.current.byteLength));
+
+  return (
+    <div className="settle space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <Heading description={broadcastMessages.pageDescription}>
+          {broadcastMessages.pageTitle}
+        </Heading>
+        {feedbackOutcome !== null && (
+          <Chip tone={feedbackOutcome === 'delivered' ? 'live' : 'idle'}>
+            {feedbackOutcome === 'delivered'
+              ? broadcastMessages.deliveredFeedback
+              : broadcastMessages.queuedFeedback}
+          </Chip>
+        )}
+      </div>
+
+      {isDeviceConnected === false && (
+        <p className="border px-3 py-2 text-xs text-muted-foreground">
+          {broadcastMessages.deviceOfflineHint}
+        </p>
+      )}
+
+      <Panel title={broadcastMessages.textPanelTitle}>
+        <form
+          onSubmit={handleSendText}
+          className="flex flex-wrap items-center gap-2 p-3"
+          aria-busy={isSendingText}
+        >
+          <Input
+            value={textMessage}
+            onChange={(event) => setTextMessage(event.target.value)}
+            placeholder={broadcastMessages.textPlaceholder}
+            aria-label={broadcastMessages.textInputAriaLabel}
+            maxLength={500}
+            className="h-8 min-w-48 flex-1 text-sm"
+          />
+          <Button type="submit" size="sm" disabled={isSendingText}>
+            {isSendingText
+              ? broadcastMessages.sendingLabel
+              : broadcastMessages.sendTextLabel}
+          </Button>
+        </form>
+        {textErrorMessage !== null && (
+          <p role="alert" className="px-3 pb-3 text-xs text-destructive">
+            {textErrorMessage}
+          </p>
+        )}
+      </Panel>
+
+      <Panel
+        title={broadcastMessages.audioPanelTitle}
+        meta={
+          <span className="text-xs text-dim">{broadcastMessages.maxDurationHint}</span>
+        }
+      >
+        <div className="space-y-3 p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {recorderPhase === 'idle' && (
+              <Button size="sm" onClick={() => void handleStartRecording()}>
+                {broadcastMessages.recordLabel}
+              </Button>
+            )}
+            {recorderPhase === 'recording' && (
+              <>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => void handleStopRecording()}
+                >
+                  {broadcastMessages.stopLabel}
+                </Button>
+                <span role="status" className="text-xs text-muted-foreground">
+                  {broadcastMessages.recordingLabel(elapsedSeconds)}
+                </span>
+              </>
+            )}
+            {recorderPhase === 'recorded' && (
+              <>
+                <Button size="sm" onClick={() => void handleSendRecording()}>
+                  {broadcastMessages.sendRecordingLabel}
+                </Button>
+                <Button size="sm" variant="outline" onClick={handleDiscardRecording}>
+                  {broadcastMessages.discardLabel}
+                </Button>
+                <span className="text-xs text-dim">{recordedDurationSeconds}s</span>
+              </>
+            )}
+            {recorderPhase === 'uploading' && uploadProgress !== null && (
+              <span role="status" className="text-xs text-muted-foreground">
+                {broadcastMessages.uploadProgressLabel(
+                  uploadProgress[0],
+                  uploadProgress[1],
+                )}
+              </span>
+            )}
+          </div>
+          {previewUrl !== null && recorderPhase !== 'uploading' && (
+            <audio
+              controls
+              src={previewUrl}
+              aria-label={broadcastMessages.previewAriaLabel}
+              className="h-9 w-full max-w-md"
+            />
+          )}
+          {audioErrorMessage !== null && (
+            <p role="alert" className="text-xs text-destructive">
+              {audioErrorMessage}
+            </p>
+          )}
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/console/src/broadcast/page.tsx
+++ b/apps/console/src/broadcast/page.tsx
@@ -45,6 +45,7 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
   const recorderHandleRef = useRef<BroadcastRecorderHandle | null>(null);
   const recordedPcmRef = useRef<Uint8Array | null>(null);
   const stopRecordingRef = useRef<() => void>(() => {});
+  const isUnmountedRef = useRef(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -96,6 +97,7 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
     () => () => {
       // Navigating away mid-recording must release the microphone, not just
       // remove the controls.
+      isUnmountedRef.current = true;
       const abandonedRecorderHandle = recorderHandleRef.current;
       if (abandonedRecorderHandle !== null) {
         recorderHandleRef.current = null;
@@ -138,7 +140,16 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
     setAudioErrorMessage(null);
     setFeedbackOutcome(null);
     try {
-      recorderHandleRef.current = await startBroadcastRecording();
+      const recorderHandle = await startBroadcastRecording();
+      if (isUnmountedRef.current) {
+        // The page went away while the microphone was being acquired; there is
+        // no ref left that could ever stop this handle, so stop it here.
+        recorderHandle.stop().catch(() => {
+          // Releasing an already-torn-down graph has nothing left to report.
+        });
+        return;
+      }
+      recorderHandleRef.current = recorderHandle;
       setElapsedSeconds(0);
       setRecorderPhase('recording');
     } catch (error) {

--- a/apps/console/src/broadcast/page.tsx
+++ b/apps/console/src/broadcast/page.tsx
@@ -46,6 +46,7 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
   const recordedPcmRef = useRef<Uint8Array | null>(null);
   const stopRecordingRef = useRef<() => void>(() => {});
   const isUnmountedRef = useRef(false);
+  const isStartingRecordingRef = useRef(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -133,10 +134,17 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
   }
 
   async function handleStartRecording() {
+    // Guarded by a ref, not the phase state: the phase only flips after the
+    // microphone resolves, so a double click would acquire two streams and
+    // strand the first one without a reachable stop.
+    if (isStartingRecordingRef.current || recorderHandleRef.current !== null) {
+      return;
+    }
     if (!isRecordingSupported()) {
       setAudioErrorMessage(broadcastMessages.micUnsupportedError);
       return;
     }
+    isStartingRecordingRef.current = true;
     setAudioErrorMessage(null);
     setFeedbackOutcome(null);
     try {
@@ -158,6 +166,8 @@ export function BroadcastPage({ consoleRpc }: { readonly consoleRpc: ConsoleRpc 
           ? broadcastMessages.micDeniedError
           : broadcastMessages.sendFallbackError,
       );
+    } finally {
+      isStartingRecordingRef.current = false;
     }
   }
 

--- a/apps/console/src/broadcast/recorder.ts
+++ b/apps/console/src/broadcast/recorder.ts
@@ -1,0 +1,199 @@
+// The ESP32 has no audio decoder, so the browser must produce the exact wire
+// format: raw s16le mono PCM at 24 kHz. Capture happens at the hardware rate
+// through an AudioWorklet and is resampled offline before upload.
+export const BROADCAST_TARGET_SAMPLE_RATE_HZ = 24_000;
+export const BROADCAST_MAX_RECORDING_SECONDS = 30;
+export const BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH = 180_000;
+
+const CAPTURE_WORKLET_SOURCE = `
+class BroadcastCaptureProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const channelSamples = inputs[0]?.[0];
+    if (channelSamples !== undefined) {
+      this.port.postMessage(channelSamples.slice(0));
+    }
+    return true;
+  }
+}
+registerProcessor('broadcastcapture', BroadcastCaptureProcessor);
+`;
+
+export type BroadcastRecorderHandle = {
+  readonly stop: () => Promise<{
+    readonly sampleList: Float32Array<ArrayBuffer>;
+    readonly sourceSampleRateHz: number;
+  }>;
+};
+
+export function isRecordingSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.mediaDevices?.getUserMedia !== undefined &&
+    typeof AudioWorkletNode !== 'undefined'
+  );
+}
+
+export async function startBroadcastRecording(): Promise<BroadcastRecorderHandle> {
+  const mediaStream = await navigator.mediaDevices.getUserMedia({
+    audio: { echoCancellation: true, noiseSuppression: true },
+  });
+  const audioContext = new AudioContext();
+  const workletUrl = URL.createObjectURL(
+    new Blob([CAPTURE_WORKLET_SOURCE], { type: 'application/javascript' }),
+  );
+  try {
+    await audioContext.audioWorklet.addModule(workletUrl);
+  } finally {
+    URL.revokeObjectURL(workletUrl);
+  }
+
+  const capturedChunkList: Float32Array<ArrayBuffer>[] = [];
+  const maxSampleCount = BROADCAST_MAX_RECORDING_SECONDS * audioContext.sampleRate;
+  let capturedSampleCount = 0;
+
+  const captureNode = new AudioWorkletNode(audioContext, 'broadcastcapture', {
+    numberOfInputs: 1,
+    numberOfOutputs: 0,
+    channelCount: 1,
+  });
+  const handleCapturedChunk = (messageEvent: MessageEvent<Float32Array<ArrayBuffer>>) => {
+    if (capturedSampleCount >= maxSampleCount) {
+      return;
+    }
+    capturedChunkList.push(messageEvent.data);
+    capturedSampleCount += messageEvent.data.length;
+  };
+  captureNode.port.addEventListener('message', handleCapturedChunk);
+  captureNode.port.start();
+  audioContext.createMediaStreamSource(mediaStream).connect(captureNode);
+
+  return {
+    stop: async () => {
+      captureNode.port.removeEventListener('message', handleCapturedChunk);
+      captureNode.disconnect();
+      for (const track of mediaStream.getTracks()) {
+        track.stop();
+      }
+      const sourceSampleRateHz = audioContext.sampleRate;
+      await audioContext.close();
+      return {
+        sampleList: concatenateSampleChunks(capturedChunkList, maxSampleCount),
+        sourceSampleRateHz,
+      };
+    },
+  };
+}
+
+function concatenateSampleChunks(
+  chunkList: readonly Float32Array<ArrayBuffer>[],
+  maxSampleCount: number,
+): Float32Array<ArrayBuffer> {
+  const totalSampleCount = Math.min(
+    chunkList.reduce((total, chunk) => total + chunk.length, 0),
+    maxSampleCount,
+  );
+  const concatenated = new Float32Array(totalSampleCount);
+  let writeOffset = 0;
+  for (const chunk of chunkList) {
+    const remainingSampleCount = totalSampleCount - writeOffset;
+    if (remainingSampleCount <= 0) {
+      break;
+    }
+    const boundedChunk =
+      chunk.length > remainingSampleCount
+        ? chunk.subarray(0, remainingSampleCount)
+        : chunk;
+    concatenated.set(boundedChunk, writeOffset);
+    writeOffset += boundedChunk.length;
+  }
+  return concatenated;
+}
+
+export async function resampleToTargetRate(
+  sampleList: Float32Array<ArrayBuffer>,
+  sourceSampleRateHz: number,
+): Promise<Float32Array<ArrayBuffer>> {
+  if (sampleList.length === 0) {
+    return new Float32Array(0);
+  }
+  if (sourceSampleRateHz === BROADCAST_TARGET_SAMPLE_RATE_HZ) {
+    return sampleList;
+  }
+  const targetSampleCount = Math.ceil(
+    (sampleList.length / sourceSampleRateHz) * BROADCAST_TARGET_SAMPLE_RATE_HZ,
+  );
+  const offlineContext = new OfflineAudioContext(
+    1,
+    targetSampleCount,
+    BROADCAST_TARGET_SAMPLE_RATE_HZ,
+  );
+  const sourceBuffer = offlineContext.createBuffer(
+    1,
+    sampleList.length,
+    sourceSampleRateHz,
+  );
+  sourceBuffer.copyToChannel(sampleList, 0);
+  const bufferSource = offlineContext.createBufferSource();
+  bufferSource.buffer = sourceBuffer;
+  bufferSource.connect(offlineContext.destination);
+  bufferSource.start();
+  const renderedBuffer = await offlineContext.startRendering();
+  return renderedBuffer.getChannelData(0);
+}
+
+export function convertFloat32ToInt16Pcm(sampleList: Float32Array): Int16Array {
+  const pcmSampleList = new Int16Array(sampleList.length);
+  for (let sampleIndex = 0; sampleIndex < sampleList.length; sampleIndex += 1) {
+    const clampedSample = Math.max(-1, Math.min(1, sampleList[sampleIndex] ?? 0));
+    pcmSampleList[sampleIndex] = Math.round(clampedSample * 32_767);
+  }
+  return pcmSampleList;
+}
+
+export function encodePcmToBase64ChunkList(
+  pcmBytes: Uint8Array,
+  chunkByteLength: number = BROADCAST_UPLOAD_CHUNK_RAW_BYTE_LENGTH,
+): string[] {
+  const base64ChunkList: string[] = [];
+  for (let readOffset = 0; readOffset < pcmBytes.length; readOffset += chunkByteLength) {
+    const chunkBytes = pcmBytes.subarray(readOffset, readOffset + chunkByteLength);
+    let binaryString = '';
+    for (const byteValue of chunkBytes) {
+      binaryString += String.fromCharCode(byteValue);
+    }
+    base64ChunkList.push(btoa(binaryString));
+  }
+  return base64ChunkList;
+}
+
+export function computeRecordingDurationSeconds(pcmByteLength: number): number {
+  return pcmByteLength / (BROADCAST_TARGET_SAMPLE_RATE_HZ * 2);
+}
+
+// A 44-byte canonical RIFF header so the recording can be previewed through a
+// plain <audio> element before it is sent.
+export function wrapPcmInWavHeader(pcmBytes: Uint8Array): Blob {
+  const headerBytes = new ArrayBuffer(44);
+  const headerView = new DataView(headerBytes);
+  const bytesPerSecond = BROADCAST_TARGET_SAMPLE_RATE_HZ * 2;
+  writeAsciiTag(headerView, 0, 'RIFF');
+  headerView.setUint32(4, 36 + pcmBytes.length, true);
+  writeAsciiTag(headerView, 8, 'WAVE');
+  writeAsciiTag(headerView, 12, 'fmt ');
+  headerView.setUint32(16, 16, true);
+  headerView.setUint16(20, 1, true);
+  headerView.setUint16(22, 1, true);
+  headerView.setUint32(24, BROADCAST_TARGET_SAMPLE_RATE_HZ, true);
+  headerView.setUint32(28, bytesPerSecond, true);
+  headerView.setUint16(32, 2, true);
+  headerView.setUint16(34, 16, true);
+  writeAsciiTag(headerView, 36, 'data');
+  headerView.setUint32(40, pcmBytes.length, true);
+  return new Blob([headerBytes, pcmBytes.slice().buffer], { type: 'audio/wav' });
+}
+
+function writeAsciiTag(view: DataView, byteOffset: number, tag: string): void {
+  for (let characterIndex = 0; characterIndex < tag.length; characterIndex += 1) {
+    view.setUint8(byteOffset + characterIndex, tag.charCodeAt(characterIndex));
+  }
+}

--- a/apps/console/src/broadcast/recorder.ts
+++ b/apps/console/src/broadcast/recorder.ts
@@ -37,7 +37,25 @@ export async function startBroadcastRecording(): Promise<BroadcastRecorderHandle
   const mediaStream = await navigator.mediaDevices.getUserMedia({
     audio: { echoCancellation: true, noiseSuppression: true },
   });
-  const audioContext = new AudioContext();
+  let audioContext: AudioContext | null = null;
+  try {
+    audioContext = new AudioContext();
+    return await wireCaptureGraph(mediaStream, audioContext);
+  } catch (setupError) {
+    // The stream is live the moment getUserMedia resolves; a failure while
+    // wiring the graph must not leave the microphone capturing.
+    for (const track of mediaStream.getTracks()) {
+      track.stop();
+    }
+    await audioContext?.close();
+    throw setupError;
+  }
+}
+
+async function wireCaptureGraph(
+  mediaStream: MediaStream,
+  audioContext: AudioContext,
+): Promise<BroadcastRecorderHandle> {
   const workletUrl = URL.createObjectURL(
     new Blob([CAPTURE_WORKLET_SOURCE], { type: 'application/javascript' }),
   );

--- a/apps/console/src/broadcast/upload.ts
+++ b/apps/console/src/broadcast/upload.ts
@@ -1,0 +1,29 @@
+import { encodePcmToBase64ChunkList } from '@/broadcast/recorder';
+import type { ConsoleRpc } from '@/agent/rpc';
+import type { BroadcastResult } from '@/agent/schema';
+
+// Chunks go up sequentially on the already-open RPC socket; any failure aborts
+// the whole upload and the caller restarts from the first chunk, because the
+// server session may have been evicted in between.
+export async function uploadBroadcastAudio(
+  consoleRpc: ConsoleRpc,
+  pcmBytes: Uint8Array,
+  onProgress: (sentChunkCount: number, totalChunkCount: number) => void,
+): Promise<BroadcastResult['outcome']> {
+  const base64ChunkList = encodePcmToBase64ChunkList(pcmBytes);
+  onProgress(0, base64ChunkList.length);
+  const { uploadId } = await consoleRpc.beginBroadcastAudioUpload(
+    pcmBytes.length,
+    base64ChunkList.length,
+  );
+  for (let chunkIndex = 0; chunkIndex < base64ChunkList.length; chunkIndex += 1) {
+    const base64Chunk = base64ChunkList[chunkIndex];
+    if (base64Chunk === undefined) {
+      throw new Error('Missing chunk while uploading');
+    }
+    await consoleRpc.appendBroadcastAudioChunk(uploadId, chunkIndex, base64Chunk);
+    onProgress(chunkIndex + 1, base64ChunkList.length);
+  }
+  const { outcome } = await consoleRpc.commitBroadcastAudioUpload(uploadId);
+  return outcome;
+}

--- a/apps/console/src/components/icons.tsx
+++ b/apps/console/src/components/icons.tsx
@@ -1,4 +1,5 @@
 import {
+  MdOutlineCampaign,
   MdOutlineClose,
   MdOutlineDescription,
   MdOutlineExtension,
@@ -32,6 +33,7 @@ function LogoMark({ size = 20, ...props }: IconBaseProps) {
 }
 
 export const Icons = {
+  Broadcast: MdOutlineCampaign,
   Close: MdOutlineClose,
   Device: MdOutlineSpeaker,
   History: MdOutlineQuestionAnswer,

--- a/apps/console/src/layout/nav.tsx
+++ b/apps/console/src/layout/nav.tsx
@@ -12,6 +12,7 @@ import type { ConsoleRoute } from '@/router/route';
 export const ROUTE_ICON_MAP = {
   status: Icons.Status,
   device: Icons.Device,
+  broadcast: Icons.Broadcast,
   mcp: Icons.Mcp,
   memory: Icons.Memory,
   schedules: Icons.Schedules,

--- a/apps/console/src/layout/shell.tsx
+++ b/apps/console/src/layout/shell.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useSyncExternalStore } from 'react';
 
 import { useApolloAgent } from '@/agent/hook';
 import { createConsoleRpc } from '@/agent/rpc';
+import { BroadcastPage } from '@/broadcast/page';
 import { Icons } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/utility';
@@ -121,6 +122,7 @@ export function Shell({ connection }: { readonly connection: ConsoleConnection }
           {activeRoute === 'device' && (
             <DevicePage agent={agent} consoleRpc={consoleRpc} />
           )}
+          {activeRoute === 'broadcast' && <BroadcastPage consoleRpc={consoleRpc} />}
           {activeRoute === 'mcp' && <McpPage consoleRpc={consoleRpc} />}
           {activeRoute === 'memory' && <MemoryPage consoleRpc={consoleRpc} />}
           {activeRoute === 'schedules' && <SchedulesPage consoleRpc={consoleRpc} />}

--- a/apps/console/src/router/metadata.ts
+++ b/apps/console/src/router/metadata.ts
@@ -8,6 +8,7 @@ export const ROUTE_LABEL_CATALOG: Record<Locale, Record<ConsoleRoute, string>> =
   es: {
     status: 'Estado',
     device: 'Dispositivo',
+    broadcast: 'Difusión',
     mcp: 'MCP',
     memory: 'Memoria',
     schedules: 'Agenda',
@@ -17,6 +18,7 @@ export const ROUTE_LABEL_CATALOG: Record<Locale, Record<ConsoleRoute, string>> =
   en: {
     status: 'Status',
     device: 'Device',
+    broadcast: 'Broadcast',
     mcp: 'MCP',
     memory: 'Memory',
     schedules: 'Schedules',
@@ -31,6 +33,8 @@ export const ROUTE_DESCRIPTION_CATALOG: Record<Locale, Record<ConsoleRoute, stri
       'Estado del agente en vivo, conectividad del dispositivo y telemetría de un vistazo.',
     device:
       'El dispositivo de escritorio en 3D, con controles de modo, volumen, brillo y ubicación del clima.',
+    broadcast:
+      'Habla al escritorio al instante — escribe una frase o graba tu voz y suena en el dispositivo.',
     mcp: 'Servidores MCP instalados, su estado de conexión y habilitación por herramienta.',
     memory: 'Lo que el agente recuerda — memorias, datos del dueño y listas.',
     schedules: 'Recordatorios programados y temporizadores en curso.',
@@ -41,6 +45,8 @@ export const ROUTE_DESCRIPTION_CATALOG: Record<Locale, Record<ConsoleRoute, stri
     status: 'Live agent status, device connectivity, and telemetry at a glance.',
     device:
       'The desk device in 3D, with mode, volume, brightness, and weather location controls.',
+    broadcast:
+      'Speak to the desk instantly — type a phrase or record your voice and it plays on the device.',
     mcp: 'Installed MCP servers, their connection state, and per-tool enablement.',
     memory: 'What the agent remembers — memories, owner facts, and lists.',
     schedules: 'Scheduled reminders and running timers.',

--- a/apps/console/src/router/route.ts
+++ b/apps/console/src/router/route.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStore } from 'react';
 export type ConsoleRoute =
   | 'status'
   | 'device'
+  | 'broadcast'
   | 'mcp'
   | 'memory'
   | 'schedules'
@@ -12,6 +13,7 @@ export type ConsoleRoute =
 export const CONSOLE_ROUTE_LIST: readonly ConsoleRoute[] = [
   'status',
   'device',
+  'broadcast',
   'mcp',
   'memory',
   'schedules',

--- a/documentation/capabilities/broadcast.md
+++ b/documentation/capabilities/broadcast.md
@@ -1,0 +1,25 @@
+# Broadcast
+
+Broadcast lets the owner speak through the desk from the console: type a phrase and Apollo reads it aloud in its own voice, or record audio and the device plays the owner's actual voice. It exists for leaving messages to whoever is near the desk when the owner is not — "vuelvo a las ocho" sounding in the room, not a notification on a phone.
+
+## Delivery
+
+Both modes are owner-triggered, so they bypass every proactive-speech policy on purpose: no quiet hours, no daily budget, no focus deferral, no initiative engine. The device plays a `chime` earcon, then the standard speech run (`tts_start` → PCM frames → `tts_end` → `turn_end { expectsReply: false }`). A text broadcast also sends a `reminder` card so the screen shows the message; an audio broadcast is sound only. Nothing here required a firmware change — the wire vocabulary is entirely reused.
+
+Text goes through the normal TTS pipeline (sanitize, ElevenLabs, R2 cache). Recorded audio never touches ElevenLabs: the browser produces the exact wire format — raw s16le mono PCM at 24 kHz — by capturing through an `AudioWorklet` and resampling with an `OfflineAudioContext`, because the Worker has no audio decoder and the ESP32 cannot decode anything else.
+
+## Upload
+
+The console cannot push binary frames over its WebSocket (non-device connections are excluded from raw message handling by design), so recorded audio rides the RPC surface as base64 chunks: `beginConsoleBroadcastAudioUpload` → up to 8 × `appendConsoleBroadcastAudioChunk` (180,000 raw bytes each) → `commitConsoleBroadcastAudioUpload`. Recordings cap at 30 seconds (1,440,000 bytes), which keeps every chunk far under the WebSocket frame limit. Upload sessions live in Durable Object memory with a 2-minute TTL; a DO restart mid-upload fails the commit with a clear error and the console restarts from the first chunk.
+
+## Offline queueing
+
+A broadcast sent while the device is offline is not lost: text is stored as a pending row (and re-synthesized on delivery — the TTS cache makes this free), audio is stored in R2 under `broadcast-audio/<id>.pcm` with a pending row pointing at it. On the next device connect the pending flush replays broadcasts *with sound* — chime plus the full speech run — unlike reminders and background results, which replay as silent cards. Queued broadcasts expire after 24 hours; the flush sweeps expired rows and their R2 objects before replaying.
+
+## Where the code lives
+
+`apps/agent/src/broadcast/` holds the pure upload/session logic (`logic.ts`) and the delivery orchestration (`deliver.ts`); the `@callable` wrappers sit in `apps/agent/src/agents/apollo.ts`. The console page is `apps/console/src/broadcast/` — recorder, upload client, and the panel UI.
+
+## Navigation
+
+Prev: [Timers](timers.md) · Next: [Lists](lists.md)

--- a/documentation/capabilities/lists.md
+++ b/documentation/capabilities/lists.md
@@ -27,4 +27,4 @@ the device reads it literally, so markdown would be spoken out loud (see
 
 ## Navigation
 
-Prev: [Timers](timers.md) · Next: [Dollar rates](rates.md)
+Prev: [Broadcast](broadcast.md) · Next: [Dollar rates](rates.md)

--- a/documentation/capabilities/timers.md
+++ b/documentation/capabilities/timers.md
@@ -35,4 +35,4 @@ Carrying duration/remaining on the wire so the device can draw a countdown arc i
 
 ## Navigation
 
-Prev: [Reminders](reminders.md) · Next: [Lists](lists.md)
+Prev: [Reminders](reminders.md) · Next: [Broadcast](broadcast.md)

--- a/documentation/console/product.md
+++ b/documentation/console/product.md
@@ -29,6 +29,7 @@ The owner enters their worker URL, device instance name (default `desk`), and th
 ## Capabilities and Constraints
 
 - V1 areas (user-confirmed): MCP servers & tools, live status & telemetry, memory browser, schedules & reminders.
+- Broadcast (added 2026-08-13): typed phrases spoken by Apollo or owner-recorded audio played on the device, immediate and policy-free, queued while the device is offline. The browser produces the wire PCM (24 kHz s16le mono) and uploads it as chunked base64 RPCs — the read-and-RPC constraint holds.
 - The console must never take the device's protocol path (dashboard connections are deliberately excluded from device message handling) and never call agent state writes; it is read-and-RPC only.
 - MCP servers can require OAuth: install returns an authUrl the owner must open; server state may be `authenticating`/`failed`; tool enablement is opt-in with safety levels (`safe`/`confirm`/`unsafe`).
 - Telemetry is a snapshot with staleness (receivedAtMs), not a stream; the device pushes it only while connected.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -29,30 +29,31 @@ This handbook is meant to be read in order. Later chapters assume the concepts i
 13. [Focus](capabilities/focus.md) — Focus timer behavior
 14. [Reminders](capabilities/reminders.md) — Schedules and delivery
 15. [Timers](capabilities/timers.md) — Countdowns and pomodoros
-16. [Lists](capabilities/lists.md) — Durable spoken lists
-17. [Dollar rates](capabilities/rates.md) — Argentine dollar quotes
-18. [Email](capabilities/email.md) — Reports and notes to the owner
-19. [Sandbox](capabilities/sandbox.md) — Isolated code execution
-20. [Coding](capabilities/coding.md) — Clone a repo, change it, open a pull request
-21. [MCP servers](capabilities/mcp.md) — Connect external tools at runtime
+16. [Broadcast](capabilities/broadcast.md) — Owner messages spoken through the desk, typed or recorded
+17. [Lists](capabilities/lists.md) — Durable spoken lists
+18. [Dollar rates](capabilities/rates.md) — Argentine dollar quotes
+19. [Email](capabilities/email.md) — Reports and notes to the owner
+20. [Sandbox](capabilities/sandbox.md) — Isolated code execution
+21. [Coding](capabilities/coding.md) — Clone a repo, change it, open a pull request
+22. [MCP servers](capabilities/mcp.md) — Connect external tools at runtime
 
 ### Part IV — Operations
 
-22. [Setup](operations/setup.md) — Local development
-23. [Deploy](operations/deploy.md) — Workers, bindings, secrets, and vars
-24. [Auth](operations/auth.md) — Device and dashboard credentials
-25. [Testing](operations/testing.md) — How this repo verifies behavior
+23. [Setup](operations/setup.md) — Local development
+24. [Deploy](operations/deploy.md) — Workers, bindings, secrets, and vars
+25. [Auth](operations/auth.md) — Device and dashboard credentials
+26. [Testing](operations/testing.md) — How this repo verifies behavior
 
 ### Part V — Console
 
-26. [Product](console/product.md) — What the console is for and who it serves
-27. [Design](console/design.md) — The console's visual system, documented from the code as built
-28. [Landing](console/landing.md) — The marketing landing at `/`, its narrative, pixel face, and motion policy
+27. [Product](console/product.md) — What the console is for and who it serves
+28. [Design](console/design.md) — The console's visual system, documented from the code as built
+29. [Landing](console/landing.md) — The marketing landing at `/`, its narrative, pixel face, and motion policy
 
 ### Part VI — Reference
 
-29. [Mapping](reference/mapping.md) — Handbook topics to `apps/agent/src/` folders
-30. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
+30. [Mapping](reference/mapping.md) — Handbook topics to `apps/agent/src/` folders
+31. [Roadmap](reference/roadmap.md) — Confirmed work, proposals, and open ideas
 
 ## The firmware
 

--- a/documentation/reference/mapping.md
+++ b/documentation/reference/mapping.md
@@ -19,6 +19,7 @@ Thin map from handbook topics to code folders. Prefer the narrative chapters for
 | Focus | `apps/agent/src/focus/`, `apps/agent/src/tools/focus.ts` |
 | Reminders | `apps/agent/src/reminders/`, `apps/agent/src/tools/reminder.ts` |
 | Timers / pomodoro | `apps/agent/src/tools/timer.ts` (rides `apps/agent/src/reminders/`) |
+| Broadcast | `apps/agent/src/broadcast/`, `apps/console/src/broadcast/` |
 | Lists | `apps/agent/src/lists/`, `apps/agent/src/tools/list.ts` |
 | Dollar rates | `apps/agent/src/rates/`, `apps/agent/src/tools/dollar.ts` |
 | Email | `apps/agent/src/notifications/`, `apps/agent/src/tools/email.ts` |

--- a/documentation/runtime/protocol.md
+++ b/documentation/runtime/protocol.md
@@ -53,7 +53,8 @@ no-op (it used to mute the microphone and did so invisibly — see `#handleGestu
 | `mcp` | JSON-RPC request for the device's embedded MCP server |
 
 `play_effect` carries a logical `name` — `ding` (timer/reminder landing), `chime`
-(confirmation request), `error` (turn failure), `low_battery` — and the firmware maps
+(confirmation request and console broadcasts), `error` (turn failure), `low_battery` —
+and the firmware maps
 names to flash assets, so the server can re-purpose sounds without a flash. Unknown
 names are logged and ignored. The point is latency: the earcon plays instantly while the
 TTS announcement is still being synthesized, and it costs no ElevenLabs credits.
@@ -61,6 +62,13 @@ TTS announcement is still being synthesized, and it costs no ElevenLabs credits.
 `tts_start` carries `format` (always `pcm` in production), `bytes` for the clip that
 follows, and optional `sampleRate` / `channels` — 24 000 Hz mono, so the ESP32 needs no
 decoder. The binary frames that follow belong to the clip just announced.
+
+Console broadcasts ([Broadcast](../capabilities/broadcast.md)) add no vocabulary of
+their own: a text broadcast is a `chime` effect, a `reminder` card, and a standard
+`tts_start`/PCM/`tts_end`/`turn_end` run; an audio broadcast is the same minus the card,
+with the PCM recorded by the owner instead of synthesized. Pending replay on reconnect
+may therefore speak — queued broadcasts deliver with sound, while queued reminders and
+background results stay silent cards.
 
 `turn_end.expectsReply` is the model's own judgment: the persona appends an `[[escucho]]`
 mark when its reply asks the user for something (a reply ending in `?` counts even


### PR DESCRIPTION
## What

A broadcast system: from the console, type a phrase or record audio and the desk device plays it immediately — Apollo's ElevenLabs voice for text, the owner's actual voice for recordings. Built for leaving messages to whoever is near the desk when the owner is not.

## How

- **Delivery** reuses the proactive-speech backbone: `chime` earcon → `reminder` card (text only) → standard `tts_start`/PCM/`tts_end`/`turn_end` run. The speech-framing block of `notify.ts` is extracted into `announcePcmToConnections` so owner-recorded PCM rides the exact same paced path as TTS. **No firmware changes.**
- **Policy-free on purpose**: owner-triggered means explicit intent, so broadcasts bypass quiet hours, the daily initiative budget, and focus mode.
- **Audio pipeline** is browser-side (the Worker has no decoder): AudioWorklet capture → `OfflineAudioContext` resample to 24 kHz s16le mono → ≤8 base64 chunks of 180 KB raw over the dashboard RPC socket (`begin`/`append`/`commit`), 30-second cap.
- **Offline queueing**: text queues as a pending row (re-synthesized on delivery, TTS cache makes it free); audio goes to R2 under `broadcast-audio/<id>.pcm`. The reconnect flush sweeps entries older than 24 h and replays survivors *with sound*, unlike the silent card replay reminders get.
- **Console**: new `/console/broadcast` route (Difusión), composer with text field, recorder with WAV preview and per-chunk upload progress, delivered/queued feedback chips, offline hint, full es/en copy.

## Testing

- `bun run check` green repo-wide: 593 agent tests + 75 console tests, lint, format, typecheck.
- New specs: upload session lifecycle and PCM assembly, delivery frame sequences against fake connections/R2, pending-queue round-trips, recorder PCM conversion/chunking/WAV header, console RPC payload shapes.
- Console build prerenders `broadcast.html`.

## Docs

New handbook chapter `documentation/capabilities/broadcast.md`; updates to `protocol.md`, `console/product.md`, `mapping.md`, and the index read order.

## Review

Greptile: **5/5, zero comments** after 4 review iterations. The loop surfaced and fixed three real microphone-lifecycle bugs: capture leaking when recorder setup fails after `getUserMedia`, capture surviving page unmount (including a start that resolves after unmount), and concurrent record starts orphaning a stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7XJDFReJTuUFiiYcYhrXS

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds console-triggered text and recorded-audio broadcasts using the existing device speech protocol, including offline persistence and replay.
- Adds authenticated text and chunked PCM upload RPCs.
- Adds queued broadcast storage, expiry, replay, and R2 audio cleanup.
- Adds the broadcast console route, recording controls, localized copy, tests, and documentation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported microphone leaks are addressed for setup failures, active-recording unmounts, and recording starts that resolve after unmount.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20galfrevn%2Fapollo%20PR%20%2355%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=galfrevn%2Fapollo&pr=55&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(console): guard concurrent record st..."](https://github.com/galfrevn/apollo/commit/df1d2292730c661773d57023626a5d8591b0d2ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53014369)</sub>

<!-- /greptile_comment -->