### PR TITLE
chore(create): v0.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,14 +45,10 @@ jobs:
       - name: Smoke-build the starter that will be embedded
         run: bun tooling/starter/build.ts --smoke
 
-      - name: Setup Node for npm publishing
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-
-      # Trusted Publishing needs a recent npm; provenance is attested from the
-      # OIDC-verified workflow identity.
+      # Trusted Publishing needs a recent npm and NO configured auth token:
+      # setup-node's registry-url writes a placeholder-token .npmrc that
+      # overrides the OIDC exchange and turns the publish into a 404. The
+      # runner's preinstalled Node is enough to bootstrap npm@latest.
       - name: Publish with provenance
         working-directory: tooling/create
         run: |

--- a/tooling/create/package.json
+++ b/tooling/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-heyapollo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Scaffold your own Apollo — a personal desk agent on your Cloudflare account — and walk through its setup wizard.",
   "license": "MIT",
   "author": "Valentín Galfre",


### PR DESCRIPTION
Version bump for the first automated npm release. The `create-v0.2.0` tag already points at this commit; merging (merge commit, not squash) lands it in main's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes setup-node’s npm authentication configuration so trusted publishing can use OIDC, and bumps create-heyapollo to version 0.2.0.
- Relies on the GitHub runner’s preinstalled Node to install the latest npm.
- Publishes without setup-node’s placeholder-token `.npmrc`.
- Updates the create package manifest to version 0.2.0.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The current GitHub runner provides a compatible Node version, the workflow upgrades npm before publishing, and the package version bump is consumed correctly by the tag check and npm publish.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: drop setup-node registry config that..."](https://github.com/galfrevn/apollo/commit/2cf2b0643f491c5454a422378a203fb0935e6588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53161590)</sub>

<!-- /greptile_comment -->