### PR TITLE
feat(wizard): opening banner, phased prompts, and richer validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ node_modules/
 dist/
 *.tsbuildinfo
 .turbo/
+# stray starter/create output generated inside the wizard workspace; the
+# canonical outputs live at tooling/starter/out and tooling/create/template
+apps/wizard/.sandbox/
+apps/wizard/generator/
+apps/wizard/template/
 
 # development
 worker-configuration.d.ts

--- a/apps/wizard/package.json
+++ b/apps/wizard/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "picocolors": "^1.1.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/wizard/src/__tests__/identity.spec.ts
+++ b/apps/wizard/src/__tests__/identity.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
 
 import {
+  readCurrentHomeLocation,
   readCurrentTtsVoiceId,
   rewriteTimeZone,
   rewriteTtsVoiceId,
@@ -95,6 +96,22 @@ describe('identity rewriters against the shipped file shape', () => {
     const secondPass = rewriteTimeZone(firstPass, 'Europe/Lisbon', 'hora de Lisboa');
     expect(secondPass).toContain("export const APOLLO_TIME_ZONE = 'Europe/Lisbon';");
     expect(secondPass).toContain("= 'hora de Lisboa';");
+  });
+
+  it('reads the configured home back, including escaped labels', async () => {
+    const identityContent = await readGeneratedShapeIdentityContent();
+    expect(readCurrentHomeLocation(identityContent)?.timezone).toBeDefined();
+    const rewrittenContent = rewriteWeatherLocation(identityContent, {
+      latitude: 41.36,
+      longitude: 2.1,
+      locationLabel: "L'Hospitalet de Llobregat",
+      timezone: 'Europe/Madrid',
+    });
+    expect(readCurrentHomeLocation(rewrittenContent)).toEqual({
+      locationLabel: "L'Hospitalet de Llobregat",
+      timezone: 'Europe/Madrid',
+    });
+    expect(readCurrentHomeLocation('const somethingElse = 1;')).toBeUndefined();
   });
 
   it('throws loudly when an anchor is missing', () => {

--- a/apps/wizard/src/__tests__/mapping.spec.ts
+++ b/apps/wizard/src/__tests__/mapping.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
 import { mapGeocodeResponseToCandidateList } from '@/geocode';
-import { mapVoicesResponseToChoiceList, MAXIMUM_VOICE_CHOICE_COUNT } from '@/keys';
+import {
+  describeOpenRouterKeyStatus,
+  mapVoicesResponseToChoiceList,
+  MAXIMUM_VOICE_CHOICE_COUNT,
+} from '@/keys';
 
 describe('mapGeocodeResponseToCandidateList', () => {
   it('labels candidates and drops entries without a timezone', () => {
@@ -43,7 +47,8 @@ describe('mapVoicesResponseToChoiceList', () => {
     });
     expect(choiceList[0]).toEqual({
       voiceId: 'voice-1',
-      displayLabel: 'Malena (argentine, es, cloned)',
+      displayLabel: 'Malena',
+      detailHint: 'argentine, es, cloned',
     });
     expect(choiceList[1]).toEqual({ voiceId: 'voice-2', displayLabel: 'Plain' });
   });
@@ -56,5 +61,24 @@ describe('mapVoicesResponseToChoiceList', () => {
     expect(mapVoicesResponseToChoiceList({ voices: oversizedVoiceList })).toHaveLength(
       MAXIMUM_VOICE_CHOICE_COUNT,
     );
+  });
+});
+
+describe('describeOpenRouterKeyStatus', () => {
+  it('prefers remaining credit when the key has a limit', () => {
+    expect(
+      describeOpenRouterKeyStatus({ data: { usage: 1.2, limit_remaining: 8.766 } }),
+    ).toBe('$8.77 credit remaining');
+  });
+
+  it('falls back to usage for unlimited keys', () => {
+    expect(
+      describeOpenRouterKeyStatus({ data: { usage: 4.821, limit_remaining: null } }),
+    ).toBe('$4.82 used so far');
+  });
+
+  it('returns undefined for an unexpected payload', () => {
+    expect(describeOpenRouterKeyStatus({ unexpected: true })).toBeUndefined();
+    expect(describeOpenRouterKeyStatus({ data: {} })).toBeUndefined();
   });
 });

--- a/apps/wizard/src/banner.ts
+++ b/apps/wizard/src/banner.ts
@@ -1,0 +1,117 @@
+import picocolors from 'picocolors';
+
+const COMPACT_COLUMN_THRESHOLD = 48;
+const FACE_COLUMN_WIDTH = 25;
+const BLINK_CLOSE_DELAY_MILLISECONDS = 450;
+const BLINK_REOPEN_DELAY_MILLISECONDS = 140;
+const OPEN_EYE_GLYPH_PAIR = '●  ●';
+const CLOSED_EYE_GLYPH_PAIR = '▬  ▬';
+
+const GOLD_COLOR_CODE_LIST = [223, 222, 220, 214, 208, 172] as const;
+
+function paintGold(text: string, rowIndex: number): string {
+  if (!picocolors.isColorSupported) {
+    return text;
+  }
+  const colorCode = GOLD_COLOR_CODE_LIST[rowIndex] ?? GOLD_COLOR_CODE_LIST[0];
+  return `\u001B[38;5;${colorCode}m${text}\u001B[39m`;
+}
+
+function paintFaceDetail(text: string): string {
+  return picocolors.bold(picocolors.white(text));
+}
+
+type BannerRow = {
+  readonly plainFace: string;
+  readonly paintedFace: string;
+  readonly sideText: string;
+};
+
+function composeEyeRow(eyeGlyphPair: string): BannerRow {
+  return {
+    plainFace: `    ██    ${eyeGlyphPair}    ██`,
+    paintedFace:
+      paintGold('    ██    ', 2) + paintFaceDetail(eyeGlyphPair) + paintGold('    ██', 2),
+    sideText: picocolors.bold(picocolors.yellow('A P O L L O')),
+  };
+}
+
+function composeDeviceFaceRowList(
+  eyeGlyphPair: string,
+  taglineLabel: string,
+): readonly BannerRow[] {
+  return [
+    {
+      plainFace: '       ▄▄██████▄▄',
+      paintedFace: paintGold('       ▄▄██████▄▄', 0),
+      sideText: '',
+    },
+    {
+      plainFace: '     ▄██▀      ▀██▄',
+      paintedFace: paintGold('     ▄██▀      ▀██▄', 1),
+      sideText: '',
+    },
+    composeEyeRow(eyeGlyphPair),
+    {
+      plainFace: '    ██     ──     ██',
+      paintedFace:
+        paintGold('    ██     ', 3) + paintFaceDetail('──') + paintGold('     ██', 3),
+      sideText: picocolors.dim('Your desk, listening.'),
+    },
+    {
+      plainFace: '     ▀██▄      ▄██▀',
+      paintedFace: paintGold('     ▀██▄      ▄██▀', 4),
+      sideText: picocolors.dim(taglineLabel),
+    },
+    {
+      plainFace: '       ▀▀██████▀▀',
+      paintedFace: paintGold('       ▀▀██████▀▀', 5),
+      sideText: '',
+    },
+  ];
+}
+
+function renderBannerRow(row: BannerRow): string {
+  if (row.sideText === '') {
+    return row.paintedFace;
+  }
+  const paddingWidth = Math.max(1, FACE_COLUMN_WIDTH - row.plainFace.length);
+  return `${row.paintedFace}${' '.repeat(paddingWidth)}${row.sideText}`;
+}
+
+function composeCompactBanner(taglineLabel: string): string {
+  return [
+    `   ${picocolors.bold(picocolors.yellow(OPEN_EYE_GLYPH_PAIR))}`,
+    `   ${picocolors.yellow('‾‾‾‾')}   ${picocolors.bold('apollo')} ${picocolors.dim('— your desk, listening')}`,
+    `          ${picocolors.dim(taglineLabel)}`,
+  ].join('\n');
+}
+
+async function blinkOnce(): Promise<void> {
+  const rewriteEyeRow = (eyeGlyphPair: string): void => {
+    const eyeRowLine = renderBannerRow(composeEyeRow(eyeGlyphPair));
+    // The banner prints six rows plus a blank line, leaving the cursor five
+    // lines below the eye row; move up, repaint that single row, move back.
+    process.stdout.write(`\u001B[5A\r\u001B[2K${eyeRowLine}\u001B[5B\r`);
+  };
+  await Bun.sleep(BLINK_CLOSE_DELAY_MILLISECONDS);
+  rewriteEyeRow(CLOSED_EYE_GLYPH_PAIR);
+  await Bun.sleep(BLINK_REOPEN_DELAY_MILLISECONDS);
+  rewriteEyeRow(OPEN_EYE_GLYPH_PAIR);
+}
+
+export async function playOpeningBanner(input: {
+  readonly taglineLabel: string;
+  readonly isReturningRun: boolean;
+}): Promise<void> {
+  const columnCount = process.stdout.columns ?? 80;
+  if (input.isReturningRun || columnCount < COMPACT_COLUMN_THRESHOLD) {
+    process.stdout.write(`\n${composeCompactBanner(input.taglineLabel)}\n\n`);
+    return;
+  }
+  const bannerRowList = composeDeviceFaceRowList(OPEN_EYE_GLYPH_PAIR, input.taglineLabel);
+  process.stdout.write(`\n${bannerRowList.map(renderBannerRow).join('\n')}\n\n`);
+  if (process.stdout.isTTY) {
+    await blinkOnce();
+  }
+}

--- a/apps/wizard/src/configure.ts
+++ b/apps/wizard/src/configure.ts
@@ -1,0 +1,196 @@
+import { cancel, confirm, password, select, spinner, text } from '@clack/prompts';
+import picocolors from 'picocolors';
+import { z } from 'zod';
+
+import { readCurrentTtsVoiceId, rewriteTtsVoiceId } from '@/identity';
+import {
+  listElevenLabsVoiceChoiceList,
+  validateOpenRouterApiKey,
+  validateResendApiKey,
+  validateTavilyApiKey,
+} from '@/keys';
+import { collectValidatedKey, KEY_ATTEMPT_LIMIT, requireAnswer } from '@/prompts';
+import { renderMutedLine, renderPhaseHeader, TOTAL_PHASE_COUNT } from '@/theme';
+import { upsertDevelopmentVariable } from '@/vars';
+
+async function chooseVoice(identityContent: string): Promise<{
+  readonly elevenLabsKey: string;
+  readonly identityContent: string;
+  readonly voiceLabel: string;
+}> {
+  renderMutedLine('elevenlabs.io → Profile');
+  for (let attemptIndex = 0; attemptIndex < KEY_ATTEMPT_LIMIT; attemptIndex += 1) {
+    const elevenLabsKey = requireAnswer(
+      await password({ message: 'ElevenLabs API key', mask: '•' }),
+    );
+    const voicesSpinner = spinner();
+    voicesSpinner.start('Fetching your voice library');
+    try {
+      const voiceChoiceList = await listElevenLabsVoiceChoiceList(elevenLabsKey);
+      voicesSpinner.stop(
+        picocolors.green(`${voiceChoiceList.length} voices in your library`),
+      );
+      const currentVoiceId = readCurrentTtsVoiceId(identityContent) ?? '';
+      const chosenVoiceId = requireAnswer(
+        await select({
+          message: 'Pick the voice Apollo speaks with',
+          options: [
+            ...(currentVoiceId !== ''
+              ? [{ value: currentVoiceId, label: 'Keep current', hint: currentVoiceId }]
+              : []),
+            ...voiceChoiceList.map((choice) => ({
+              value: choice.voiceId,
+              label: choice.displayLabel,
+              hint: choice.detailHint,
+            })),
+          ],
+        }),
+      );
+      const chosenVoice = voiceChoiceList.find(
+        (choice) => choice.voiceId === chosenVoiceId,
+      );
+      return {
+        elevenLabsKey,
+        identityContent: rewriteTtsVoiceId(identityContent, chosenVoiceId),
+        voiceLabel: chosenVoice?.displayLabel ?? `Keep current (${chosenVoiceId})`,
+      };
+    } catch (error) {
+      voicesSpinner.stop(
+        picocolors.red(error instanceof Error ? error.message : 'key rejected'),
+        2,
+      );
+      const remainingAttemptCount = KEY_ATTEMPT_LIMIT - attemptIndex - 1;
+      if (remainingAttemptCount > 0) {
+        renderMutedLine(`${remainingAttemptCount} attempt(s) left`);
+      }
+    }
+  }
+  cancel('Could not validate the ElevenLabs key.');
+  process.exit(1);
+}
+
+export type RealModeConfiguration = {
+  readonly developmentVariablesContent: string;
+  readonly identityContent: string;
+  readonly voiceLabel: string;
+  readonly webSearchLabel: string;
+  readonly emailLabel: string;
+};
+
+export async function collectRealModeConfiguration(input: {
+  readonly developmentVariablesContent: string;
+  readonly identityContent: string;
+}): Promise<RealModeConfiguration> {
+  let developmentVariablesContent = input.developmentVariablesContent;
+
+  renderPhaseHeader({
+    stepNumber: 2,
+    totalStepCount: TOTAL_PHASE_COUNT,
+    title: 'Intelligence',
+  });
+  const openRouterKey = await collectValidatedKey({
+    promptLabel: 'OpenRouter API key',
+    hintText: 'openrouter.ai/settings/keys · stays in .dev.vars, never committed',
+    failureHintText: 'keys start with sk-or-… · check for a trailing space',
+    validate: validateOpenRouterApiKey,
+    isSkippable: false,
+  });
+  if (openRouterKey !== undefined) {
+    developmentVariablesContent = upsertDevelopmentVariable(
+      developmentVariablesContent,
+      'OPENROUTER_API_KEY',
+      openRouterKey,
+    );
+  }
+
+  renderPhaseHeader({
+    stepNumber: 3,
+    totalStepCount: TOTAL_PHASE_COUNT,
+    title: 'Voice',
+  });
+  const voiceSetup = await chooseVoice(input.identityContent);
+  developmentVariablesContent = upsertDevelopmentVariable(
+    developmentVariablesContent,
+    'ELEVENLABS_API_KEY',
+    voiceSetup.elevenLabsKey,
+  );
+
+  renderPhaseHeader({
+    stepNumber: 4,
+    totalStepCount: TOTAL_PHASE_COUNT,
+    title: 'Extras',
+  });
+  let webSearchLabel = picocolors.dim('skipped');
+  const wantsWebSearch = requireAnswer(
+    await confirm({ message: 'Enable web search? (Tavily key, free tier available)' }),
+  );
+  if (wantsWebSearch) {
+    const tavilyKey = await collectValidatedKey({
+      promptLabel: 'Tavily API key',
+      hintText: 'app.tavily.com · the free tier is enough',
+      validate: validateTavilyApiKey,
+      isSkippable: true,
+    });
+    if (tavilyKey !== undefined) {
+      developmentVariablesContent = upsertDevelopmentVariable(
+        developmentVariablesContent,
+        'TAVILY_API_KEY',
+        tavilyKey,
+      );
+      webSearchLabel = `${picocolors.green('on')} ${picocolors.dim('· Tavily')}`;
+    }
+  }
+
+  let emailLabel = picocolors.dim('skipped');
+  const wantsEmail = requireAnswer(
+    await confirm({ message: 'Enable email reports to yourself? (Resend key)' }),
+  );
+  if (wantsEmail) {
+    const resendKey = await collectValidatedKey({
+      promptLabel: 'Resend API key',
+      hintText: 'resend.com/api-keys',
+      validate: async (apiKey) => {
+        const validationResult = await validateResendApiKey(apiKey);
+        // Sending-only Resend keys cannot list domains; accept with a warning.
+        return validationResult.isValid ? validationResult : { isValid: true };
+      },
+      isSkippable: true,
+    });
+    if (resendKey !== undefined) {
+      const ownerEmail = requireAnswer(
+        await text({
+          message:
+            'Your email (must be the address you signed up to Resend with, unless you verified a domain)',
+          validate: (enteredValue) =>
+            z.string().email().safeParse(enteredValue).success
+              ? undefined
+              : 'That does not look like an email address',
+        }),
+      );
+      developmentVariablesContent = upsertDevelopmentVariable(
+        developmentVariablesContent,
+        'RESEND_API_KEY',
+        resendKey,
+      );
+      developmentVariablesContent = upsertDevelopmentVariable(
+        developmentVariablesContent,
+        'APOLLO_OWNER_EMAIL',
+        ownerEmail,
+      );
+      emailLabel = `${picocolors.green('on')} ${picocolors.dim(`· reports to ${ownerEmail}`)}`;
+    }
+  }
+
+  developmentVariablesContent = upsertDevelopmentVariable(
+    developmentVariablesContent,
+    'MOCK_VOICE',
+    '',
+  );
+  return {
+    developmentVariablesContent,
+    identityContent: voiceSetup.identityContent,
+    voiceLabel: voiceSetup.voiceLabel,
+    webSearchLabel,
+    emailLabel,
+  };
+}

--- a/apps/wizard/src/configure.ts
+++ b/apps/wizard/src/configure.ts
@@ -60,13 +60,16 @@ async function chooseVoice(identityContent: string): Promise<{
         2,
       );
       const remainingAttemptCount = KEY_ATTEMPT_LIMIT - attemptIndex - 1;
-      if (remainingAttemptCount > 0) {
-        renderMutedLine(`${remainingAttemptCount} attempt(s) left`);
+      if (remainingAttemptCount === 0) {
+        cancel('Could not validate the ElevenLabs key.');
+        process.exit(1);
       }
+      renderMutedLine(`${remainingAttemptCount} attempt(s) left`);
     }
   }
-  cancel('Could not validate the ElevenLabs key.');
-  process.exit(1);
+  // SAFETY: every iteration returns or exits, but the starter's worker types do
+  // not mark process.exit as `never`, so the compiler needs a terminal path.
+  throw new Error('unreachable: the ElevenLabs key loop returns or exits');
 }
 
 export type RealModeConfiguration = {

--- a/apps/wizard/src/identity.ts
+++ b/apps/wizard/src/identity.ts
@@ -81,6 +81,45 @@ export function rewriteWeatherLocation(
   );
 }
 
+export type DeskHomeIdentity = {
+  readonly locationLabel: string;
+  readonly timezone: string;
+};
+
+function unescapeSingleQuotedLiteral(quotedLiteralText: string): string {
+  return quotedLiteralText.slice(1, -1).replace(/\\(.)/g, '$1');
+}
+
+export function readCurrentHomeLocation(
+  fileContent: string,
+): DeskHomeIdentity | undefined {
+  const locationBlockText = fileContent.match(
+    /export const DEFAULT_DESK_WEATHER_LOCATION = \{[^}]*\} as const;/,
+  )?.[0];
+  if (locationBlockText === undefined) {
+    return undefined;
+  }
+  const labelLiteral = locationBlockText.match(
+    new RegExp(`locationLabel: (${QUOTED_LITERAL_PATTERN_TEXT}),`),
+  )?.[1];
+  // The shipped block references APOLLO_TIME_ZONE by identifier until the
+  // first rewrite inlines a literal, so fall back to the constant itself.
+  const timezoneLiteral =
+    locationBlockText.match(
+      new RegExp(`timezone: (${QUOTED_LITERAL_PATTERN_TEXT}),`),
+    )?.[1] ??
+    fileContent.match(
+      new RegExp(`export const APOLLO_TIME_ZONE = (${QUOTED_LITERAL_PATTERN_TEXT});`),
+    )?.[1];
+  if (labelLiteral === undefined || timezoneLiteral === undefined) {
+    return undefined;
+  }
+  return {
+    locationLabel: unescapeSingleQuotedLiteral(labelLiteral),
+    timezone: unescapeSingleQuotedLiteral(timezoneLiteral),
+  };
+}
+
 export function readCurrentTtsVoiceId(fileContent: string): string | undefined {
   return fileContent
     .match(

--- a/apps/wizard/src/index.ts
+++ b/apps/wizard/src/index.ts
@@ -1,58 +1,52 @@
-import {
-  cancel,
-  confirm,
-  intro,
-  note,
-  outro,
-  password,
-  select,
-  spinner,
-  text,
-} from '@clack/prompts';
+import { cancel, confirm, intro, log, note, outro, select } from '@clack/prompts';
 import { existsSync } from 'node:fs';
+import picocolors from 'picocolors';
 import { z } from 'zod';
 
-import {
-  readCurrentTtsVoiceId,
-  rewriteTimeZone,
-  rewriteTtsVoiceId,
-  rewriteWeatherLocation,
-} from '@/identity';
-import {
-  listElevenLabsVoiceChoiceList,
-  validateOpenRouterApiKey,
-  validateResendApiKey,
-  validateTavilyApiKey,
-} from '@/keys';
+import { playOpeningBanner } from '@/banner';
+import { collectRealModeConfiguration } from '@/configure';
+import { rewriteTimeZone, rewriteWeatherLocation } from '@/identity';
 import {
   inspectWranglerAuthState,
   isR2Enabled,
   runBootstrapSubcommand,
   runInteractiveWranglerLogin,
 } from '@/preflight';
+import { chooseCity, requireAnswer } from '@/prompts';
+import { buildOutroMessage, buildRecapLineList } from '@/summary';
 import {
-  chooseCity,
-  collectValidatedKey,
-  KEY_ATTEMPT_LIMIT,
-  requireAnswer,
-} from '@/prompts';
+  renderMutedLine,
+  renderPhaseHeader,
+  renderSuccessLine,
+  TOTAL_PHASE_COUNT,
+} from '@/theme';
 import { parseDevelopmentVariableMap, upsertDevelopmentVariable } from '@/vars';
 
 const DEVELOPMENT_VARIABLES_FILE = '.dev.vars';
 const IDENTITY_FILE = 'src/configuration/identity.ts';
 
 const deploymentStateSchema = z.object({ workerUrl: z.string().url() }).partial();
+const packageManifestSchema = z.object({ version: z.string().optional() });
 
-async function runWizard(): Promise<void> {
-  intro('Apollo setup — from nothing to a talking worker');
-
-  if (!existsSync(DEVELOPMENT_VARIABLES_FILE)) {
-    await Bun.write(
-      DEVELOPMENT_VARIABLES_FILE,
-      await Bun.file('.dev.vars.example').text(),
+async function readSetupTaglineLabel(): Promise<string> {
+  try {
+    const packageManifest = packageManifestSchema.parse(
+      JSON.parse(await Bun.file('package.json').text()),
     );
+    return packageManifest.version === undefined
+      ? 'setup'
+      : `setup · v${packageManifest.version}`;
+  } catch {
+    return 'setup';
   }
+}
 
+async function confirmCloudflareAccount(): Promise<void> {
+  renderPhaseHeader({
+    stepNumber: 1,
+    totalStepCount: TOTAL_PHASE_COUNT,
+    title: 'Cloudflare',
+  });
   let authState = inspectWranglerAuthState();
   if (!authState.isLoggedIn) {
     const shouldLogin = requireAnswer(
@@ -76,7 +70,6 @@ async function runWizard(): Promise<void> {
     );
     process.exit(1);
   }
-
   while (!isR2Enabled()) {
     note(
       'R2 is not enabled on this account (it needs a payment card on file, even for free usage).\nEnable it at https://dash.cloudflare.com → R2, then continue.',
@@ -88,6 +81,24 @@ async function runWizard(): Promise<void> {
       process.exit(1);
     }
   }
+  renderSuccessLine('Cloudflare ready', 'account confirmed · R2 enabled');
+}
+
+async function runWizard(): Promise<void> {
+  await playOpeningBanner({
+    taglineLabel: await readSetupTaglineLabel(),
+    isReturningRun: existsSync('.apollo.json'),
+  });
+  intro(picocolors.bold("Let's set up your desk agent"));
+
+  if (!existsSync(DEVELOPMENT_VARIABLES_FILE)) {
+    await Bun.write(
+      DEVELOPMENT_VARIABLES_FILE,
+      await Bun.file('.dev.vars.example').text(),
+    );
+  }
+
+  await confirmCloudflareAccount();
 
   let developmentVariablesContent = await Bun.file(DEVELOPMENT_VARIABLES_FILE).text();
   let identityContent = await Bun.file(IDENTITY_FILE).text();
@@ -96,135 +107,35 @@ async function runWizard(): Promise<void> {
     await select({
       message: 'Do you have your API keys ready?',
       options: [
-        { value: 'real', label: 'Yes — OpenRouter + ElevenLabs (full voice agent)' },
+        {
+          value: 'real',
+          label: 'Yes — OpenRouter + ElevenLabs',
+          hint: 'full voice agent',
+        },
         {
           value: 'trial',
-          label: 'Not yet — trial mode (MOCK_VOICE=1, zero external spend)',
+          label: 'Not yet — trial mode',
+          hint: 'MOCK_VOICE=1, zero external spend',
         },
       ],
     }),
   );
 
+  let voiceLabel: string | undefined;
+  let webSearchLabel: string | undefined;
+  let emailLabel: string | undefined;
   if (setupMode === 'real') {
-    const openRouterKey = await collectValidatedKey({
-      promptLabel: 'OpenRouter API key (openrouter.ai/settings/keys)',
-      validate: validateOpenRouterApiKey,
-      isSkippable: false,
-    });
-    if (openRouterKey !== undefined) {
-      developmentVariablesContent = upsertDevelopmentVariable(
-        developmentVariablesContent,
-        'OPENROUTER_API_KEY',
-        openRouterKey,
-      );
-    }
-
-    for (let attemptIndex = 0; attemptIndex < KEY_ATTEMPT_LIMIT; attemptIndex += 1) {
-      const elevenLabsKey = requireAnswer(
-        await password({
-          message: 'ElevenLabs API key (elevenlabs.io → Profile)',
-          mask: '•',
-        }),
-      );
-      const voicesSpinner = spinner();
-      voicesSpinner.start('Fetching your voice library');
-      try {
-        const voiceChoiceList = await listElevenLabsVoiceChoiceList(elevenLabsKey);
-        voicesSpinner.stop(`${voiceChoiceList.length} voices available`);
-        developmentVariablesContent = upsertDevelopmentVariable(
-          developmentVariablesContent,
-          'ELEVENLABS_API_KEY',
-          elevenLabsKey,
-        );
-        const currentVoiceId = readCurrentTtsVoiceId(identityContent) ?? '';
-        const chosenVoiceId = requireAnswer(
-          await select({
-            message: 'Pick the voice Apollo speaks with',
-            options: [
-              ...(currentVoiceId !== ''
-                ? [{ value: currentVoiceId, label: `Keep current (${currentVoiceId})` }]
-                : []),
-              ...voiceChoiceList.map((choice) => ({
-                value: choice.voiceId,
-                label: choice.displayLabel,
-              })),
-            ],
-          }),
-        );
-        identityContent = rewriteTtsVoiceId(identityContent, chosenVoiceId);
-        break;
-      } catch (error) {
-        voicesSpinner.stop(error instanceof Error ? error.message : 'key rejected');
-        if (attemptIndex === KEY_ATTEMPT_LIMIT - 1) {
-          cancel('Could not validate the ElevenLabs key.');
-          process.exit(1);
-        }
-      }
-    }
-
-    const wantsWebSearch = requireAnswer(
-      await confirm({ message: 'Enable web search? (Tavily key, free tier available)' }),
-    );
-    if (wantsWebSearch) {
-      const tavilyKey = await collectValidatedKey({
-        promptLabel: 'Tavily API key (app.tavily.com)',
-        validate: validateTavilyApiKey,
-        isSkippable: true,
-      });
-      if (tavilyKey !== undefined) {
-        developmentVariablesContent = upsertDevelopmentVariable(
-          developmentVariablesContent,
-          'TAVILY_API_KEY',
-          tavilyKey,
-        );
-      }
-    }
-
-    const wantsEmail = requireAnswer(
-      await confirm({ message: 'Enable email reports to yourself? (Resend key)' }),
-    );
-    if (wantsEmail) {
-      const resendKey = await collectValidatedKey({
-        promptLabel: 'Resend API key (resend.com/api-keys)',
-        validate: async (apiKey) => {
-          const validationResult = await validateResendApiKey(apiKey);
-          // Sending-only Resend keys cannot list domains; accept with a warning.
-          return validationResult.isValid
-            ? validationResult
-            : { isValid: true, reason: undefined };
-        },
-        isSkippable: true,
-      });
-      if (resendKey !== undefined) {
-        const ownerEmail = requireAnswer(
-          await text({
-            message:
-              'Your email (must be the address you signed up to Resend with, unless you verified a domain)',
-            validate: (enteredValue) =>
-              z.string().email().safeParse(enteredValue).success
-                ? undefined
-                : 'That does not look like an email address',
-          }),
-        );
-        developmentVariablesContent = upsertDevelopmentVariable(
-          developmentVariablesContent,
-          'RESEND_API_KEY',
-          resendKey,
-        );
-        developmentVariablesContent = upsertDevelopmentVariable(
-          developmentVariablesContent,
-          'APOLLO_OWNER_EMAIL',
-          ownerEmail,
-        );
-      }
-    }
-
-    developmentVariablesContent = upsertDevelopmentVariable(
+    const realModeConfiguration = await collectRealModeConfiguration({
       developmentVariablesContent,
-      'MOCK_VOICE',
-      '',
-    );
+      identityContent,
+    });
+    developmentVariablesContent = realModeConfiguration.developmentVariablesContent;
+    identityContent = realModeConfiguration.identityContent;
+    voiceLabel = realModeConfiguration.voiceLabel;
+    webSearchLabel = realModeConfiguration.webSearchLabel;
+    emailLabel = realModeConfiguration.emailLabel;
   } else {
+    renderMutedLine('Trial mode — skipping Intelligence, Voice, and Extras (2–4).');
     developmentVariablesContent = upsertDevelopmentVariable(
       developmentVariablesContent,
       'MOCK_VOICE',
@@ -232,6 +143,11 @@ async function runWizard(): Promise<void> {
     );
   }
 
+  renderPhaseHeader({
+    stepNumber: 5,
+    totalStepCount: TOTAL_PHASE_COUNT,
+    title: 'Home',
+  });
   const chosenCity = await chooseCity();
   if (chosenCity !== undefined) {
     const cityName = chosenCity.label.split(',')[0];
@@ -254,6 +170,22 @@ async function runWizard(): Promise<void> {
 
   await Bun.write(DEVELOPMENT_VARIABLES_FILE, developmentVariablesContent);
   await Bun.write(IDENTITY_FILE, identityContent);
+
+  renderPhaseHeader({ title: 'Ready to launch' });
+  const recapLineList = buildRecapLineList({
+    modeLabel:
+      setupMode === 'real' ? 'Full voice agent' : 'Trial — replies mocked, zero spend',
+    voiceLabel,
+    homeLabel:
+      chosenCity !== undefined
+        ? `${chosenCity.label.split(',')[0]} · ${chosenCity.timezone}`
+        : `Buenos Aires ${picocolors.dim('· default')}`,
+    webSearchLabel,
+    emailLabel,
+  });
+  for (const recapLine of recapLineList) {
+    log.message(recapLine);
+  }
 
   const shouldDeploy = requireAnswer(
     await confirm({
@@ -285,16 +217,11 @@ async function runWizard(): Promise<void> {
   }
   const deviceWebSocketUrl = `${workerUrl.replace(/^https/, 'wss')}/agents/apollo/desk?token=<DEVICE_SHARED_SECRET>`;
   outro(
-    [
-      'Apollo is live.',
-      `  Worker:  ${workerUrl}`,
-      `  Device:  ${deviceWebSocketUrl}`,
-      '  Secrets: DEVICE_SHARED_SECRET and DASHBOARD_SHARED_SECRET are in .dev.vars',
-      '  Console: https://heyapollo.dev/console → your worker URL + instance `desk` + DASHBOARD_SHARED_SECRET',
-      variableMap.get('MOCK_VOICE') === '1'
-        ? '  Trial mode: replies are mocked — re-run `bun run setup` when you have keys.'
-        : `  Try it:  bun run probe -- --url ${workerUrl.replace(/^https/, 'wss')}/agents/apollo/desk --token <DEVICE_SHARED_SECRET> --text "hola"`,
-    ].join('\n'),
+    buildOutroMessage({
+      workerUrl,
+      deviceWebSocketUrl,
+      isTrialMode: variableMap.get('MOCK_VOICE') === '1',
+    }),
   );
 }
 

--- a/apps/wizard/src/index.ts
+++ b/apps/wizard/src/index.ts
@@ -5,7 +5,11 @@ import { z } from 'zod';
 
 import { playOpeningBanner } from '@/banner';
 import { collectRealModeConfiguration } from '@/configure';
-import { rewriteTimeZone, rewriteWeatherLocation } from '@/identity';
+import {
+  readCurrentHomeLocation,
+  rewriteTimeZone,
+  rewriteWeatherLocation,
+} from '@/identity';
 import {
   inspectWranglerAuthState,
   isR2Enabled,
@@ -172,6 +176,7 @@ async function runWizard(): Promise<void> {
   await Bun.write(IDENTITY_FILE, identityContent);
 
   renderPhaseHeader({ title: 'Ready to launch' });
+  const retainedHome = readCurrentHomeLocation(identityContent);
   const recapLineList = buildRecapLineList({
     modeLabel:
       setupMode === 'real' ? 'Full voice agent' : 'Trial — replies mocked, zero spend',
@@ -179,7 +184,9 @@ async function runWizard(): Promise<void> {
     homeLabel:
       chosenCity !== undefined
         ? `${chosenCity.label.split(',')[0]} · ${chosenCity.timezone}`
-        : `Buenos Aires ${picocolors.dim('· default')}`,
+        : retainedHome !== undefined
+          ? `${retainedHome.locationLabel} · ${retainedHome.timezone} ${picocolors.dim('· unchanged')}`
+          : `Buenos Aires ${picocolors.dim('· default')}`,
     webSearchLabel,
     emailLabel,
   });

--- a/apps/wizard/src/keys.ts
+++ b/apps/wizard/src/keys.ts
@@ -4,7 +4,7 @@ const KEY_VALIDATION_TIMEOUT_MILLISECONDS = 10_000;
 export const MAXIMUM_VOICE_CHOICE_COUNT = 30;
 
 export type KeyValidationResult =
-  | { readonly isValid: true }
+  | { readonly isValid: true; readonly successDetail?: string }
   | { readonly isValid: false; readonly reason: string };
 
 async function fetchWithTimeout(
@@ -23,6 +23,29 @@ function describeHttpFailure(response: Response): string {
     : `unexpected status ${response.status}`;
 }
 
+const openRouterKeyResponseSchema = z.object({
+  data: z.object({
+    usage: z.number().optional(),
+    limit_remaining: z.number().nullable().optional(),
+  }),
+});
+
+export function describeOpenRouterKeyStatus(rawResponse: unknown): string | undefined {
+  const parsedResponse = openRouterKeyResponseSchema.safeParse(rawResponse);
+  if (!parsedResponse.success) {
+    return undefined;
+  }
+  const remainingCredit = parsedResponse.data.data.limit_remaining;
+  if (typeof remainingCredit === 'number') {
+    return `$${remainingCredit.toFixed(2)} credit remaining`;
+  }
+  const usedCredit = parsedResponse.data.data.usage;
+  if (typeof usedCredit === 'number') {
+    return `$${usedCredit.toFixed(2)} used so far`;
+  }
+  return undefined;
+}
+
 export async function validateOpenRouterApiKey(
   apiKey: string,
 ): Promise<KeyValidationResult> {
@@ -30,9 +53,11 @@ export async function validateOpenRouterApiKey(
     const response = await fetchWithTimeout('https://openrouter.ai/api/v1/key', {
       headers: { Authorization: `Bearer ${apiKey}` },
     });
-    return response.ok
-      ? { isValid: true }
-      : { isValid: false, reason: describeHttpFailure(response) };
+    if (!response.ok) {
+      return { isValid: false, reason: describeHttpFailure(response) };
+    }
+    const responseBody: unknown = await response.json().catch(() => undefined);
+    return { isValid: true, successDetail: describeOpenRouterKeyStatus(responseBody) };
   } catch (error) {
     return {
       isValid: false,
@@ -55,6 +80,7 @@ const elevenLabsVoicesResponseSchema = z.object({
 export type VoiceChoice = {
   readonly voiceId: string;
   readonly displayLabel: string;
+  readonly detailHint?: string;
 };
 
 export function mapVoicesResponseToChoiceList(
@@ -69,10 +95,8 @@ export function mapVoicesResponseToChoiceList(
     ].filter((detail): detail is string => detail !== undefined && detail.length > 0);
     return {
       voiceId: voice.voice_id,
-      displayLabel:
-        labelDetailList.length > 0
-          ? `${voice.name} (${labelDetailList.join(', ')})`
-          : voice.name,
+      displayLabel: voice.name,
+      ...(labelDetailList.length > 0 ? { detailHint: labelDetailList.join(', ') } : {}),
     };
   });
 }

--- a/apps/wizard/src/prompts.ts
+++ b/apps/wizard/src/prompts.ts
@@ -7,8 +7,11 @@ import {
   spinner,
   text,
 } from '@clack/prompts';
+import picocolors from 'picocolors';
 
 import { searchCityCandidateList, type CityCandidate } from '@/geocode';
+import { renderMutedLine, renderSuccessLine } from '@/theme';
+import type { KeyValidationResult } from '@/keys';
 
 const KEY_ATTEMPT_LIMIT = 3;
 
@@ -24,9 +27,14 @@ export function requireAnswer<AnswerType>(answer: AnswerType | symbol): AnswerTy
 
 export async function collectValidatedKey(input: {
   readonly promptLabel: string;
-  readonly validate: (apiKey: string) => Promise<{ isValid: boolean; reason?: string }>;
+  readonly hintText?: string;
+  readonly failureHintText?: string;
+  readonly validate: (apiKey: string) => Promise<KeyValidationResult>;
   readonly isSkippable: boolean;
 }): Promise<string | undefined> {
+  if (input.hintText !== undefined) {
+    renderMutedLine(input.hintText);
+  }
   for (let attemptIndex = 0; attemptIndex < KEY_ATTEMPT_LIMIT; attemptIndex += 1) {
     const enteredKey = requireAnswer(
       await password({ message: input.promptLabel, mask: '•' }),
@@ -35,10 +43,25 @@ export async function collectValidatedKey(input: {
     validationSpinner.start('Validating key');
     const validationResult = await input.validate(enteredKey);
     if (validationResult.isValid) {
-      validationSpinner.stop('Key is valid');
+      const detailSuffix =
+        validationResult.successDetail === undefined
+          ? ''
+          : ` ${picocolors.dim(`· ${validationResult.successDetail}`)}`;
+      validationSpinner.stop(`${picocolors.green('Key valid')}${detailSuffix}`);
       return enteredKey;
     }
-    validationSpinner.stop(`Key rejected: ${validationResult.reason ?? 'unknown'}`);
+    validationSpinner.stop(
+      picocolors.red(`Key rejected — ${validationResult.reason}`),
+      2,
+    );
+    const remainingAttemptCount = KEY_ATTEMPT_LIMIT - attemptIndex - 1;
+    if (remainingAttemptCount > 0) {
+      renderMutedLine(
+        [input.failureHintText, `${remainingAttemptCount} attempt(s) left`]
+          .filter((hintPart) => hintPart !== undefined)
+          .join(' · '),
+      );
+    }
     if (input.isSkippable) {
       const shouldRetry = requireAnswer(
         await confirm({ message: 'Try another key? ("No" skips this feature)' }),
@@ -55,8 +78,8 @@ export async function collectValidatedKey(input: {
 export async function chooseCity(): Promise<CityCandidate | undefined> {
   const cityQuery = requireAnswer(
     await text({
-      message: 'Which city is this desk in? (empty keeps Buenos Aires)',
-      placeholder: 'e.g. Madrid',
+      message: 'Which city is this desk in?',
+      placeholder: 'e.g. Madrid — empty keeps Buenos Aires',
       defaultValue: '',
     }),
   );
@@ -69,22 +92,26 @@ export async function chooseCity(): Promise<CityCandidate | undefined> {
   try {
     candidateList = await searchCityCandidateList(cityQuery.trim());
   } catch (error) {
-    geocodeSpinner.stop(error instanceof Error ? error.message : 'geocoding failed');
+    geocodeSpinner.stop(error instanceof Error ? error.message : 'geocoding failed', 2);
+    return undefined;
+  }
+  if (candidateList.length === 0) {
+    geocodeSpinner.stop(picocolors.red('No matches — keeping Buenos Aires'), 2);
     return undefined;
   }
   geocodeSpinner.stop(`${candidateList.length} match(es)`);
-  if (candidateList.length === 0) {
-    return undefined;
-  }
-  return requireAnswer(
+  const chosenCandidate = requireAnswer(
     await select({
       message: 'Which of these?',
       options: candidateList.map((candidate) => ({
         value: candidate,
-        label: `${candidate.label} — ${candidate.timezone}`,
+        label: candidate.label,
+        hint: candidate.timezone,
       })),
     }),
   );
+  renderSuccessLine('Home set', `${chosenCandidate.label} · ${chosenCandidate.timezone}`);
+  return chosenCandidate;
 }
 
 export { KEY_ATTEMPT_LIMIT };

--- a/apps/wizard/src/summary.ts
+++ b/apps/wizard/src/summary.ts
@@ -1,0 +1,59 @@
+import picocolors from 'picocolors';
+
+const RECAP_LABEL_COLUMN_WIDTH = 13;
+
+export type SetupRecap = {
+  readonly modeLabel: string;
+  readonly voiceLabel?: string;
+  readonly homeLabel: string;
+  readonly webSearchLabel?: string;
+  readonly emailLabel?: string;
+};
+
+function composeRecapRow(rowLabel: string, rowValue: string): string {
+  return `${picocolors.dim(rowLabel.padEnd(RECAP_LABEL_COLUMN_WIDTH))}${rowValue}`;
+}
+
+export function buildRecapLineList(recap: SetupRecap): readonly string[] {
+  const recapRowList: string[] = [
+    composeRecapRow('Mode', picocolors.bold(recap.modeLabel)),
+  ];
+  if (recap.voiceLabel !== undefined) {
+    recapRowList.push(composeRecapRow('Voice', recap.voiceLabel));
+  }
+  recapRowList.push(composeRecapRow('Home', recap.homeLabel));
+  if (recap.webSearchLabel !== undefined) {
+    recapRowList.push(composeRecapRow('Web search', recap.webSearchLabel));
+  }
+  if (recap.emailLabel !== undefined) {
+    recapRowList.push(composeRecapRow('Email', recap.emailLabel));
+  }
+  return recapRowList;
+}
+
+export function buildOutroMessage(input: {
+  readonly workerUrl: string;
+  readonly deviceWebSocketUrl: string;
+  readonly isTrialMode: boolean;
+}): string {
+  const outroLineList = [
+    picocolors.bold(picocolors.green('✦ Apollo is live')),
+    '',
+    `   ${picocolors.dim('Worker'.padEnd(10))}${picocolors.cyan(input.workerUrl)}`,
+    `   ${picocolors.dim('Device'.padEnd(10))}${picocolors.cyan(input.deviceWebSocketUrl)}`,
+    `   ${picocolors.dim('Console'.padEnd(10))}${picocolors.cyan('https://heyapollo.dev/console')} ${picocolors.dim('→ worker URL + instance `desk` + DASHBOARD_SHARED_SECRET')}`,
+    `   ${picocolors.dim('Secrets'.padEnd(10))}DEVICE_SHARED_SECRET and DASHBOARD_SHARED_SECRET are in .dev.vars`,
+    '',
+  ];
+  if (input.isTrialMode) {
+    outroLineList.push(
+      `   ${picocolors.dim('Trial mode: replies are mocked — re-run `bun run setup` when you have keys.')}`,
+    );
+  } else {
+    outroLineList.push(
+      `   ${picocolors.dim('Say hello:')}`,
+      `   ${picocolors.yellow(`bun run probe -- --url ${input.deviceWebSocketUrl.split('?')[0]} --token <DEVICE_SHARED_SECRET> --text "hola"`)}`,
+    );
+  }
+  return outroLineList.join('\n');
+}

--- a/apps/wizard/src/theme.ts
+++ b/apps/wizard/src/theme.ts
@@ -1,0 +1,42 @@
+import { log } from '@clack/prompts';
+import picocolors from 'picocolors';
+
+const PHASE_HEADER_TOTAL_WIDTH = 52;
+
+export const TOTAL_PHASE_COUNT = 5;
+
+export function renderPhaseHeader(input: {
+  readonly stepNumber?: number;
+  readonly totalStepCount?: number;
+  readonly title: string;
+}): void {
+  const numberingPrefix =
+    input.stepNumber !== undefined && input.totalStepCount !== undefined
+      ? `${input.stepNumber}/${input.totalStepCount} · `
+      : '';
+  const headline = `${numberingPrefix}${input.title}`;
+  const trailingRuleWidth = Math.max(4, PHASE_HEADER_TOTAL_WIDTH - headline.length);
+  log.message(
+    `${picocolors.bold(picocolors.yellow(headline))} ${picocolors.dim('─'.repeat(trailingRuleWidth))}`,
+    { symbol: picocolors.yellow('◆──') },
+  );
+}
+
+export function renderSuccessLine(headline: string, detailText?: string): void {
+  const detailSuffix =
+    detailText === undefined ? '' : ` ${picocolors.dim(`· ${detailText}`)}`;
+  log.message(`${picocolors.green(headline)}${detailSuffix}`, {
+    symbol: picocolors.green('✓'),
+  });
+}
+
+export function renderFailureLine(headline: string, hintText?: string): void {
+  log.message(picocolors.red(headline), { symbol: picocolors.red('✗') });
+  if (hintText !== undefined) {
+    renderMutedLine(hintText);
+  }
+}
+
+export function renderMutedLine(text: string): void {
+  log.message(picocolors.dim(text));
+}

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
       "name": "@apollo/wizard",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
+        "picocolors": "^1.1.1",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -83,7 +84,7 @@
     },
     "tooling/create": {
       "name": "create-heyapollo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "create-heyapollo": "dist/index.js",
       },

--- a/tooling/starter/assets/scripts/bootstrap.ts
+++ b/tooling/starter/assets/scripts/bootstrap.ts
@@ -227,6 +227,16 @@ async function runVerify(urlFlagValue: string | undefined): Promise<void> {
 
 const subcommand = Bun.argv[2];
 const urlFlagValue = readFlagValue(Bun.argv, '--url');
+const bootstrapStageList: readonly {
+  readonly stageName: string;
+  readonly execute: () => Promise<void> | void;
+}[] = [
+  { stageName: 'preflight', execute: runPreflight },
+  { stageName: 'provision', execute: runProvision },
+  { stageName: 'secrets', execute: runSecrets },
+  { stageName: 'deploy', execute: runDeploy },
+  { stageName: 'verify', execute: () => runVerify(urlFlagValue) },
+];
 switch (subcommand) {
   case 'preflight':
     await runPreflight();
@@ -244,11 +254,12 @@ switch (subcommand) {
     await runVerify(urlFlagValue);
     break;
   case 'all':
-    await runPreflight();
-    runProvision();
-    await runSecrets();
-    await runDeploy();
-    await runVerify(urlFlagValue);
+    for (const [stageIndex, stage] of bootstrapStageList.entries()) {
+      console.log(
+        `\n[${stageIndex + 1}/${bootstrapStageList.length}] ${stage.stageName}`,
+      );
+      await stage.execute();
+    }
     break;
   default:
     console.log(


### PR DESCRIPTION
## What

A UX facelift for `bun run setup`, matching the approved terminal mockups. Everything stays on `@clack/prompts` — no flow-logic changes, no new prompt engine.

- **Opening banner** (`src/banner.ts`): a gold-gradient ASCII render of the 1.85″ round device that blinks once before the first prompt. Terminals under 48 columns and re-runs (`.apollo.json` present) get a compact eyes-only mark. Degrades to plain glyphs under `NO_COLOR`/non-TTY.
- **Named phases** (`src/theme.ts`): the ~10 questions are grouped under `◆── 2/5 · Intelligence ──` style headers; trial mode says which phases it skips.
- **Inputs that explain themselves** (`src/prompts.ts`, `src/configure.ts`): short questions with dim hint lines (where the key lives, that it stays in `.dev.vars`), selects with clack-native `hint` descriptors for voices and cities.
- **Validation that proves something** (`src/keys.ts`): OpenRouter success shows credit remaining (parsed from the `/api/v1/key` response previously discarded), ElevenLabs shows the voice count. Rejections name the cause, a likely fix, and attempts left.
- **Recap + outro** (`src/summary.ts`): every decision on one screen before the deploy confirm; the outro gives each fact a labeled row and ends with a copy-ready `bun run probe` command.
- **Bootstrap stages**: `bootstrap all` prints a `[n/5]` banner before each stage so the deploy minute has visible progress.
- **Housekeeping**: stray generated starter output inside `apps/wizard/` (`.sandbox/`, `generator/`, `template/`) is now gitignored — it was breaking the repo-wide format check; the canonical outputs live at `tooling/starter/out` and `tooling/create/template`. `picocolors` (already in the tree via clack) is now a declared dependency and merges into the generated starter automatically.

`src/index.ts` was split to stay under the 300-line cap: phases 2–4 moved to `src/configure.ts`. All new files are flat single-word names, so the starter's `emitWizard` copy keeps working unchanged.

## Test plan

- `bun run check` green (lint, format, typecheck, 1215 tests)
- New unit tests for `describeOpenRouterKeyStatus` and the updated voice-choice shape
- Banner, recap, and outro renderers exercised directly; plain-text fallback verified to align (padding is computed on unpainted strings, so colored output aligns identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rs11vLqz3Jh1NPUUEz6apZ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes the setup wizard with an opening banner, phased prompts, richer validation feedback, a deployment recap, and clearer bootstrap progress.
- Splits real-mode configuration into a dedicated module and adds reusable theme and summary renderers.
- Preserves an existing home location in the recap when returning users leave the city prompt empty.
- Declares `picocolors` directly and propagates it into generated starters.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported retained-home recap issue is fixed by reading the effective home from the updated identity content before rendering the recap.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(wizard): recap reads the retained ho..."](https://github.com/galfrevn/apollo/commit/f08c025e1cff2069f4a6355401d858cc2b834be7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53177512)</sub>

<!-- /greptile_comment -->