### PR TITLE
feat(console): copy-command get-started pass across landing and docs

### DIFF
--- a/apps/console/src/components/__tests__/clipboard.spec.ts
+++ b/apps/console/src/components/__tests__/clipboard.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+
+import { copyTextUsingWriter } from '@/components/clipboard';
+
+describe('copyTextUsingWriter', () => {
+  it('resolves true and forwards the text when the writer succeeds', async () => {
+    const writtenTextList: string[] = [];
+    const didCopy = await copyTextUsingWriter(async (text) => {
+      writtenTextList.push(text);
+    }, 'bun create heyapollo');
+
+    expect(didCopy).toBe(true);
+    expect(writtenTextList).toEqual(['bun create heyapollo']);
+  });
+
+  it('resolves false when the writer rejects', async () => {
+    const didCopy = await copyTextUsingWriter(
+      () => Promise.reject(new Error('clipboard denied')),
+      'bun create heyapollo',
+    );
+
+    expect(didCopy).toBe(false);
+  });
+
+  it('resolves false when the writer throws synchronously', async () => {
+    const didCopy = await copyTextUsingWriter(() => {
+      throw new Error('no clipboard in this context');
+    }, 'npm create heyapollo');
+
+    expect(didCopy).toBe(false);
+  });
+});

--- a/apps/console/src/components/clipboard.ts
+++ b/apps/console/src/components/clipboard.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const COPY_FEEDBACK_DURATION_MS = 2000;
+
+export async function copyTextUsingWriter(
+  writeText: (text: string) => Promise<void>,
+  text: string,
+): Promise<boolean> {
+  try {
+    await writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The Clipboard API is secure-context only and can be absent or throw when the
+// browser denies access (permissions policy, sandboxed embeds); copying must
+// fail silently instead of crashing the page.
+function resolveClipboardWriter(): ((text: string) => Promise<void>) | null {
+  try {
+    const clipboard = navigator.clipboard;
+    return clipboard ? (text) => clipboard.writeText(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function useClipboard(): {
+  readonly isCopied: boolean;
+  readonly copyTextToClipboard: (text: string) => void;
+} {
+  const [isCopied, setIsCopied] = useState(false);
+  const feedbackTimerReference = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimerReference.current !== null) {
+        clearTimeout(feedbackTimerReference.current);
+      }
+    };
+  }, []);
+
+  const copyTextToClipboard = useCallback((text: string) => {
+    const writeText = resolveClipboardWriter();
+    if (writeText === null) {
+      return;
+    }
+    const showCopiedFeedback = async () => {
+      const didCopy = await copyTextUsingWriter(writeText, text);
+      if (!didCopy) {
+        return;
+      }
+      setIsCopied(true);
+      if (feedbackTimerReference.current !== null) {
+        clearTimeout(feedbackTimerReference.current);
+      }
+      feedbackTimerReference.current = setTimeout(() => {
+        setIsCopied(false);
+        feedbackTimerReference.current = null;
+      }, COPY_FEEDBACK_DURATION_MS);
+    };
+    void showCopiedFeedback();
+  }, []);
+
+  return { isCopied, copyTextToClipboard };
+}

--- a/apps/console/src/components/icons.tsx
+++ b/apps/console/src/components/icons.tsx
@@ -1,6 +1,8 @@
 import {
   MdOutlineCampaign,
+  MdOutlineCheck,
   MdOutlineClose,
+  MdOutlineContentCopy,
   MdOutlineDescription,
   MdOutlineExtension,
   MdOutlineLogout,
@@ -34,7 +36,9 @@ function LogoMark({ size = 20, ...props }: IconBaseProps) {
 
 export const Icons = {
   Broadcast: MdOutlineCampaign,
+  Check: MdOutlineCheck,
   Close: MdOutlineClose,
+  Copy: MdOutlineContentCopy,
   Device: MdOutlineSpeaker,
   History: MdOutlineQuestionAnswer,
   Jobs: MdOutlineDescription,

--- a/apps/console/src/docs/catalog.ts
+++ b/apps/console/src/docs/catalog.ts
@@ -51,7 +51,7 @@ export const DOCS_PART_LIST: readonly DocsPart[] = [
       {
         slug: 'setup',
         title: 'Setup',
-        description: 'Local development, from clone to first spoken turn.',
+        description: 'From one command to a deployed, talking worker.',
       },
     ],
   },

--- a/apps/console/src/docs/chapter.tsx
+++ b/apps/console/src/docs/chapter.tsx
@@ -15,7 +15,10 @@ const PROSE_CLASS_LIST = [
   '[&_a]:border-b [&_a]:border-dashed [&_a]:border-muted-foreground/40 [&_a]:text-foreground [&_a:hover]:border-muted-foreground',
   '[&_blockquote]:my-5 [&_blockquote]:border-l [&_blockquote]:border-border-hover [&_blockquote]:pl-5 [&_blockquote_p]:text-muted-foreground',
   '[&_code]:rounded-none [&_code]:font-mono [&_code]:text-[0.82em]',
-  '[&_pre]:my-5 [&_pre]:overflow-x-auto [&_pre]:rounded-none [&_pre]:border [&_pre]:bg-card [&_pre]:p-4 [&_pre]:text-[12.5px] [&_pre]:leading-[1.7]',
+  '[&_[data-streamdown=code-block]]:my-5 [&_[data-streamdown=code-block]]:gap-0 [&_[data-streamdown=code-block]]:rounded-none [&_[data-streamdown=code-block]]:bg-card [&_[data-streamdown=code-block]]:p-0',
+  '[&_[data-streamdown=code-block-header]]:h-10 [&_[data-streamdown=code-block-header]]:border-b [&_[data-streamdown=code-block-header]]:px-4 [&_[data-streamdown=code-block-header]]:text-dim',
+  '[&_[data-streamdown=code-block-actions]]:rounded-none [&_[data-streamdown=code-block-actions]]:border-0 [&_[data-streamdown=code-block-actions]]:bg-transparent [&_[data-streamdown=code-block-actions]]:p-0 [&_[data-streamdown=code-block-actions]]:pr-2 [&_[data-streamdown=code-block-actions]]:backdrop-blur-none',
+  '[&_[data-streamdown=code-block-body]]:rounded-none [&_[data-streamdown=code-block-body]]:border-0 [&_[data-streamdown=code-block-body]]:bg-transparent [&_[data-streamdown=code-block-body]]:p-4 [&_[data-streamdown=code-block-body]]:text-[12.5px] [&_[data-streamdown=code-block-body]]:leading-[1.7]',
   '[&_ul]:my-3.5 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-3.5 [&_ol]:list-decimal [&_ol]:pl-5',
   '[&_li]:my-1.5 [&_li]:text-[15.5px] [&_li]:leading-[1.7] [&_li]:text-foreground/80',
   '[&_hr]:my-8 [&_hr]:border-border [&_img]:rounded-none [&_table]:rounded-none',
@@ -48,7 +51,20 @@ export function DocsChapter({
       <hr className="my-10 w-12 border-border-hover" />
 
       <div className={PROSE_CLASS_LIST}>
-        <Streamdown>{chapterSource}</Streamdown>
+        <Streamdown
+          controls={{
+            code: { copy: true, download: false },
+            table: false,
+            mermaid: false,
+          }}
+          lineNumbers={false}
+          translations={{
+            copyCode: docsMessages.copyCodeLabel,
+            copied: docsMessages.copiedCodeLabel,
+          }}
+        >
+          {chapterSource}
+        </Streamdown>
       </div>
 
       <footer className="mt-20 border-t pt-3.5">

--- a/apps/console/src/docs/content/setup.md
+++ b/apps/console/src/docs/content/setup.md
@@ -1,13 +1,64 @@
-Everything runs from the repository root with Bun and Turborepo. This chapter walks from a fresh clone to a first spoken turn against a local worker.
+Apollo deploys from a single command. It scaffolds the starter — the brain with the author's personal values stripped out — initializes git, installs dependencies, and hands you to an interactive wizard that ends at a live worker and a verified device handshake. No keys yet is a first-class answer: trial mode deploys a fully protocol-correct brain with zero external spend.
 
-## Prerequisites
+## What you need
 
-This section is not written yet.
+- [Bun](https://bun.sh), the runtime and package manager.
+- A Cloudflare account. The free plan is enough; R2 asks for a payment card on file even at zero cost.
+- An [OpenRouter](https://openrouter.ai) API key for reasoning, transcription, and embeddings.
+- An [ElevenLabs](https://elevenlabs.io) API key and a voice for speech synthesis.
+- Optional: [Tavily](https://tavily.com) for web search, [Resend](https://resend.com) for email reports, and Workers Paid plus Docker only for the coding sandbox.
 
-## Running the worker
+No keys yet? Deploy in trial mode (`MOCK_VOICE=1`, preset in `.dev.vars.example`): mocked speech, real everything else, zero spend.
 
-This section is not written yet.
+## One command
 
-## Talking to it
+```sh
+bun create heyapollo
+```
 
-This section is not written yet.
+```sh
+npm create heyapollo
+```
+
+The template is embedded in the package — no cloning, no network fetch. Pass a directory name to scaffold somewhere other than `apollo/`, and opt out of any step with `--no-install`, `--no-setup`, or `--no-git`. The wizard can be re-run any time from the project root with `bun run setup`.
+
+## The wizard, phase by phase
+
+- **Cloudflare account.** Logs you in through `wrangler` if needed, then shows exactly which account it is about to touch and asks before provisioning into it. It also checks that R2 is enabled.
+- **API keys.** Choose real keys or trial mode. Real keys are validated live before anything is written, and Apollo's voice is picked from your own ElevenLabs library. Keys land in `.dev.vars`; shared secrets are generated for you.
+- **Persona and location.** Your city sets the timezone and the weather default in `src/configuration/identity.ts`. The starter speaks Rioplatense Spanish by default; changing language, voice, or region is a guided task in `.claude/skills/apollo-persona`.
+- **Deploy.** Provisions R2, Vectorize, and the queue, pushes secrets, deploys the worker, and verifies with a real device handshake. It ends by printing your worker URL, the device WebSocket address, and the console pointer.
+
+## Or ask your agent
+
+Open the scaffolded folder with [Claude Code](https://claude.com/claude-code) or any agent that reads `AGENTS.md` and say:
+
+> set this up for me
+
+The `apollo-setup` skill walks the agent through the whole flow. You paste keys into `.dev.vars` yourself; they never enter the chat.
+
+## By hand
+
+Every wizard step has a plain-script equivalent:
+
+```sh
+bun install
+bunx wrangler login
+cp .dev.vars.example .dev.vars     # fill in your keys, or keep MOCK_VOICE=1
+bun run bootstrap preflight        # confirms which Cloudflare account you are on
+bun run bootstrap provision        # R2 buckets, Vectorize index, queue
+bun run bootstrap secrets          # generates shared secrets, pushes them to the worker
+bun run bootstrap deploy           # wrangler deploy
+bun run bootstrap verify           # /health plus a real device handshake probe
+```
+
+## First spoken turn
+
+No hardware required — the probe script holds a device-grade WebSocket from your terminal:
+
+```sh
+bun run probe -- --url wss://apollo.<you>.workers.dev/agents/apollo/desk \
+  --token <DEVICE_SHARED_SECRET from .dev.vars> --text "hola"
+```
+
+A physical device points at `wss://<your-worker>/agents/apollo/desk?token=<DEVICE_SHARED_SECRET>`; the wire contract lives in the Protocol chapter. To manage the deployment from a browser, the hosted console at [heyapollo.dev/console](https://heyapollo.dev/console) connects directly to your worker with the worker URL, the instance name `desk`, and your `DASHBOARD_SHARED_SECRET` — all three stay in your browser's local storage.

--- a/apps/console/src/docs/copy.ts
+++ b/apps/console/src/docs/copy.ts
@@ -12,6 +12,8 @@ interface DocsMessages {
   readonly contentsTagline: string;
   readonly previousChapterLabel: string;
   readonly nextChapterLabel: string;
+  readonly copyCodeLabel: string;
+  readonly copiedCodeLabel: string;
   readonly buildChapterPositionLabel: (
     chapterNumber: number,
     chapterTotal: number,
@@ -31,6 +33,8 @@ export const DOCS_MESSAGE_CATALOG: Record<Locale, DocsMessages> = {
     contentsTagline: 'El manual de Apollo, pensado para leerse en orden.',
     previousChapterLabel: 'Capítulo anterior',
     nextChapterLabel: 'Capítulo siguiente',
+    copyCodeLabel: 'Copiar el código',
+    copiedCodeLabel: 'Copiado',
     buildChapterPositionLabel: (chapterNumber, chapterTotal) =>
       `Capítulo ${chapterNumber} de ${chapterTotal}`,
   },
@@ -46,6 +50,8 @@ export const DOCS_MESSAGE_CATALOG: Record<Locale, DocsMessages> = {
     contentsTagline: 'The Apollo handbook, meant to be read in order.',
     previousChapterLabel: 'Previous chapter',
     nextChapterLabel: 'Next chapter',
+    copyCodeLabel: 'Copy code',
+    copiedCodeLabel: 'Copied',
     buildChapterPositionLabel: (chapterNumber, chapterTotal) =>
       `Chapter ${chapterNumber} of ${chapterTotal}`,
   },

--- a/apps/console/src/landing/__tests__/discovery.spec.ts
+++ b/apps/console/src/landing/__tests__/discovery.spec.ts
@@ -107,6 +107,12 @@ describe('landing document generation', () => {
       for (const ownershipCard of landingMessages.yours.ownershipCardList) {
         expect(staticBlock).toContain(`${ownershipCard.label}</h3>`);
       }
+      expect(staticBlock).toContain(`${landingMessages.start.title}</h3>`);
+      expect(staticBlock).toContain('$ bun create heyapollo');
+      expect(staticBlock).toContain('$ npm create heyapollo');
+      expect(staticBlock).toContain(landingMessages.start.terminalCaption);
+      expect(staticBlock).toContain(landingMessages.start.agentPrompt);
+      expect(staticBlock).toContain(landingMessages.start.agentCaption);
       expect(staticBlock).toContain('<h3 class=');
       expect(staticBlock).toContain(LANDING_REPOSITORY_URL);
     }

--- a/apps/console/src/landing/command.tsx
+++ b/apps/console/src/landing/command.tsx
@@ -1,0 +1,39 @@
+import { useClipboard } from '@/components/clipboard';
+import { Icons } from '@/components/icons';
+import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
+import { LANDING_COMMAND_MAP } from '@/landing/metadata';
+import { useMessages } from '@/locale/context';
+
+export function LandingCommand() {
+  const startMessages = useMessages(LANDING_MESSAGE_CATALOG).start;
+  const { isCopied, copyTextToClipboard } = useClipboard();
+
+  return (
+    <button
+      type="button"
+      onClick={() => copyTextToClipboard(LANDING_COMMAND_MAP.bun)}
+      aria-label={startMessages.copyCommandLabel}
+      className="group flex items-center gap-3 border px-4 py-2.5 font-mono text-sm transition-colors duration-150 hover:border-border-hover hover:bg-card"
+    >
+      <span aria-hidden className="text-dim">
+        $
+      </span>
+      <span>{LANDING_COMMAND_MAP.bun}</span>
+      <span
+        aria-hidden
+        className="inline-block h-3.5 w-[7px] bg-muted-foreground [animation:caret_1.1s_steps(1)_infinite]"
+      />
+      {isCopied ? (
+        <Icons.Check size={14} className="text-foreground" />
+      ) : (
+        <Icons.Copy
+          size={14}
+          className="text-dim transition-colors duration-150 group-hover:text-foreground"
+        />
+      )}
+      <span aria-live="polite" className="sr-only">
+        {isCopied ? startMessages.copiedLabel : ''}
+      </span>
+    </button>
+  );
+}

--- a/apps/console/src/landing/copy/en.ts
+++ b/apps/console/src/landing/copy/en.ts
@@ -16,7 +16,6 @@ export const LANDING_MESSAGES_EN: LandingMessages = {
     lineTwo: 'desk agent',
     subhead:
       'The open-source brain for physical agentic devices. It lives in your Cloudflare account; the body sits on your desk.',
-    gettingStartedLabel: 'Getting started →',
   },
   showcase: {
     actIndexLabel: '01 · Listen',
@@ -149,12 +148,14 @@ export const LANDING_MESSAGES_EN: LandingMessages = {
       {
         label: 'The brain',
         description: 'Voice turns, memory, tools, and schedules in one Durable Object.',
-        action: 'One command to deploy.',
+        action: 'One command to deploy →',
+        actionTargetId: 'start',
       },
       {
         label: 'The body',
         description: 'The firmware for the device on your desk.',
         action: 'Flash it. Set it down.',
+        actionTargetId: null,
       },
     ],
     docsCardLabel: 'The docs',
@@ -164,6 +165,19 @@ export const LANDING_MESSAGES_EN: LandingMessages = {
     consoleCardLabel: 'The console',
     consoleCardDescription: 'Everything it knows and plans, live from your worker.',
     consoleCardAction: 'Open console →',
+  },
+  start: {
+    title: 'Two ways in',
+    terminalTabLabel: 'The terminal',
+    agentTabLabel: 'Your coding agent',
+    terminalCaption: 'About five minutes; trial mode needs zero API keys.',
+    agentPromptLabel: 'Paste into any agent that reads AGENTS.md',
+    agentPrompt:
+      'Run `bun create heyapollo`, open the new folder, read AGENTS.md, and follow the apollo-setup skill to provision my Cloudflare account and deploy. I will paste API keys into .dev.vars myself; never ask for them in chat.',
+    agentCaption: 'Keys never enter the chat; they go straight into .dev.vars.',
+    copyCommandLabel: 'Copy the command',
+    copyPromptLabel: 'Copy the prompt',
+    copiedLabel: 'Copied',
   },
   footer: {
     echoWordList: ['The', 'desk', 'is', 'listening'],

--- a/apps/console/src/landing/copy/es.ts
+++ b/apps/console/src/landing/copy/es.ts
@@ -16,7 +16,6 @@ export const LANDING_MESSAGES_ES: LandingMessages = {
     lineTwo: 'de escritorio',
     subhead:
       'El cerebro open source para dispositivos agénticos físicos. Vive en tu cuenta de Cloudflare; el cuerpo descansa en tu escritorio.',
-    gettingStartedLabel: 'Primeros pasos →',
   },
   showcase: {
     actIndexLabel: '01 · Escuchar',
@@ -151,12 +150,14 @@ export const LANDING_MESSAGES_ES: LandingMessages = {
         label: 'El cerebro',
         description:
           'Turnos de voz, memoria, herramientas y agenda en un solo Durable Object.',
-        action: 'Un comando para desplegar.',
+        action: 'Un comando para desplegar →',
+        actionTargetId: 'start',
       },
       {
         label: 'El cuerpo',
         description: 'El firmware del dispositivo en tu escritorio.',
         action: 'Flashéalo. Déjalo en su lugar.',
+        actionTargetId: null,
       },
     ],
     docsCardLabel: 'La documentación',
@@ -166,6 +167,19 @@ export const LANDING_MESSAGES_ES: LandingMessages = {
     consoleCardLabel: 'La consola',
     consoleCardDescription: 'Todo lo que sabe y planea, en vivo desde tu worker.',
     consoleCardAction: 'Abrir consola →',
+  },
+  start: {
+    title: 'Dos formas de empezar',
+    terminalTabLabel: 'La terminal',
+    agentTabLabel: 'Tu agente de código',
+    terminalCaption: 'Unos cinco minutos. El modo de prueba no necesita ninguna API key.',
+    agentPromptLabel: 'Para pegar en cualquier agente que lea AGENTS.md',
+    agentPrompt:
+      'Ejecuta `bun create heyapollo`, abre la carpeta nueva, lee AGENTS.md y sigue el skill apollo-setup para aprovisionar mi cuenta de Cloudflare y desplegar. Yo pego las API keys en .dev.vars; nunca me las pidas en el chat.',
+    agentCaption: 'Las claves nunca entran al chat: van directo a .dev.vars.',
+    copyCommandLabel: 'Copiar el comando',
+    copyPromptLabel: 'Copiar el prompt',
+    copiedLabel: 'Copiado',
   },
   footer: {
     echoWordList: ['Tu', 'escritorio', 'escucha'],

--- a/apps/console/src/landing/copy/messages.ts
+++ b/apps/console/src/landing/copy/messages.ts
@@ -20,6 +20,7 @@ export interface OwnershipCard {
   readonly label: string;
   readonly description: string;
   readonly action: string;
+  readonly actionTargetId: string | null;
 }
 
 export interface EmphasizedParagraph {
@@ -42,7 +43,6 @@ export interface LandingMessages {
     readonly lineOne: string;
     readonly lineTwo: string;
     readonly subhead: string;
-    readonly gettingStartedLabel: string;
   };
   readonly showcase: {
     readonly actIndexLabel: string;
@@ -103,6 +103,18 @@ export interface LandingMessages {
     readonly consoleCardLabel: string;
     readonly consoleCardDescription: string;
     readonly consoleCardAction: string;
+  };
+  readonly start: {
+    readonly title: string;
+    readonly terminalTabLabel: string;
+    readonly agentTabLabel: string;
+    readonly terminalCaption: string;
+    readonly agentPromptLabel: string;
+    readonly agentPrompt: string;
+    readonly agentCaption: string;
+    readonly copyCommandLabel: string;
+    readonly copyPromptLabel: string;
+    readonly copiedLabel: string;
   };
   readonly footer: {
     readonly echoWordList: readonly string[];

--- a/apps/console/src/landing/hero.tsx
+++ b/apps/console/src/landing/hero.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 
+import { LandingCommand } from '@/landing/command';
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
 import { MagneticLink } from '@/landing/magnet';
 import { LANDING_LINK_MAP } from '@/landing/metadata';
@@ -69,13 +70,7 @@ export function LandingHero() {
             >
               {landingMessages.nav.docsLabel}
             </MagneticLink>
-            <MagneticLink
-              href={LANDING_LINK_MAP.documentation}
-              onWarm={warmDocsChunk}
-              className="border px-4 py-2.5 transition-colors hover:border-border-hover hover:bg-card"
-            >
-              {landingMessages.hero.gettingStartedLabel}
-            </MagneticLink>
+            <LandingCommand />
           </div>
         </div>
       </div>

--- a/apps/console/src/landing/metadata.ts
+++ b/apps/console/src/landing/metadata.ts
@@ -9,6 +9,13 @@ export const LANDING_LINK_MAP = {
   console: '/console',
 };
 
+export const LANDING_COMMAND_MAP = {
+  bun: 'bun create heyapollo',
+  npm: 'npm create heyapollo',
+} as const;
+
+export const LANDING_START_ANCHOR_ID = 'start';
+
 export function useLandingMetadata(): void {
   const { locale } = useLocale();
 

--- a/apps/console/src/landing/start.tsx
+++ b/apps/console/src/landing/start.tsx
@@ -1,0 +1,188 @@
+import { useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+
+import { useClipboard } from '@/components/clipboard';
+import { Icons } from '@/components/icons';
+import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
+import { LANDING_COMMAND_MAP, LANDING_START_ANCHOR_ID } from '@/landing/metadata';
+import { useMessages } from '@/locale/context';
+
+type StartPane = 'terminal' | 'agent';
+type CommandRuntime = keyof typeof LANDING_COMMAND_MAP;
+
+function CopyButton({
+  textToCopy,
+  copyLabel,
+  copiedLabel,
+}: {
+  readonly textToCopy: string;
+  readonly copyLabel: string;
+  readonly copiedLabel: string;
+}) {
+  const { isCopied, copyTextToClipboard } = useClipboard();
+  return (
+    <button
+      type="button"
+      onClick={() => copyTextToClipboard(textToCopy)}
+      aria-label={copyLabel}
+      className="flex items-center gap-2 font-mono text-xs text-dim transition-colors duration-150 hover:text-foreground"
+    >
+      {isCopied ? <Icons.Check size={14} /> : <Icons.Copy size={14} />}
+      <span aria-live="polite">{isCopied ? copiedLabel : copyLabel}</span>
+    </button>
+  );
+}
+
+export function LandingStart() {
+  const startMessages = useMessages(LANDING_MESSAGE_CATALOG).start;
+  const [selectedPane, setSelectedPane] = useState<StartPane>('terminal');
+  const [selectedRuntime, setSelectedRuntime] = useState<CommandRuntime>('bun');
+  const terminalTabReference = useRef<HTMLButtonElement | null>(null);
+  const agentTabReference = useRef<HTMLButtonElement | null>(null);
+
+  const selectedCommand = LANDING_COMMAND_MAP[selectedRuntime];
+
+  function activatePane(nextPane: StartPane): void {
+    setSelectedPane(nextPane);
+    const nextTabReference =
+      nextPane === 'terminal' ? terminalTabReference : agentTabReference;
+    nextTabReference.current?.focus();
+  }
+
+  function handleTablistKeyDown(keyboardEvent: KeyboardEvent<HTMLDivElement>): void {
+    if (keyboardEvent.key === 'ArrowLeft' || keyboardEvent.key === 'ArrowRight') {
+      keyboardEvent.preventDefault();
+      activatePane(selectedPane === 'terminal' ? 'agent' : 'terminal');
+      return;
+    }
+    if (keyboardEvent.key === 'Home') {
+      keyboardEvent.preventDefault();
+      activatePane('terminal');
+      return;
+    }
+    if (keyboardEvent.key === 'End') {
+      keyboardEvent.preventDefault();
+      activatePane('agent');
+    }
+  }
+
+  const tabDescriptorList = [
+    {
+      pane: 'terminal' as const,
+      label: startMessages.terminalTabLabel,
+      reference: terminalTabReference,
+    },
+    {
+      pane: 'agent' as const,
+      label: startMessages.agentTabLabel,
+      reference: agentTabReference,
+    },
+  ];
+
+  return (
+    <div id={LANDING_START_ANCHOR_ID} data-reveal className="mt-14 md:ml-[220px]">
+      <p className="text-xs text-dim">{startMessages.title}</p>
+      <div className="mt-4 border bg-card">
+        <div
+          role="tablist"
+          aria-label={startMessages.title}
+          onKeyDown={handleTablistKeyDown}
+          className="flex border-b"
+        >
+          {tabDescriptorList.map((tabDescriptor) => {
+            const isSelected = selectedPane === tabDescriptor.pane;
+            return (
+              <button
+                key={tabDescriptor.pane}
+                ref={tabDescriptor.reference}
+                type="button"
+                role="tab"
+                id={`start-tab-${tabDescriptor.pane}`}
+                aria-selected={isSelected}
+                aria-controls={`start-panel-${tabDescriptor.pane}`}
+                tabIndex={isSelected ? 0 : -1}
+                onClick={() => setSelectedPane(tabDescriptor.pane)}
+                className={`border-r px-5 py-3 text-sm transition-colors duration-150 ${
+                  isSelected
+                    ? 'text-foreground'
+                    : 'text-dim hover:bg-card-hover hover:text-muted-foreground'
+                }`}
+              >
+                {tabDescriptor.label}
+              </button>
+            );
+          })}
+        </div>
+        <div
+          role="tabpanel"
+          id="start-panel-terminal"
+          aria-labelledby="start-tab-terminal"
+          tabIndex={0}
+          hidden={selectedPane !== 'terminal'}
+          className="p-6"
+        >
+          <div className="flex gap-4 font-mono text-xs">
+            {(Object.keys(LANDING_COMMAND_MAP) as readonly CommandRuntime[]).map(
+              (commandRuntime) => (
+                <button
+                  key={commandRuntime}
+                  type="button"
+                  aria-pressed={selectedRuntime === commandRuntime}
+                  onClick={() => setSelectedRuntime(commandRuntime)}
+                  className={`transition-colors duration-150 ${
+                    selectedRuntime === commandRuntime
+                      ? 'text-foreground'
+                      : 'text-dim hover:text-muted-foreground'
+                  }`}
+                >
+                  {commandRuntime}
+                </button>
+              ),
+            )}
+          </div>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-4 border bg-background px-4 py-3.5">
+            <p className="font-mono text-sm">
+              <span aria-hidden className="text-dim">
+                $&nbsp;
+              </span>
+              {selectedCommand}
+            </p>
+            <CopyButton
+              textToCopy={selectedCommand}
+              copyLabel={startMessages.copyCommandLabel}
+              copiedLabel={startMessages.copiedLabel}
+            />
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground">
+            {startMessages.terminalCaption}
+          </p>
+        </div>
+        <div
+          role="tabpanel"
+          id="start-panel-agent"
+          aria-labelledby="start-tab-agent"
+          tabIndex={0}
+          hidden={selectedPane !== 'agent'}
+          className="p-6"
+        >
+          <div className="border bg-background p-4">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="text-xs text-dim">{startMessages.agentPromptLabel}</p>
+              <CopyButton
+                textToCopy={startMessages.agentPrompt}
+                copyLabel={startMessages.copyPromptLabel}
+                copiedLabel={startMessages.copiedLabel}
+              />
+            </div>
+            <p className="mt-3 max-w-[68ch] font-mono text-[13px] leading-[1.7] text-muted-foreground">
+              {startMessages.agentPrompt}
+            </p>
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground">
+            {startMessages.agentCaption}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/landing/static.ts
+++ b/apps/console/src/landing/static.ts
@@ -1,5 +1,5 @@
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
-import { LANDING_LINK_MAP } from '@/landing/metadata';
+import { LANDING_COMMAND_MAP, LANDING_LINK_MAP } from '@/landing/metadata';
 import { LANDING_PUBLIC_ORIGIN } from '@/landing/origin';
 
 import type { LandingMessages } from '@/landing/copy/messages';
@@ -65,15 +65,20 @@ function renderOwnershipList(landingMessages: LandingMessages): string {
   return `<ul class="mt-6 space-y-5">${ownershipItemList.join('')}${docsItem}${consoleItem}</ul>`;
 }
 
+function renderStartBlock(landingMessages: LandingMessages): string {
+  const startMessages = landingMessages.start;
+  return `<h3 class="mt-6 text-base">${escapeHtmlText(startMessages.title)}</h3><p class="mt-1 font-mono text-sm">$ ${LANDING_COMMAND_MAP.bun} · $ ${LANDING_COMMAND_MAP.npm}</p><p class="mt-1 text-sm text-muted-foreground">${escapeHtmlText(startMessages.terminalCaption)}</p><p class="mt-2 text-sm text-muted-foreground">${escapeHtmlText(startMessages.agentPromptLabel)}: ${escapeHtmlText(startMessages.agentPrompt)}</p><p class="mt-1 text-sm text-muted-foreground">${escapeHtmlText(startMessages.agentCaption)}</p>`;
+}
+
 export function renderLandingStaticBlock(locale: Locale): string {
   const landingMessages = LANDING_MESSAGE_CATALOG[locale];
   const heroHeading = `${escapeHtmlText(landingMessages.hero.lineOne)} ${escapeHtmlText(landingMessages.hero.lineTwo)}`;
   const navigation = `<nav aria-label="Apollo" class="flex flex-wrap gap-6 text-sm text-muted-foreground"><a class="underline underline-offset-4" href="${LANDING_LINK_MAP.github}">${escapeHtmlText(landingMessages.nav.githubLabel)}</a> <a class="underline underline-offset-4" href="${LANDING_LINK_MAP.documentation}">${escapeHtmlText(landingMessages.nav.docsLabel)}</a> <a class="underline underline-offset-4" href="${LANDING_LINK_MAP.console}">${escapeHtmlText(landingMessages.nav.openConsoleLabel)}</a></nav>`;
-  const hero = `<header class="mt-14"><h1 class="font-serif text-5xl leading-[1.05] tracking-[-0.02em]">${heroHeading}</h1><p class="mt-6 max-w-[44ch] text-sm text-muted-foreground">${escapeHtmlText(landingMessages.hero.subhead)}</p></header>`;
+  const hero = `<header class="mt-14"><h1 class="font-serif text-5xl leading-[1.05] tracking-[-0.02em]">${heroHeading}</h1><p class="mt-6 max-w-[44ch] text-sm text-muted-foreground">${escapeHtmlText(landingMessages.hero.subhead)}</p><p class="mt-4 font-mono text-sm">$ ${LANDING_COMMAND_MAP.bun}</p></header>`;
   const showcaseSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.showcase.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.showcase.intro)}</section>`;
   const architectureSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.architecture.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.architecture.intro)}<p class="mt-4 leading-relaxed text-muted-foreground">${escapeHtmlText(landingMessages.architecture.bodyNodeHeadline)} ${escapeHtmlText(landingMessages.architecture.brainNodeHeadline)}</p></section>`;
   const capabilitiesSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.capabilities.actTitle)}</h2>${renderEmphasizedParagraph(landingMessages.capabilities.intro)}${renderCapabilityList(landingMessages)}</section>`;
-  const yoursSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.yours.actTitle)}</h2><p class="mt-4 leading-relaxed text-muted-foreground">${escapeHtmlText(landingMessages.yours.introLead)}<em class="not-italic text-foreground">${escapeHtmlText(landingMessages.yours.introEmphasis)}</em></p>${renderOwnershipList(landingMessages)}</section>`;
+  const yoursSection = `<section class="mt-16 border-t pt-8"><h2 class="font-serif text-2xl">${escapeHtmlText(landingMessages.yours.actTitle)}</h2><p class="mt-4 leading-relaxed text-muted-foreground">${escapeHtmlText(landingMessages.yours.introLead)}<em class="not-italic text-foreground">${escapeHtmlText(landingMessages.yours.introEmphasis)}</em></p>${renderStartBlock(landingMessages)}${renderOwnershipList(landingMessages)}</section>`;
   const footer = `<footer class="mt-20 border-t pt-8 text-sm text-muted-foreground"><p>${escapeHtmlText(landingMessages.footer.echoWordList.join(' '))}. ${escapeHtmlText(landingMessages.footer.wakePhrase)}</p><p class="mt-2">${escapeHtmlText(landingMessages.footer.builtByPrefix)}<a class="underline underline-offset-4" href="https://github.com/galfrevn">Valentín Galfre</a></p></footer>`;
   return `<div data-landing-static class="mx-auto max-w-3xl px-6 py-16">${navigation}<main>${hero}${showcaseSection}${architectureSection}${capabilitiesSection}${yoursSection}</main>${footer}</div>`;
 }

--- a/apps/console/src/landing/yours.tsx
+++ b/apps/console/src/landing/yours.tsx
@@ -13,12 +13,23 @@ import { useMessages } from '@/locale/context';
 // ScrollSmoother transforms the pinned content instead of scrolling the page,
 // so native hash navigation lands at the wrong position while it is active.
 function handleAnchorActivation(clickEvent: MouseEvent<HTMLAnchorElement>): void {
+  const isPlainLeftClick =
+    clickEvent.button === 0 &&
+    !clickEvent.metaKey &&
+    !clickEvent.ctrlKey &&
+    !clickEvent.shiftKey &&
+    !clickEvent.altKey;
+  if (!isPlainLeftClick) {
+    return;
+  }
   const smoother = ScrollSmoother.get();
   if (smoother) {
     clickEvent.preventDefault();
     const targetHash = clickEvent.currentTarget.hash;
     smoother.scrollTo(targetHash, true);
-    window.history.pushState(null, '', targetHash);
+    if (window.location.hash !== targetHash) {
+      window.history.pushState(null, '', targetHash);
+    }
   }
 }
 

--- a/apps/console/src/landing/yours.tsx
+++ b/apps/console/src/landing/yours.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { MouseEvent } from 'react';
 
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
@@ -21,8 +22,33 @@ function handleAnchorActivation(clickEvent: MouseEvent<HTMLAnchorElement>): void
   }
 }
 
+// The hash can arrive from outside this page, so it is not guaranteed to be a
+// valid selector; querySelector throws on malformed input.
+function findAnchorTargetElement(targetHash: string): Element | null {
+  try {
+    return targetHash === '' ? null : document.querySelector(targetHash);
+  } catch {
+    return null;
+  }
+}
+
+function useAnchorHistoryRestoration(): void {
+  useEffect(() => {
+    const handleHistoryTraversal = () => {
+      const smoother = ScrollSmoother.get();
+      if (!smoother) {
+        return;
+      }
+      smoother.scrollTo(findAnchorTargetElement(window.location.hash) ?? 0, true);
+    };
+    window.addEventListener('popstate', handleHistoryTraversal);
+    return () => window.removeEventListener('popstate', handleHistoryTraversal);
+  }, []);
+}
+
 export function LandingYours() {
   const yoursMessages = useMessages(LANDING_MESSAGE_CATALOG).yours;
+  useAnchorHistoryRestoration();
   return (
     <section id="yours" className="border-t py-[130px]">
       <div className="mx-auto w-full max-w-[1180px] px-8">

--- a/apps/console/src/landing/yours.tsx
+++ b/apps/console/src/landing/yours.tsx
@@ -41,6 +41,9 @@ function useAnchorHistoryRestoration(): void {
       }
       smoother.scrollTo(findAnchorTargetElement(window.location.hash) ?? 0, true);
     };
+    if (window.location.hash !== '') {
+      handleHistoryTraversal();
+    }
     window.addEventListener('popstate', handleHistoryTraversal);
     return () => window.removeEventListener('popstate', handleHistoryTraversal);
   }, []);

--- a/apps/console/src/landing/yours.tsx
+++ b/apps/console/src/landing/yours.tsx
@@ -1,9 +1,23 @@
+import type { MouseEvent } from 'react';
+
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
 import { ActHeading } from '@/landing/heading';
 import { MagneticLink } from '@/landing/magnet';
 import { LANDING_LINK_MAP } from '@/landing/metadata';
+import { ScrollSmoother } from '@/landing/motion';
 import { warmConsoleChunk, warmDocsChunk } from '@/landing/prefetch';
+import { LandingStart } from '@/landing/start';
 import { useMessages } from '@/locale/context';
+
+// ScrollSmoother transforms the pinned content instead of scrolling the page,
+// so native hash navigation lands at the wrong position while it is active.
+function handleAnchorActivation(clickEvent: MouseEvent<HTMLAnchorElement>): void {
+  const smoother = ScrollSmoother.get();
+  if (smoother) {
+    clickEvent.preventDefault();
+    smoother.scrollTo(clickEvent.currentTarget.hash, true);
+  }
+}
 
 export function LandingYours() {
   const yoursMessages = useMessages(LANDING_MESSAGE_CATALOG).yours;
@@ -22,6 +36,7 @@ export function LandingYours() {
             <span className="text-foreground">{yoursMessages.introEmphasis}</span>
           </p>
         </div>
+        <LandingStart />
         <div className="mt-14 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
           {yoursMessages.ownershipCardList.map((ownershipCard, cardIndex) => (
             <div
@@ -33,7 +48,17 @@ export function LandingYours() {
               <h3 className="text-xs font-normal text-dim">{ownershipCard.label}</h3>
               <p className="text-sm text-muted-foreground">{ownershipCard.description}</p>
               <div className="mt-auto pt-4">
-                <p className="text-sm">{ownershipCard.action}</p>
+                {ownershipCard.actionTargetId === null ? (
+                  <p className="text-sm">{ownershipCard.action}</p>
+                ) : (
+                  <a
+                    href={`#${ownershipCard.actionTargetId}`}
+                    onClick={handleAnchorActivation}
+                    className="underline-reveal text-sm"
+                  >
+                    {ownershipCard.action}
+                  </a>
+                )}
               </div>
             </div>
           ))}

--- a/apps/console/src/landing/yours.tsx
+++ b/apps/console/src/landing/yours.tsx
@@ -15,7 +15,9 @@ function handleAnchorActivation(clickEvent: MouseEvent<HTMLAnchorElement>): void
   const smoother = ScrollSmoother.get();
   if (smoother) {
     clickEvent.preventDefault();
-    smoother.scrollTo(clickEvent.currentTarget.hash, true);
+    const targetHash = clickEvent.currentTarget.hash;
+    smoother.scrollTo(targetHash, true);
+    window.history.pushState(null, '', targetHash);
   }
 }
 


### PR DESCRIPTION
## What

The landing promised "One command to deploy." but never showed the command, and the agent-native setup path was invisible. This PR makes getting started a first-class surface on both the landing and the docs:

- **Hero**: the "Getting started →" outline button becomes a click-to-copy terminal chip — `$ bun create heyapollo` with the blinking caret, a copy→check icon flip, and an aria-live "Copiado/Copied" announcement (`landing/command.tsx`).
- **04 · Yours**: a tabbed "Dos formas de empezar / Two ways in" band (`landing/start.tsx`) — a Terminal pane with a bun/npm switcher and copy row, and a Coding-agent pane with a copyable prompt built around `AGENTS.md` and the `apollo-setup` skill. "The brain" card's action now anchors to it via `ScrollSmoother.scrollTo` (native hash jumps land wrong inside smoothed content).
- **Docs**: the `setup` chapter is written for real — requirements, both commands, the wizard phase by phase, the by-hand `bootstrap` path, the agent path, and the first spoken turn via `bun run probe`. Catalog description updated to match.
- **Docs code fences**: Streamdown 2.5.0's built-in copy control is enabled (`controls`/`translations`) and restyled to the house look via `data-streamdown` attribute variants — square, hairline border, mono header.

## How

- Clipboard logic lives in a new GSAP-free `components/clipboard.ts` (hook + pure `copyTextUsingWriter`), so the docs chunk keeps zero GSAP.
- All new strings go through the es/en catalogs (`landing/copy/*`, `docs/copy.ts`), including aria-labels and copied-state.
- Command strings live once in `landing/metadata.ts` (`LANDING_COMMAND_MAP`), shared with the crawler mirror in `landing/static.ts`; `discovery.spec.ts` asserts the new copy per locale.
- `Copy`/`Check` added to the `Icons` object.

## Verified

- `bun run check` green (95 console tests, including new clipboard specs and extended discovery assertions).
- `vite build` + discovery prerender emit both commands and the band copy into `dist/index.html` / `dist/en.html`; `dist/docs/setup.html` carries the new description.
- GSAP remains exclusively in the landing chunk (checked built assets).
- Clicked through in Chrome: hero copy, both tabs, npm switch, docs copy button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTpCNgTPwHkhVsgcu864JV

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds copyable onboarding commands and an agent setup path across the landing page and documentation.
- Adds reusable clipboard behavior, command and prompt controls, localized feedback, and landing-page navigation.
- Expands setup documentation and enables localized Streamdown code-copy controls.
- Extends static discovery output and tests with the new onboarding content.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because copied feedback can describe a different command from the one actually written to the clipboard.

The outstanding clipboard race remains: asynchronous completion sets a text-agnostic copied boolean after the runtime selector may have changed the command displayed by the preserved CopyButton.

**Files Needing Attention:** apps/console/src/components/clipboard.ts, apps/console/src/landing/start.tsx
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(console): keep native modified-click..."](https://github.com/galfrevn/apollo/commit/3ad497bfa516049988b793e13de1f2284beac713) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53181507)</sub>

<!-- /greptile_comment -->