### PR TITLE
feat(console): docs surface at heyapollo.dev/docs

### DIFF
--- a/apps/console/public/llms.txt
+++ b/apps/console/public/llms.txt
@@ -16,7 +16,7 @@ Apollo tiene licencia MIT y es gratis. El cerebro se despliega con un comando a 
 ## Enlaces
 
 - [Repositorio](https://github.com/galfrevn/apollo)
-- [Documentación](https://github.com/galfrevn/apollo/tree/main/documentation)
+- [Documentación](https://heyapollo.dev/docs)
 - [Landing en español](https://heyapollo.dev/)
 - [Consola](https://heyapollo.dev/console)
 
@@ -29,3 +29,4 @@ Apollo is MIT licensed and free. The brain deploys with one command to your own 
 Capabilities: voice turns tuned for a desk device, memory recalled by meaning (Vectorize), reminders that fire on the device itself, live answers condensed from web research, a sandboxed coding agent for repository work, and your own services connected over MCP.
 
 - [English landing](https://heyapollo.dev/en)
+- [Handbook](https://heyapollo.dev/docs)

--- a/apps/console/public/sitemap.xml
+++ b/apps/console/public/sitemap.xml
@@ -41,4 +41,28 @@
       href="https://heyapollo.dev/"
     />
   </url>
+  <url>
+    <loc>https://heyapollo.dev/docs</loc>
+    <lastmod>2026-08-13</lastmod>
+  </url>
+  <url>
+    <loc>https://heyapollo.dev/docs/purpose</loc>
+    <lastmod>2026-08-13</lastmod>
+  </url>
+  <url>
+    <loc>https://heyapollo.dev/docs/concepts</loc>
+    <lastmod>2026-08-13</lastmod>
+  </url>
+  <url>
+    <loc>https://heyapollo.dev/docs/loop</loc>
+    <lastmod>2026-08-13</lastmod>
+  </url>
+  <url>
+    <loc>https://heyapollo.dev/docs/protocol</loc>
+    <lastmod>2026-08-13</lastmod>
+  </url>
+  <url>
+    <loc>https://heyapollo.dev/docs/setup</loc>
+    <lastmod>2026-08-13</lastmod>
+  </url>
 </urlset>

--- a/apps/console/scripts/discovery.ts
+++ b/apps/console/scripts/discovery.ts
@@ -1,5 +1,7 @@
 import { mkdir, rm } from 'node:fs/promises';
 
+import { DOCS_CHAPTER_LIST } from '@/docs/catalog';
+import { buildDocsDocument } from '@/docs/static';
 import {
   collectLandingPreloadPathList,
   injectModulePreloadLinkList,
@@ -8,6 +10,8 @@ import {
 } from '@/landing/preload';
 import { buildConsoleDocument, buildLandingDocument } from '@/landing/static';
 import { CONSOLE_ROUTE_LIST } from '@/router/route';
+
+const DOCS_PAGE_MANIFEST_KEY = 'src/docs/page.tsx';
 
 const distDirectoryUrl = new URL('../dist/', import.meta.url);
 const templateFileUrl = new URL('index.html', distDirectoryUrl);
@@ -47,8 +51,27 @@ for (const consoleRoute of CONSOLE_ROUTE_LIST) {
   );
 }
 
+const docsPreloadPathList = collectLandingPreloadPathList(
+  buildManifest,
+  DOCS_PAGE_MANIFEST_KEY,
+);
+await mkdir(new URL('docs/', distDirectoryUrl), { recursive: true });
+await Bun.write(
+  new URL('docs.html', distDirectoryUrl),
+  injectModulePreloadLinkList(buildDocsDocument(templateHtml, null), docsPreloadPathList),
+);
+for (const chapterEntry of DOCS_CHAPTER_LIST) {
+  await Bun.write(
+    new URL(`docs/${chapterEntry.slug}.html`, distDirectoryUrl),
+    injectModulePreloadLinkList(
+      buildDocsDocument(templateHtml, chapterEntry),
+      docsPreloadPathList,
+    ),
+  );
+}
+
 await rm(manifestDirectoryUrl, { recursive: true, force: true });
 
 process.stdout.write(
-  `discovery: wrote index.html, en.html, and ${CONSOLE_ROUTE_LIST.length + 1} console shells\n`,
+  `discovery: wrote index.html, en.html, ${CONSOLE_ROUTE_LIST.length + 1} console shells, and ${DOCS_CHAPTER_LIST.length + 1} docs documents\n`,
 );

--- a/apps/console/src/docs/__tests__/catalog.spec.ts
+++ b/apps/console/src/docs/__tests__/catalog.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  DOCS_CHAPTER_LIST,
+  DOCS_PART_LIST,
+  findDocsChapterBySlug,
+  formatDocsChapterNumber,
+} from '@/docs/catalog';
+
+describe('docs catalog', () => {
+  it('keeps every chapter slug unique and single-word lowercase', () => {
+    const slugList = DOCS_CHAPTER_LIST.map((chapterEntry) => chapterEntry.slug);
+    expect(new Set(slugList).size).toBe(slugList.length);
+    for (const slug of slugList) {
+      expect(slug).toMatch(/^[a-z]+$/);
+    }
+  });
+
+  it('numbers chapters contiguously in reading order', () => {
+    DOCS_CHAPTER_LIST.forEach((chapterEntry, chapterIndex) => {
+      expect(chapterEntry.number).toBe(chapterIndex + 1);
+    });
+  });
+
+  it('assigns every chapter to a declared part', () => {
+    const partTitleList = DOCS_PART_LIST.map((part) => part.title);
+    for (const chapterEntry of DOCS_CHAPTER_LIST) {
+      expect(partTitleList).toContain(chapterEntry.partTitle);
+    }
+  });
+
+  it('ships a content stub for every chapter', async () => {
+    for (const chapterEntry of DOCS_CHAPTER_LIST) {
+      const contentFileUrl = new URL(
+        `../content/${chapterEntry.slug}.md`,
+        import.meta.url,
+      );
+      const contentText = await Bun.file(contentFileUrl).text();
+      expect(contentText.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolves chapters by slug and rejects unknown slugs', () => {
+    expect(findDocsChapterBySlug('loop')?.title).toBe('Loop');
+    expect(findDocsChapterBySlug('nonsense')).toBeNull();
+  });
+
+  it('formats chapter numbers with two digits', () => {
+    expect(formatDocsChapterNumber(3)).toBe('03');
+    expect(formatDocsChapterNumber(12)).toBe('12');
+  });
+});

--- a/apps/console/src/docs/__tests__/route.spec.ts
+++ b/apps/console/src/docs/__tests__/route.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildChapterPath, parseChapterSlugFromPathname } from '@/docs/route';
+
+describe('parseChapterSlugFromPathname', () => {
+  it('resolves the docs root to the contents view', () => {
+    expect(parseChapterSlugFromPathname('/docs')).toBeNull();
+    expect(parseChapterSlugFromPathname('/docs/')).toBeNull();
+  });
+
+  it('resolves known chapter paths to their slug', () => {
+    expect(parseChapterSlugFromPathname('/docs/loop')).toBe('loop');
+    expect(parseChapterSlugFromPathname('/docs/loop/')).toBe('loop');
+  });
+
+  it('falls back to the contents view for unknown chapters', () => {
+    expect(parseChapterSlugFromPathname('/docs/nonsense')).toBeNull();
+  });
+});
+
+describe('buildChapterPath', () => {
+  it('builds the contents and chapter paths', () => {
+    expect(buildChapterPath(null)).toBe('/docs');
+    expect(buildChapterPath('loop')).toBe('/docs/loop');
+  });
+});

--- a/apps/console/src/docs/__tests__/static.spec.ts
+++ b/apps/console/src/docs/__tests__/static.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+
+import { DOCS_CHAPTER_LIST, findDocsChapterBySlug } from '@/docs/catalog';
+import { DOCS_DOCUMENT_TITLE_MAP } from '@/docs/metadata';
+import { buildDocsDocument } from '@/docs/static';
+import { LANDING_PUBLIC_ORIGIN } from '@/landing/origin';
+import { LANDING_STATIC_OPEN_MARKER } from '@/landing/static';
+
+const applicationRootUrl = new URL('../../../', import.meta.url);
+
+async function readApplicationFile(relativePath: string): Promise<string> {
+  return Bun.file(new URL(relativePath, applicationRootUrl)).text();
+}
+
+describe('docs document generation', () => {
+  it('builds an indexable english contents document without landing copy', async () => {
+    const templateHtml = await readApplicationFile('index.html');
+    const docsDocument = buildDocsDocument(templateHtml, null);
+    expect(docsDocument).toContain('<meta name="robots" content="index, follow" />');
+    expect(docsDocument).not.toContain(LANDING_STATIC_OPEN_MARKER);
+    expect(docsDocument).toContain('<html lang="en">');
+    expect(docsDocument).toContain(`<title>${DOCS_DOCUMENT_TITLE_MAP.en}</title>`);
+    expect(docsDocument).toContain(
+      `<link rel="canonical" href="${LANDING_PUBLIC_ORIGIN}/docs" />`,
+    );
+    expect(docsDocument).not.toContain('hreflang=');
+  });
+
+  it('builds a chapter document carrying that chapter metadata', async () => {
+    const templateHtml = await readApplicationFile('index.html');
+    const loopChapter = findDocsChapterBySlug('loop');
+    expect(loopChapter).not.toBeNull();
+    if (loopChapter === null) {
+      return;
+    }
+    const chapterDocument = buildDocsDocument(templateHtml, loopChapter);
+    expect(chapterDocument).toContain(
+      `<title>${DOCS_DOCUMENT_TITLE_MAP.en} | ${loopChapter.title}</title>`,
+    );
+    expect(chapterDocument).toContain(`content="${loopChapter.description}"`);
+    expect(chapterDocument).toContain(
+      `<link rel="canonical" href="${LANDING_PUBLIC_ORIGIN}/docs/loop" />`,
+    );
+  });
+});
+
+describe('docs crawl control', () => {
+  it('lists the docs root and every chapter in the sitemap', async () => {
+    const sitemapDocument = await readApplicationFile('public/sitemap.xml');
+    expect(sitemapDocument).toContain(`<loc>${LANDING_PUBLIC_ORIGIN}/docs</loc>`);
+    for (const chapterEntry of DOCS_CHAPTER_LIST) {
+      expect(sitemapDocument).toContain(
+        `<loc>${LANDING_PUBLIC_ORIGIN}/docs/${chapterEntry.slug}</loc>`,
+      );
+    }
+  });
+
+  it('points language models at the hosted docs', async () => {
+    const llmsDocument = await readApplicationFile('public/llms.txt');
+    expect(llmsDocument).toContain(`${LANDING_PUBLIC_ORIGIN}/docs`);
+    expect(llmsDocument).not.toContain(
+      'github.com/galfrevn/apollo/tree/main/documentation',
+    );
+  });
+
+  it('keeps the docs crawlable in the robots policy', async () => {
+    const robotsPolicy = await readApplicationFile('public/robots.txt');
+    expect(robotsPolicy).not.toContain('Disallow: /docs');
+  });
+});

--- a/apps/console/src/docs/catalog.ts
+++ b/apps/console/src/docs/catalog.ts
@@ -1,0 +1,83 @@
+export interface DocsChapter {
+  readonly slug: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+export interface DocsPart {
+  readonly title: string;
+  readonly chapterList: readonly DocsChapter[];
+}
+
+export interface DocsChapterEntry extends DocsChapter {
+  readonly number: number;
+  readonly partTitle: string;
+}
+
+export const DOCS_PART_LIST: readonly DocsPart[] = [
+  {
+    title: 'Part I — Introduction',
+    chapterList: [
+      {
+        slug: 'purpose',
+        title: 'Purpose',
+        description: 'What Apollo is and is not.',
+      },
+      {
+        slug: 'concepts',
+        title: 'Concepts',
+        description: 'Desk, turns, sessions, and tools.',
+      },
+    ],
+  },
+  {
+    title: 'Part II — Runtime',
+    chapterList: [
+      {
+        slug: 'loop',
+        title: 'Loop',
+        description: 'How a request becomes a spoken reply.',
+      },
+      {
+        slug: 'protocol',
+        title: 'Protocol',
+        description: 'The messages between the device and the server.',
+      },
+    ],
+  },
+  {
+    title: 'Part III — Operations',
+    chapterList: [
+      {
+        slug: 'setup',
+        title: 'Setup',
+        description: 'Local development, from clone to first spoken turn.',
+      },
+    ],
+  },
+];
+
+function flattenDocsPartList(partList: readonly DocsPart[]): readonly DocsChapterEntry[] {
+  const chapterEntryList: DocsChapterEntry[] = [];
+  for (const part of partList) {
+    for (const chapter of part.chapterList) {
+      chapterEntryList.push({
+        ...chapter,
+        number: chapterEntryList.length + 1,
+        partTitle: part.title,
+      });
+    }
+  }
+  return chapterEntryList;
+}
+
+export const DOCS_CHAPTER_LIST: readonly DocsChapterEntry[] =
+  flattenDocsPartList(DOCS_PART_LIST);
+
+export function findDocsChapterBySlug(slug: string): DocsChapterEntry | null {
+  return DOCS_CHAPTER_LIST.find((chapterEntry) => chapterEntry.slug === slug) ?? null;
+}
+
+export function formatDocsChapterNumber(chapterNumber: number): string {
+  return String(chapterNumber).padStart(2, '0');
+}

--- a/apps/console/src/docs/chapter.tsx
+++ b/apps/console/src/docs/chapter.tsx
@@ -1,0 +1,110 @@
+import { Streamdown } from 'streamdown';
+
+import { DOCS_CHAPTER_LIST, formatDocsChapterNumber } from '@/docs/catalog';
+import { DOCS_MESSAGE_CATALOG } from '@/docs/copy';
+import { DOCS_BASE_PATH, buildChapterPath, handleChapterLinkClick } from '@/docs/route';
+import { DOCS_SOURCE_MAP } from '@/docs/source';
+import { useMessages } from '@/locale/context';
+
+import type { DocsChapterEntry } from '@/docs/catalog';
+
+const PROSE_CLASS_LIST = [
+  '[&_p]:my-3.5 [&_p]:text-[15.5px] [&_p]:leading-[1.78] [&_p]:text-foreground/80',
+  '[&_h2]:mb-3.5 [&_h2]:mt-14 [&_h2]:font-serif [&_h2]:text-[26px] [&_h2]:font-normal [&_h2]:leading-[1.25] [&_h2]:tracking-[-0.01em]',
+  '[&_h3]:mt-9 [&_h3]:text-lg [&_h3]:font-normal',
+  '[&_a]:border-b [&_a]:border-dashed [&_a]:border-muted-foreground/40 [&_a]:text-foreground [&_a:hover]:border-muted-foreground',
+  '[&_blockquote]:my-5 [&_blockquote]:border-l [&_blockquote]:border-border-hover [&_blockquote]:pl-5 [&_blockquote_p]:text-muted-foreground',
+  '[&_code]:rounded-none [&_code]:font-mono [&_code]:text-[0.82em]',
+  '[&_pre]:my-5 [&_pre]:overflow-x-auto [&_pre]:rounded-none [&_pre]:border [&_pre]:bg-card [&_pre]:p-4 [&_pre]:text-[12.5px] [&_pre]:leading-[1.7]',
+  '[&_ul]:my-3.5 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-3.5 [&_ol]:list-decimal [&_ol]:pl-5',
+  '[&_li]:my-1.5 [&_li]:text-[15.5px] [&_li]:leading-[1.7] [&_li]:text-foreground/80',
+  '[&_hr]:my-8 [&_hr]:border-border [&_img]:rounded-none [&_table]:rounded-none',
+].join(' ');
+
+export function DocsChapter({
+  chapterEntry,
+}: {
+  readonly chapterEntry: DocsChapterEntry;
+}) {
+  const docsMessages = useMessages(DOCS_MESSAGE_CATALOG);
+  const chapterIndex = DOCS_CHAPTER_LIST.findIndex(
+    (candidateEntry) => candidateEntry.slug === chapterEntry.slug,
+  );
+  const previousChapter = DOCS_CHAPTER_LIST[chapterIndex - 1] ?? null;
+  const nextChapter = DOCS_CHAPTER_LIST[chapterIndex + 1] ?? null;
+  const chapterSource = DOCS_SOURCE_MAP[chapterEntry.slug] ?? '';
+
+  return (
+    <article className="settle">
+      <p className="font-mono text-xs text-dim">
+        {formatDocsChapterNumber(chapterEntry.number)} · {chapterEntry.partTitle}
+      </p>
+      <h1 className="mt-3.5 font-serif text-[clamp(42px,6vw,62px)] leading-[1.05] tracking-[-0.015em] text-balance">
+        {chapterEntry.title}
+      </h1>
+      <p className="mt-4 max-w-[46ch] text-[16.5px] leading-relaxed text-muted-foreground">
+        {chapterEntry.description}
+      </p>
+      <hr className="my-10 w-12 border-border-hover" />
+
+      <div className={PROSE_CLASS_LIST}>
+        <Streamdown>{chapterSource}</Streamdown>
+      </div>
+
+      <footer className="mt-20 border-t pt-3.5">
+        <p className="mb-6 mt-2.5 text-center text-xs">
+          <a
+            href={DOCS_BASE_PATH}
+            onClick={(event) => handleChapterLinkClick(event, null)}
+            className="text-dim transition-colors duration-150 hover:text-foreground"
+          >
+            {docsMessages.buildChapterPositionLabel(
+              chapterEntry.number,
+              DOCS_CHAPTER_LIST.length,
+            )}
+          </a>
+        </p>
+        <div className="grid grid-cols-2 gap-6">
+          {previousChapter === null ? (
+            <span />
+          ) : (
+            <a
+              href={buildChapterPath(previousChapter.slug)}
+              onClick={(event) => handleChapterLinkClick(event, previousChapter.slug)}
+              className="group block py-1.5"
+            >
+              <span className="mb-2 block text-xs text-dim">
+                {docsMessages.previousChapterLabel}
+              </span>
+              <span className="block font-serif text-[23px] tracking-[-0.01em] transition-colors duration-150 group-hover:text-muted-foreground">
+                {previousChapter.title}
+              </span>
+              <span className="mt-2 block font-mono text-xs text-dim">
+                {formatDocsChapterNumber(previousChapter.number)}
+              </span>
+            </a>
+          )}
+          {nextChapter === null ? (
+            <span />
+          ) : (
+            <a
+              href={buildChapterPath(nextChapter.slug)}
+              onClick={(event) => handleChapterLinkClick(event, nextChapter.slug)}
+              className="group block py-1.5 text-right"
+            >
+              <span className="mb-2 block text-xs text-dim">
+                {docsMessages.nextChapterLabel}
+              </span>
+              <span className="block font-serif text-[23px] tracking-[-0.01em] transition-colors duration-150 group-hover:text-muted-foreground">
+                {nextChapter.title}
+              </span>
+              <span className="mt-2 block font-mono text-xs text-dim">
+                {formatDocsChapterNumber(nextChapter.number)}
+              </span>
+            </a>
+          )}
+        </div>
+      </footer>
+    </article>
+  );
+}

--- a/apps/console/src/docs/content/concepts.md
+++ b/apps/console/src/docs/content/concepts.md
@@ -1,0 +1,13 @@
+A few words carry the whole handbook: the desk, a turn, a session, and a tool. Later chapters assume them, so they are defined once here.
+
+## The desk
+
+This section is not written yet.
+
+## Turns and sessions
+
+This section is not written yet.
+
+## Tools
+
+This section is not written yet.

--- a/apps/console/src/docs/content/loop.md
+++ b/apps/console/src/docs/content/loop.md
@@ -1,0 +1,19 @@
+A turn begins when the device detects the wake word and opens a stream to the worker. Everything that follows — transcription, the agent loop, and the spoken reply — happens inside a single session, so the desk keeps context across consecutive turns.
+
+> The handbook is meant to be read in order. Later chapters assume the concepts introduced earlier.
+
+## The turn
+
+This section is not written yet.
+
+## What the device sends
+
+This section is not written yet.
+
+## The agent loop
+
+This section is not written yet.
+
+## Speaking back
+
+This section is not written yet.

--- a/apps/console/src/docs/content/protocol.md
+++ b/apps/console/src/docs/content/protocol.md
@@ -1,0 +1,13 @@
+The device and the worker speak a small protocol over WebSocket. It is the contract between the firmware and the brain, and the one interface both repositories agree on.
+
+## Connection lifecycle
+
+This section is not written yet.
+
+## Message catalog
+
+This section is not written yet.
+
+## Audio framing
+
+This section is not written yet.

--- a/apps/console/src/docs/content/purpose.md
+++ b/apps/console/src/docs/content/purpose.md
@@ -1,0 +1,13 @@
+Apollo is a personal desk agent: an AI brain that runs as a Cloudflare Worker in your own account, paired with a physical body that sits on your desk. You speak to it across the desk and the answer comes back out loud.
+
+## What Apollo is
+
+This section is not written yet.
+
+## What Apollo is not
+
+This section is not written yet.
+
+## Who it is for
+
+This section is not written yet.

--- a/apps/console/src/docs/content/setup.md
+++ b/apps/console/src/docs/content/setup.md
@@ -1,0 +1,13 @@
+Everything runs from the repository root with Bun and Turborepo. This chapter walks from a fresh clone to a first spoken turn against a local worker.
+
+## Prerequisites
+
+This section is not written yet.
+
+## Running the worker
+
+This section is not written yet.
+
+## Talking to it
+
+This section is not written yet.

--- a/apps/console/src/docs/contents.tsx
+++ b/apps/console/src/docs/contents.tsx
@@ -1,0 +1,49 @@
+import {
+  DOCS_CHAPTER_LIST,
+  DOCS_PART_LIST,
+  formatDocsChapterNumber,
+} from '@/docs/catalog';
+import { DOCS_MESSAGE_CATALOG } from '@/docs/copy';
+import { buildChapterPath, handleChapterLinkClick } from '@/docs/route';
+import { useMessages } from '@/locale/context';
+
+export function DocsContents() {
+  const docsMessages = useMessages(DOCS_MESSAGE_CATALOG);
+
+  return (
+    <section className="settle">
+      <h1 className="font-serif text-[clamp(40px,5vw,56px)] leading-[1.05] tracking-[-0.015em] text-balance">
+        {docsMessages.contentsTitle}
+      </h1>
+      <p className="mt-4 max-w-[46ch] text-[16.5px] leading-relaxed text-muted-foreground">
+        {docsMessages.contentsTagline}
+      </p>
+      <div className="mt-12 grid gap-10 sm:grid-cols-2">
+        {DOCS_PART_LIST.map((part) => (
+          <div key={part.title}>
+            <span className="mb-3 block text-xs text-muted-foreground">{part.title}</span>
+            {DOCS_CHAPTER_LIST.filter(
+              (chapterEntry) => chapterEntry.partTitle === part.title,
+            ).map((chapterEntry) => (
+              <a
+                key={chapterEntry.slug}
+                href={buildChapterPath(chapterEntry.slug)}
+                onClick={(event) => handleChapterLinkClick(event, chapterEntry.slug)}
+                className="flex items-baseline gap-3 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:text-foreground"
+              >
+                <span className="min-w-[18px] font-mono text-[11.5px] tabular-nums text-dim">
+                  {formatDocsChapterNumber(chapterEntry.number)}
+                </span>
+                {chapterEntry.title}
+                <span
+                  aria-hidden
+                  className="flex-1 -translate-y-[3px] border-b border-dotted border-border-hover"
+                />
+              </a>
+            ))}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/console/src/docs/copy.ts
+++ b/apps/console/src/docs/copy.ts
@@ -1,0 +1,52 @@
+import type { Locale } from '@/locale/detect';
+
+interface DocsMessages {
+  readonly brandSectionLabel: string;
+  readonly navigationAriaLabel: string;
+  readonly searchTriggerLabel: string;
+  readonly searchPlaceholder: string;
+  readonly searchNoMatchesLabel: string;
+  readonly githubLabel: string;
+  readonly openConsoleLabel: string;
+  readonly contentsTitle: string;
+  readonly contentsTagline: string;
+  readonly previousChapterLabel: string;
+  readonly nextChapterLabel: string;
+  readonly buildChapterPositionLabel: (
+    chapterNumber: number,
+    chapterTotal: number,
+  ) => string;
+}
+
+export const DOCS_MESSAGE_CATALOG: Record<Locale, DocsMessages> = {
+  es: {
+    brandSectionLabel: 'manual',
+    navigationAriaLabel: 'Capítulos del manual',
+    searchTriggerLabel: 'Buscar en el manual',
+    searchPlaceholder: 'Buscar un capítulo…',
+    searchNoMatchesLabel: 'Ningún capítulo coincide.',
+    githubLabel: 'GitHub',
+    openConsoleLabel: 'Consola →',
+    contentsTitle: 'Contenido',
+    contentsTagline: 'El manual de Apollo, pensado para leerse en orden.',
+    previousChapterLabel: 'Capítulo anterior',
+    nextChapterLabel: 'Capítulo siguiente',
+    buildChapterPositionLabel: (chapterNumber, chapterTotal) =>
+      `Capítulo ${chapterNumber} de ${chapterTotal}`,
+  },
+  en: {
+    brandSectionLabel: 'handbook',
+    navigationAriaLabel: 'Handbook chapters',
+    searchTriggerLabel: 'Search the handbook',
+    searchPlaceholder: 'Search for a chapter…',
+    searchNoMatchesLabel: 'No chapter matches.',
+    githubLabel: 'GitHub',
+    openConsoleLabel: 'Console →',
+    contentsTitle: 'Contents',
+    contentsTagline: 'The Apollo handbook, meant to be read in order.',
+    previousChapterLabel: 'Previous chapter',
+    nextChapterLabel: 'Next chapter',
+    buildChapterPositionLabel: (chapterNumber, chapterTotal) =>
+      `Chapter ${chapterNumber} of ${chapterTotal}`,
+  },
+};

--- a/apps/console/src/docs/metadata.ts
+++ b/apps/console/src/docs/metadata.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+import { useLocale } from '@/locale/context';
+
+import type { DocsChapterEntry } from '@/docs/catalog';
+import type { Locale } from '@/locale/detect';
+
+export const DOCS_DOCUMENT_TITLE_MAP: Record<Locale, string> = {
+  es: 'Apollo | Manual',
+  en: 'Apollo | Handbook',
+};
+
+export const DOCS_DOCUMENT_DESCRIPTION_MAP: Record<Locale, string> = {
+  es: 'El manual de Apollo: cómo funciona el agente de escritorio, del turno de voz al despliegue.',
+  en: 'The Apollo handbook: how the desk agent works, from the voice turn to deployment.',
+};
+
+export function useDocsMetadata(activeChapter: DocsChapterEntry | null): void {
+  const { locale } = useLocale();
+
+  useEffect(() => {
+    const baseTitle = DOCS_DOCUMENT_TITLE_MAP[locale];
+    document.title =
+      activeChapter === null ? baseTitle : `${baseTitle} | ${activeChapter.title}`;
+
+    const descriptionElement = document.querySelector('meta[name="description"]');
+    descriptionElement?.setAttribute(
+      'content',
+      activeChapter === null
+        ? DOCS_DOCUMENT_DESCRIPTION_MAP[locale]
+        : activeChapter.description,
+    );
+  }, [activeChapter, locale]);
+}

--- a/apps/console/src/docs/nav.tsx
+++ b/apps/console/src/docs/nav.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/components/utility';
+import {
+  DOCS_CHAPTER_LIST,
+  DOCS_PART_LIST,
+  formatDocsChapterNumber,
+} from '@/docs/catalog';
+import { DOCS_MESSAGE_CATALOG } from '@/docs/copy';
+import { buildChapterPath, handleChapterLinkClick } from '@/docs/route';
+import { useMessages } from '@/locale/context';
+
+export function DocsNav({
+  activeChapterSlug,
+}: {
+  readonly activeChapterSlug: string | null;
+}) {
+  const docsMessages = useMessages(DOCS_MESSAGE_CATALOG);
+
+  return (
+    <nav
+      aria-label={docsMessages.navigationAriaLabel}
+      className="sticky top-[60px] hidden h-[calc(100vh-60px)] overflow-y-auto border-r px-4 pb-11 pt-7 md:block"
+    >
+      {DOCS_PART_LIST.map((part) => (
+        <div key={part.title} className="mb-6">
+          <span className="mb-1.5 block px-2.5 text-xs text-muted-foreground">
+            {part.title}
+          </span>
+          {DOCS_CHAPTER_LIST.filter(
+            (chapterEntry) => chapterEntry.partTitle === part.title,
+          ).map((chapterEntry) => (
+            <a
+              key={chapterEntry.slug}
+              href={buildChapterPath(chapterEntry.slug)}
+              aria-current={chapterEntry.slug === activeChapterSlug ? 'page' : undefined}
+              onClick={(event) => handleChapterLinkClick(event, chapterEntry.slug)}
+              className={cn(
+                'flex items-baseline gap-2.5 border border-transparent px-2.5 py-[5px] text-[13px] transition-colors duration-150',
+                chapterEntry.slug === activeChapterSlug
+                  ? 'border-border bg-active text-foreground'
+                  : 'text-dim hover:bg-card-hover hover:text-foreground',
+              )}
+            >
+              <span className="min-w-[18px] font-mono text-[11px] tabular-nums">
+                {formatDocsChapterNumber(chapterEntry.number)}
+              </span>
+              {chapterEntry.title}
+            </a>
+          ))}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/apps/console/src/docs/page.tsx
+++ b/apps/console/src/docs/page.tsx
@@ -1,0 +1,68 @@
+import { Icons } from '@/components/icons';
+import { findDocsChapterBySlug } from '@/docs/catalog';
+import { DocsChapter } from '@/docs/chapter';
+import { DocsContents } from '@/docs/contents';
+import { DOCS_MESSAGE_CATALOG } from '@/docs/copy';
+import { useDocsMetadata } from '@/docs/metadata';
+import { DocsNav } from '@/docs/nav';
+import { DOCS_BASE_PATH, handleChapterLinkClick, useDocsChapterSlug } from '@/docs/route';
+import { DocsSearch } from '@/docs/search';
+import { LANDING_REPOSITORY_URL } from '@/landing/origin';
+import { useMessages } from '@/locale/context';
+import { LocaleToggle } from '@/locale/toggle';
+import { CONSOLE_BASE_PATH } from '@/router/route';
+
+export function DocsPage() {
+  const activeChapterSlug = useDocsChapterSlug();
+  const activeChapter =
+    activeChapterSlug === null ? null : findDocsChapterBySlug(activeChapterSlug);
+  const docsMessages = useMessages(DOCS_MESSAGE_CATALOG);
+  useDocsMetadata(activeChapter);
+
+  return (
+    <>
+      <header className="fixed inset-x-0 top-0 z-10 flex h-[60px] items-center justify-between gap-4 border-b bg-background/70 px-5 backdrop-blur-xl">
+        <a
+          href={DOCS_BASE_PATH}
+          onClick={(event) => handleChapterLinkClick(event, null)}
+          className="flex items-center gap-2.5 text-sm"
+        >
+          <Icons.LogoMark size={20} />
+          Apollo
+          <span className="text-muted-foreground">{docsMessages.brandSectionLabel}</span>
+        </a>
+        <div className="flex items-center gap-5">
+          <DocsSearch />
+          <a
+            href={LANDING_REPOSITORY_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="hidden text-[13px] text-muted-foreground transition-colors duration-150 hover:text-foreground sm:block"
+          >
+            {docsMessages.githubLabel}
+          </a>
+          <a
+            href={CONSOLE_BASE_PATH}
+            className="hidden text-[13px] text-muted-foreground transition-colors duration-150 hover:text-foreground sm:block"
+          >
+            {docsMessages.openConsoleLabel}
+          </a>
+          <LocaleToggle />
+        </div>
+      </header>
+
+      <div className="mx-auto grid max-w-[1240px] grid-cols-1 pt-[60px] md:grid-cols-[270px_minmax(0,1fr)]">
+        <DocsNav activeChapterSlug={activeChapterSlug} />
+        <main className="min-w-0 px-6 py-12 md:px-10 md:py-[72px]">
+          <div className="mx-auto max-w-[660px]">
+            {activeChapter === null ? (
+              <DocsContents />
+            ) : (
+              <DocsChapter key={activeChapter.slug} chapterEntry={activeChapter} />
+            )}
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}

--- a/apps/console/src/docs/route.ts
+++ b/apps/console/src/docs/route.ts
@@ -1,0 +1,61 @@
+import { useSyncExternalStore } from 'react';
+import type { MouseEvent } from 'react';
+
+import { findDocsChapterBySlug } from '@/docs/catalog';
+
+export const DOCS_BASE_PATH = '/docs';
+
+const NAVIGATION_EVENT_NAME = 'docs:navigation';
+
+export function parseChapterSlugFromPathname(pathname: string): string | null {
+  const candidate = pathname.startsWith(DOCS_BASE_PATH)
+    ? pathname.slice(DOCS_BASE_PATH.length).replace(/^\/+/, '').replace(/\/+$/, '')
+    : '';
+  if (candidate === '') {
+    return null;
+  }
+  return findDocsChapterBySlug(candidate)?.slug ?? null;
+}
+
+export function buildChapterPath(chapterSlug: string | null): string {
+  return chapterSlug === null ? DOCS_BASE_PATH : `${DOCS_BASE_PATH}/${chapterSlug}`;
+}
+
+function subscribeToNavigation(onChange: () => void): () => void {
+  window.addEventListener('popstate', onChange);
+  window.addEventListener(NAVIGATION_EVENT_NAME, onChange);
+  return () => {
+    window.removeEventListener('popstate', onChange);
+    window.removeEventListener(NAVIGATION_EVENT_NAME, onChange);
+  };
+}
+
+export function useDocsChapterSlug(): string | null {
+  return useSyncExternalStore(subscribeToNavigation, () =>
+    parseChapterSlugFromPathname(window.location.pathname),
+  );
+}
+
+export function navigateToChapter(chapterSlug: string | null): void {
+  window.history.pushState(null, '', buildChapterPath(chapterSlug));
+  window.dispatchEvent(new Event(NAVIGATION_EVENT_NAME));
+  window.scrollTo({ top: 0 });
+}
+
+export function handleChapterLinkClick(
+  event: MouseEvent<HTMLAnchorElement>,
+  chapterSlug: string | null,
+): void {
+  const shouldLetBrowserHandleClick =
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey;
+  if (shouldLetBrowserHandleClick) {
+    return;
+  }
+  event.preventDefault();
+  navigateToChapter(chapterSlug);
+}

--- a/apps/console/src/docs/search.tsx
+++ b/apps/console/src/docs/search.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+
+import { Icons } from '@/components/icons';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { DOCS_CHAPTER_LIST, formatDocsChapterNumber } from '@/docs/catalog';
+import { DOCS_MESSAGE_CATALOG } from '@/docs/copy';
+import { navigateToChapter } from '@/docs/route';
+import { useMessages } from '@/locale/context';
+
+export function DocsSearch() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const docsMessages = useMessages(DOCS_MESSAGE_CATALOG);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        setIsOpen((wasOpen) => !wasOpen);
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingChapterList = DOCS_CHAPTER_LIST.filter(
+    (chapterEntry) =>
+      chapterEntry.title.toLowerCase().includes(normalizedQuery) ||
+      chapterEntry.description.toLowerCase().includes(normalizedQuery),
+  );
+
+  function handleSelectChapter(chapterSlug: string) {
+    setIsOpen(false);
+    setQuery('');
+    navigateToChapter(chapterSlug);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="flex h-8 items-center gap-2 text-sm text-muted-foreground transition-colors duration-150 hover:text-foreground md:min-w-[230px] md:justify-between md:border md:bg-card md:px-2.5 md:text-[13px] md:text-dim md:hover:border-border-hover md:hover:text-muted-foreground"
+      >
+        <Icons.Search size={18} className="md:hidden" />
+        <span className="hidden md:inline">{docsMessages.searchTriggerLabel}</span>
+        <kbd className="hidden h-5 items-center border bg-accent px-1.5 font-sans text-[10px] text-muted-foreground md:inline-flex">
+          ⌘K
+        </kbd>
+      </button>
+
+      <Dialog
+        open={isOpen}
+        onOpenChange={(isNowOpen) => {
+          setIsOpen(isNowOpen);
+          if (!isNowOpen) {
+            setQuery('');
+          }
+        }}
+      >
+        <DialogContent className="top-[20%] translate-y-0 p-0">
+          <DialogTitle className="sr-only">{docsMessages.searchTriggerLabel}</DialogTitle>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              const firstMatch = matchingChapterList[0];
+              if (firstMatch !== undefined) {
+                handleSelectChapter(firstMatch.slug);
+              }
+            }}
+            className="flex items-center gap-3 border-b px-4 pr-12"
+          >
+            <Icons.Search size={18} className="shrink-0 text-dim" />
+            <input
+              autoFocus
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={docsMessages.searchPlaceholder}
+              aria-label={docsMessages.searchTriggerLabel}
+              className="h-12 w-full bg-transparent text-sm text-foreground outline-none"
+            />
+          </form>
+          <ul className="p-2">
+            {matchingChapterList.length === 0 ? (
+              <li className="px-3 py-6 text-center text-xs text-dim">
+                {docsMessages.searchNoMatchesLabel}
+              </li>
+            ) : (
+              matchingChapterList.map((chapterEntry) => (
+                <li key={chapterEntry.slug}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectChapter(chapterEntry.slug)}
+                    className="flex h-10 w-full items-baseline gap-3 px-3 text-left text-sm text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground"
+                  >
+                    <span className="min-w-[18px] font-mono text-[11px] tabular-nums text-dim">
+                      {formatDocsChapterNumber(chapterEntry.number)}
+                    </span>
+                    {chapterEntry.title}
+                    <span className="ml-auto hidden text-xs text-dim sm:inline">
+                      {chapterEntry.partTitle}
+                    </span>
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/console/src/docs/source.ts
+++ b/apps/console/src/docs/source.ts
@@ -1,0 +1,13 @@
+import conceptsSource from '@/docs/content/concepts.md?raw';
+import loopSource from '@/docs/content/loop.md?raw';
+import protocolSource from '@/docs/content/protocol.md?raw';
+import purposeSource from '@/docs/content/purpose.md?raw';
+import setupSource from '@/docs/content/setup.md?raw';
+
+export const DOCS_SOURCE_MAP: Record<string, string> = {
+  purpose: purposeSource,
+  concepts: conceptsSource,
+  loop: loopSource,
+  protocol: protocolSource,
+  setup: setupSource,
+};

--- a/apps/console/src/docs/static.ts
+++ b/apps/console/src/docs/static.ts
@@ -1,0 +1,84 @@
+import { DOCS_DOCUMENT_DESCRIPTION_MAP, DOCS_DOCUMENT_TITLE_MAP } from '@/docs/metadata';
+import { buildChapterPath } from '@/docs/route';
+import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
+import { LANDING_PUBLIC_ORIGIN } from '@/landing/origin';
+import {
+  LANDING_OPEN_GRAPH_LOCALE_MAP,
+  LANDING_SOCIAL_DESCRIPTION_MAP,
+  replaceExactlyOnce,
+  stripLandingStaticBlock,
+} from '@/landing/static';
+
+import type { DocsChapterEntry } from '@/docs/catalog';
+
+export function buildDocsDocument(
+  templateHtml: string,
+  chapterEntry: DocsChapterEntry | null,
+): string {
+  const landingTitle = LANDING_MESSAGE_CATALOG.es.metadata.documentTitle;
+  const landingDescription = LANDING_MESSAGE_CATALOG.es.metadata.documentDescription;
+  const docsTitle =
+    chapterEntry === null
+      ? DOCS_DOCUMENT_TITLE_MAP.en
+      : `${DOCS_DOCUMENT_TITLE_MAP.en} | ${chapterEntry.title}`;
+  const docsDescription =
+    chapterEntry === null ? DOCS_DOCUMENT_DESCRIPTION_MAP.en : chapterEntry.description;
+  const docsPageUrl = `${LANDING_PUBLIC_ORIGIN}${buildChapterPath(chapterEntry?.slug ?? null)}`;
+
+  let docsDocument = stripLandingStaticBlock(templateHtml);
+  docsDocument = replaceExactlyOnce(docsDocument, '<html lang="es">', '<html lang="en">');
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<title>${landingTitle}</title>`,
+    `<title>${docsTitle}</title>`,
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `content="${landingDescription}"`,
+    `content="${docsDescription}"`,
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<link rel="canonical" href="${LANDING_PUBLIC_ORIGIN}/" />`,
+    `<link rel="canonical" href="${docsPageUrl}" />`,
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `property="og:url" content="${LANDING_PUBLIC_ORIGIN}/"`,
+    `property="og:url" content="${docsPageUrl}"`,
+  );
+  docsDocument = docsDocument.replaceAll(
+    `content="${landingTitle}"`,
+    `content="${docsTitle}"`,
+  );
+  docsDocument = docsDocument.replaceAll(
+    LANDING_SOCIAL_DESCRIPTION_MAP.es,
+    docsDescription,
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<link rel="alternate" hreflang="es" href="${LANDING_PUBLIC_ORIGIN}/" />`,
+    '',
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<link rel="alternate" hreflang="en" href="${LANDING_PUBLIC_ORIGIN}/en" />`,
+    '',
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<link rel="alternate" hreflang="x-default" href="${LANDING_PUBLIC_ORIGIN}/" />`,
+    '',
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<meta property="og:locale:alternate" content="${LANDING_OPEN_GRAPH_LOCALE_MAP.en}" />`,
+    '',
+  );
+  docsDocument = replaceExactlyOnce(
+    docsDocument,
+    `<meta property="og:locale" content="${LANDING_OPEN_GRAPH_LOCALE_MAP.es}" />`,
+    `<meta property="og:locale" content="${LANDING_OPEN_GRAPH_LOCALE_MAP.en}" />`,
+  );
+  return docsDocument;
+}

--- a/apps/console/src/landing/hero.tsx
+++ b/apps/console/src/landing/hero.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
 import { MagneticLink } from '@/landing/magnet';
 import { LANDING_LINK_MAP } from '@/landing/metadata';
+import { warmDocsChunk } from '@/landing/prefetch';
 import { REDUCED_MOTION_SAFE_QUERY, RISE_EASE, gsap, useGSAP } from '@/landing/motion';
 import { useMessages } from '@/locale/context';
 
@@ -63,14 +64,14 @@ export function LandingHero() {
             </MagneticLink>
             <MagneticLink
               href={LANDING_LINK_MAP.documentation}
-              isExternal
+              onWarm={warmDocsChunk}
               className="underline-reveal"
             >
               {landingMessages.nav.docsLabel}
             </MagneticLink>
             <MagneticLink
               href={LANDING_LINK_MAP.documentation}
-              isExternal
+              onWarm={warmDocsChunk}
               className="border px-4 py-2.5 transition-colors hover:border-border-hover hover:bg-card"
             >
               {landingMessages.hero.gettingStartedLabel}

--- a/apps/console/src/landing/metadata.ts
+++ b/apps/console/src/landing/metadata.ts
@@ -5,7 +5,7 @@ import { useLocale } from '@/locale/context';
 
 export const LANDING_LINK_MAP = {
   github: 'https://github.com/galfrevn/apollo',
-  documentation: 'https://github.com/galfrevn/apollo/tree/main/documentation',
+  documentation: '/docs',
   console: '/console',
 };
 

--- a/apps/console/src/landing/nav.tsx
+++ b/apps/console/src/landing/nav.tsx
@@ -5,7 +5,7 @@ import { Icons } from '@/components/icons';
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
 import { MagneticLink } from '@/landing/magnet';
 import { LANDING_LINK_MAP } from '@/landing/metadata';
-import { warmConsoleChunk } from '@/landing/prefetch';
+import { warmConsoleChunk, warmDocsChunk } from '@/landing/prefetch';
 import { useMessages } from '@/locale/context';
 
 const REPOSITORY_API_URL = 'https://api.github.com/repos/galfrevn/apollo';
@@ -60,8 +60,8 @@ export function LandingNav() {
         <div className="flex items-center gap-7 text-sm text-muted-foreground">
           <a
             href={LANDING_LINK_MAP.documentation}
-            target="_blank"
-            rel="noreferrer"
+            onPointerEnter={warmDocsChunk}
+            onFocus={warmDocsChunk}
             className="underline-reveal hover:text-foreground"
           >
             {landingMessages.nav.docsLabel}

--- a/apps/console/src/landing/prefetch.ts
+++ b/apps/console/src/landing/prefetch.ts
@@ -7,3 +7,13 @@ export function warmConsoleChunk(): void {
   didWarmConsoleChunk = true;
   void import('@/app');
 }
+
+let didWarmDocsChunk = false;
+
+export function warmDocsChunk(): void {
+  if (didWarmDocsChunk) {
+    return;
+  }
+  didWarmDocsChunk = true;
+  void import('@/docs/page');
+}

--- a/apps/console/src/landing/static.ts
+++ b/apps/console/src/landing/static.ts
@@ -78,7 +78,7 @@ export function renderLandingStaticBlock(locale: Locale): string {
   return `<div data-landing-static class="mx-auto max-w-3xl px-6 py-16">${navigation}<main>${hero}${showcaseSection}${architectureSection}${capabilitiesSection}${yoursSection}</main>${footer}</div>`;
 }
 
-function replaceExactlyOnce(
+export function replaceExactlyOnce(
   documentHtml: string,
   searchValue: string,
   replacementValue: string,
@@ -107,7 +107,7 @@ function injectLandingStaticBlock(documentHtml: string, locale: Locale): string 
   return `${beforeBlock}${renderLandingStaticBlock(locale)}${afterBlock}`;
 }
 
-function stripLandingStaticBlock(documentHtml: string): string {
+export function stripLandingStaticBlock(documentHtml: string): string {
   const openIndex = documentHtml.indexOf(LANDING_STATIC_OPEN_MARKER);
   const closeIndex = documentHtml.indexOf(LANDING_STATIC_CLOSE_MARKER);
   if (openIndex === -1 || closeIndex === -1 || closeIndex < openIndex) {

--- a/apps/console/src/landing/yours.tsx
+++ b/apps/console/src/landing/yours.tsx
@@ -2,7 +2,7 @@ import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
 import { ActHeading } from '@/landing/heading';
 import { MagneticLink } from '@/landing/magnet';
 import { LANDING_LINK_MAP } from '@/landing/metadata';
-import { warmConsoleChunk } from '@/landing/prefetch';
+import { warmConsoleChunk, warmDocsChunk } from '@/landing/prefetch';
 import { useMessages } from '@/locale/context';
 
 export function LandingYours() {
@@ -51,8 +51,8 @@ export function LandingYours() {
             <div className="mt-auto pt-4">
               <a
                 href={LANDING_LINK_MAP.documentation}
-                target="_blank"
-                rel="noreferrer"
+                onPointerEnter={warmDocsChunk}
+                onFocus={warmDocsChunk}
                 className="underline-reveal text-sm"
               >
                 {yoursMessages.docsCardAction}

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -36,6 +36,13 @@ if (surface.kind === 'redirect') {
       <LandingPage />
     </LocaleProvider>,
   );
+} else if (surface.kind === 'docs') {
+  const { DocsPage } = await import('@/docs/page');
+  createRoot(rootElement).render(
+    <LocaleProvider>
+      <DocsPage />
+    </LocaleProvider>,
+  );
 } else {
   const { App } = await import('@/app');
   createRoot(rootElement).render(

--- a/apps/console/src/router/__tests__/path.spec.ts
+++ b/apps/console/src/router/__tests__/path.spec.ts
@@ -32,6 +32,19 @@ describe('resolveSurfaceFromLocation', () => {
     });
   });
 
+  it('resolves docs paths to the docs surface', () => {
+    expect(resolveSurfaceFromLocation('/docs', '')).toEqual({ kind: 'docs' });
+    expect(resolveSurfaceFromLocation('/docs/', '')).toEqual({ kind: 'docs' });
+    expect(resolveSurfaceFromLocation('/docs/loop', '')).toEqual({ kind: 'docs' });
+  });
+
+  it('does not treat path prefixes of /docs as the docs surface', () => {
+    expect(resolveSurfaceFromLocation('/docsy', '')).toEqual({
+      kind: 'landing',
+      localeOverride: null,
+    });
+  });
+
   it('redirects legacy root hash routes into console paths', () => {
     expect(resolveSurfaceFromLocation('/', '#/device')).toEqual({
       kind: 'redirect',

--- a/apps/console/src/router/path.ts
+++ b/apps/console/src/router/path.ts
@@ -1,3 +1,4 @@
+import { DOCS_BASE_PATH } from '@/docs/route';
 import { CONSOLE_BASE_PATH, CONSOLE_ROUTE_LIST } from '@/router/route';
 
 import type { Locale } from '@/locale/detect';
@@ -6,6 +7,7 @@ import type { ConsoleRoute } from '@/router/route';
 export type SurfaceResolution =
   | { readonly kind: 'landing'; readonly localeOverride: Locale | null }
   | { readonly kind: 'console' }
+  | { readonly kind: 'docs' }
   | { readonly kind: 'redirect'; readonly targetUrl: string };
 
 export function resolveSurfaceFromLocation(
@@ -23,6 +25,11 @@ export function resolveSurfaceFromLocation(
       };
     }
     return { kind: 'console' };
+  }
+  const isDocsPath =
+    pathname === DOCS_BASE_PATH || pathname.startsWith(`${DOCS_BASE_PATH}/`);
+  if (isDocsPath) {
+    return { kind: 'docs' };
   }
   if (pathname === '/' && legacyHashRoute !== null) {
     return {


### PR DESCRIPTION
## What

A third surface next to the landing and the console: first-party documentation at `/docs`, replacing the landing's docs links that pointed at the GitHub `documentation/` tree.

The design was chosen from mockup proposals: an editorial handbook layout — serif chapter openers with a mono `03 · Part II — Runtime` index line, numbered chapters, a book-spread previous/next pager, and a "Chapter N of M" position line — combined with a persistent, part-grouped reference sidebar. `/docs` itself is the contents page, a book table of contents with dotted leaders.

Content is deliberately a minimal skeleton (five chapters across Parts I–III, each stub saying which sections are not written yet); the full tree gets written later.

## How

- **`apps/console/src/docs/`** — `catalog.ts` is the single source of truth (nav, numbering, pager chain, prerender paths, metadata); `copy.ts` carries bilingual chrome (es "manual" / en "handbook"); `chapter.tsx` renders markdown stubs through the already-shipped `streamdown`; `search.tsx` is a working ⌘K chapter search; markdown lives in `content/*.md` via Vite `?raw`.
- **Routing** — `resolveSurfaceFromLocation` gains a `docs` kind; `main.tsx` loads the surface as a third dynamic chunk, so gsap and console code stay out of the docs bundle (verified against the build manifest).
- **Prerender** — `scripts/discovery.ts` emits `dist/docs.html` and `dist/docs/<slug>.html`: indexable, `lang="en"`, per-chapter title/description/canonical, hreflang alternates stripped, docs chunk modulepreloaded.
- **Landing** — all four docs links flip to `/docs`, navigate in-tab, and warm the docs chunk on hover; `llms.txt` and `sitemap.xml` updated; `/docs` stays crawlable.

## Tests

- New: `docs/__tests__/catalog.spec.ts` (unique slugs, contiguous numbering, stub per chapter), `route.spec.ts` (path parsing), `static.spec.ts` (document generation + crawl-control files).
- Updated: `router/__tests__/path.spec.ts` for the `docs` surface kind.
- `bun run check` green (92 tests); production build + discovery verified, plus a browser pass over desktop/mobile in both locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7XJDFReJTuUFiiYcYhrXS

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a first-party documentation surface at `/docs`, with catalog-driven navigation, chapter search, localized chrome, metadata, static document generation, and landing-page integration.

- Adds five initial documentation chapters grouped into three parts.
- Adds client-side docs routing, navigation, search, metadata updates, and locale-aware interface copy.
- Generates discoverable docs documents and updates the sitemap, `llms.txt`, and landing links.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect remaining after review.

The documentation routes, generated documents, catalog-driven navigation, localized interface, and landing integration form a consistent implementation, and the investigated routing and metadata concerns did not establish an actionable failure.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20galfrevn%2Fapollo%20PR%20%2356%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=galfrevn%2Fapollo&pr=56&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["feat(console): docs surface at /docs — t..."](https://github.com/galfrevn/apollo/commit/f5312ddd0e3f3043a356a93288afc957972c9a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53048379)</sub>

<!-- /greptile_comment -->