### PR TITLE
chore(create): v0.3.0

### DIFF
--- a/tooling/create/package.json
+++ b/tooling/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-heyapollo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Scaffold your own Apollo — a personal desk agent on your Cloudflare account — and walk through its setup wizard.",
   "license": "MIT",
   "author": "Valentín Galfre",


### PR DESCRIPTION
Bumps create-heyapollo to 0.3.0 for the wizard facelift shipped in #62 (device-face banner, phased prompts, richer validation, recap, staged bootstrap). After merge, the `create-v0.3.0` tag triggers the trusted-publishing workflow.

Note: npm's current 0.2.1 was tagged from the unmerged `feature/create-consolidation` branch, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rs11vLqz3Jh1NPUUEz6apZ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates `create-heyapollo` from version 0.2.0 to 0.3.0 for the corresponding CLI release.

- Changes the package version in `tooling/create/package.json`.
- Keeps the release tag and package manifest version aligned.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The publishing workflow validates and publishes the version directly from `tooling/create/package.json`, and the changed version remains compatible with the current repository setup.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(create): v0.3.0"](https://github.com/galfrevn/apollo/commit/66b7d2f7cdcdd440db3e68aa592288a911abba0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53183572)</sub>

<!-- /greptile_comment -->