### PR TITLE
feat(console): ascii field behind the landing hero

### DIFF
--- a/apps/console/src/landing/__tests__/field.spec.ts
+++ b/apps/console/src/landing/__tests__/field.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  FIELD_GLYPH_RAMP,
+  RIPPLE_LIFETIME_SECONDS,
+  computeRippleContribution,
+  computeVerticalMask,
+  pruneRippleList,
+  rasterizeFieldFrame,
+} from '@/landing/field/geometry';
+
+import type { FieldRenderState, FieldRipple } from '@/landing/field/geometry';
+
+const COLUMN_COUNT = 60;
+const ROW_COUNT = 34;
+
+function buildRenderState(overrides: Partial<FieldRenderState> = {}): FieldRenderState {
+  return {
+    elapsedSeconds: 0,
+    pointerX: 0.5,
+    pointerY: 0.5,
+    pointerPresence: 0,
+    rippleList: [],
+    ...overrides,
+  };
+}
+
+function buildRipple(overrides: Partial<FieldRipple> = {}): FieldRipple {
+  return { originX: 0.5, originY: 0.25, emittedSeconds: 0, strength: 1, ...overrides };
+}
+
+describe('computeVerticalMask', () => {
+  it('keeps the top edge clear of the navigation row', () => {
+    expect(computeVerticalMask(0)).toBe(0);
+    expect(computeVerticalMask(0.16)).toBeGreaterThan(0.9);
+  });
+
+  it('thins to a residue under the headline without cutting off', () => {
+    const residualMask = computeVerticalMask(0.95);
+    expect(residualMask).toBeGreaterThan(0);
+    expect(residualMask).toBeLessThan(0.25);
+  });
+
+  it('never brightens again once it starts fading', () => {
+    let previousMask = computeVerticalMask(0.28);
+    for (let step = 29; step <= 100; step++) {
+      const currentMask = computeVerticalMask(step / 100);
+      expect(currentMask).toBeLessThanOrEqual(previousMask + Number.EPSILON);
+      previousMask = currentMask;
+    }
+  });
+});
+
+describe('computeRippleContribution', () => {
+  it('contributes nothing before emission or after its lifetime', () => {
+    const ripple = buildRipple({ emittedSeconds: 2 });
+    expect(computeRippleContribution(ripple, 1.9, 0.5, 0.25, 1)).toBe(0);
+    expect(
+      computeRippleContribution(ripple, 2 + RIPPLE_LIFETIME_SECONDS + 0.1, 0.5, 0.25, 1),
+    ).toBe(0);
+  });
+
+  it('peaks on the wavefront rather than at the origin', () => {
+    const ripple = buildRipple();
+    const originEnergy = computeRippleContribution(ripple, 2, 0.5, 0.25, 1);
+    const wavefrontEnergy = computeRippleContribution(ripple, 2, 0.5, 0.25 + 0.6, 1);
+    expect(wavefrontEnergy).toBeGreaterThan(originEnergy);
+  });
+
+  it('scales the origin into field space so the front stays circular', () => {
+    const ripple = buildRipple({ originX: 0.5, originY: 0.5 });
+    const aspectRatio = 2;
+    const horizontalEnergy = computeRippleContribution(
+      ripple,
+      2,
+      1 + 0.6,
+      0.5,
+      aspectRatio,
+    );
+    const verticalEnergy = computeRippleContribution(
+      ripple,
+      2,
+      1,
+      0.5 + 0.6,
+      aspectRatio,
+    );
+    expect(horizontalEnergy).toBeCloseTo(verticalEnergy, 10);
+  });
+});
+
+describe('pruneRippleList', () => {
+  it('drops only the ripples past their lifetime', () => {
+    const liveRipple = buildRipple({ emittedSeconds: 8 });
+    const staleRipple = buildRipple({ emittedSeconds: 1 });
+    expect(pruneRippleList([liveRipple, staleRipple], 9)).toEqual([liveRipple]);
+  });
+});
+
+describe('rasterizeFieldFrame', () => {
+  it('emits only glyphs from the ramp inside the grid bounds', () => {
+    const litCellList = rasterizeFieldFrame(
+      buildRenderState({ rippleList: [buildRipple()], elapsedSeconds: 2 }),
+      COLUMN_COUNT,
+      ROW_COUNT,
+    );
+    expect(litCellList.length).toBeGreaterThan(0);
+    for (const cell of litCellList) {
+      expect(FIELD_GLYPH_RAMP).toContain(cell.glyph);
+      expect(cell.columnIndex).toBeLessThan(COLUMN_COUNT);
+      expect(cell.rowIndex).toBeLessThan(ROW_COUNT);
+      expect(cell.inkAlpha).toBeGreaterThan(0);
+      expect(cell.inkAlpha).toBeLessThanOrEqual(0.6);
+    }
+  });
+
+  it('lights more cells with a ripple crossing than with the ambient wash alone', () => {
+    const ambientCellCount = rasterizeFieldFrame(
+      buildRenderState({ elapsedSeconds: 2 }),
+      COLUMN_COUNT,
+      ROW_COUNT,
+    ).length;
+    const rippledCellCount = rasterizeFieldFrame(
+      buildRenderState({ elapsedSeconds: 2, rippleList: [buildRipple()] }),
+      COLUMN_COUNT,
+      ROW_COUNT,
+    ).length;
+    expect(rippledCellCount).toBeGreaterThan(ambientCellCount);
+  });
+
+  it('brightens around the pointer when it is present', () => {
+    const restingCellCount = rasterizeFieldFrame(
+      buildRenderState({ elapsedSeconds: 2, pointerY: 0.2 }),
+      COLUMN_COUNT,
+      ROW_COUNT,
+    ).length;
+    const trackedCellCount = rasterizeFieldFrame(
+      buildRenderState({ elapsedSeconds: 2, pointerY: 0.2, pointerPresence: 1 }),
+      COLUMN_COUNT,
+      ROW_COUNT,
+    ).length;
+    expect(trackedCellCount).toBeGreaterThan(restingCellCount);
+  });
+
+  it('returns nothing for a degenerate grid', () => {
+    expect(rasterizeFieldFrame(buildRenderState(), 0, 0)).toEqual([]);
+  });
+});

--- a/apps/console/src/landing/field/canvas.tsx
+++ b/apps/console/src/landing/field/canvas.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import {
+  FIELD_CELL_SIZE,
+  pruneRippleList,
+  rasterizeFieldFrame,
+} from '@/landing/field/geometry';
+import {
+  REDUCED_MOTION_QUERY,
+  REDUCED_MOTION_SAFE_QUERY,
+  gsap,
+  prefersReducedMotion,
+  useGSAP,
+} from '@/landing/motion';
+
+import type { FieldRenderState } from '@/landing/field/geometry';
+
+interface FieldCanvasProps {
+  readonly wakeSignal?: number;
+  readonly className?: string;
+}
+
+const FIELD_INK_COLOR = '#fafafa';
+const GLYPH_SIZE_RATIO = 1;
+const TARGET_FRAME_INTERVAL = 1000 / 30;
+
+const AMBIENT_RIPPLE_INTERVAL_SECONDS = 5.5;
+const AMBIENT_RIPPLE_STRENGTH = 0.62;
+const POINTER_RIPPLE_STRENGTH = 0.8;
+const WAKE_RIPPLE_STRENGTH = 1.15;
+const WAKE_RIPPLE_ORIGIN_X = 0.5;
+const WAKE_RIPPLE_ORIGIN_Y = 0.26;
+const STATIC_FRAME_SECONDS = 12;
+
+interface PointerPlacement {
+  readonly normalizedX: number;
+  readonly normalizedY: number;
+}
+
+function isInsideField(placement: PointerPlacement): boolean {
+  return (
+    placement.normalizedX >= 0 &&
+    placement.normalizedX <= 1 &&
+    placement.normalizedY >= 0 &&
+    placement.normalizedY <= 1
+  );
+}
+
+export function FieldCanvas({ wakeSignal = 0, className }: FieldCanvasProps) {
+  const canvasReference = useRef<HTMLCanvasElement | null>(null);
+  const renderStateReference = useRef<FieldRenderState>({
+    elapsedSeconds: 0,
+    pointerX: 0.5,
+    pointerY: 0.5,
+    pointerPresence: 0,
+    rippleList: [],
+  });
+  const isVisibleReference = useRef(true);
+
+  const emitRipple = useCallback((originX: number, originY: number, strength: number) => {
+    const renderState = renderStateReference.current;
+    renderState.rippleList = [
+      ...pruneRippleList(renderState.rippleList, renderState.elapsedSeconds),
+      {
+        originX,
+        originY,
+        emittedSeconds: renderState.elapsedSeconds,
+        strength,
+      },
+    ];
+  }, []);
+
+  const paintFrame = useCallback(() => {
+    const canvas = canvasReference.current;
+    const context = canvas?.getContext('2d');
+    if (canvas === null || context === null || context === undefined) {
+      return;
+    }
+    const pixelRatio = window.devicePixelRatio || 1;
+    const width = Math.round(canvas.clientWidth * pixelRatio);
+    const height = Math.round(canvas.clientHeight * pixelRatio);
+    if (width === 0 || height === 0) {
+      return;
+    }
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+    const cellSize = FIELD_CELL_SIZE * pixelRatio;
+    const columnCount = Math.ceil(width / cellSize);
+    const rowCount = Math.ceil(height / cellSize);
+    const litCellList = rasterizeFieldFrame(
+      renderStateReference.current,
+      columnCount,
+      rowCount,
+    );
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = FIELD_INK_COLOR;
+    context.font = `${Math.ceil(cellSize * GLYPH_SIZE_RATIO)}px 'JetBrains Mono', monospace`;
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    for (const cell of litCellList) {
+      context.globalAlpha = cell.inkAlpha;
+      context.fillText(
+        cell.glyph,
+        (cell.columnIndex + 0.5) * cellSize,
+        (cell.rowIndex + 0.5) * cellSize,
+      );
+    }
+    context.globalAlpha = 1;
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasReference.current;
+    if (canvas === null) {
+      return;
+    }
+    const resizeObserver = new ResizeObserver(() => paintFrame());
+    resizeObserver.observe(canvas);
+    return () => resizeObserver.disconnect();
+  }, [paintFrame]);
+
+  // The hero sits above a long page, so the field stops costing anything the
+  // moment it scrolls away instead of repainting behind five other sections.
+  useEffect(() => {
+    const canvas = canvasReference.current;
+    if (canvas === null) {
+      return;
+    }
+    const intersectionObserver = new IntersectionObserver(([entry]) => {
+      isVisibleReference.current = entry.isIntersecting;
+    });
+    intersectionObserver.observe(canvas);
+    return () => intersectionObserver.disconnect();
+  }, []);
+
+  useGSAP(
+    () => {
+      const renderState = renderStateReference.current;
+      const responsiveMotion = gsap.matchMedia();
+      responsiveMotion.add(REDUCED_MOTION_SAFE_QUERY, () => {
+        emitRipple(
+          gsap.utils.random(0.25, 0.75),
+          gsap.utils.random(0.14, 0.34),
+          AMBIENT_RIPPLE_STRENGTH,
+        );
+        let lastPaintTimestamp = 0;
+        let nextAmbientRippleSeconds = AMBIENT_RIPPLE_INTERVAL_SECONDS;
+        const tickerCallback = (elapsedTime: number) => {
+          if (!isVisibleReference.current) {
+            return;
+          }
+          renderState.elapsedSeconds = elapsedTime;
+          if (elapsedTime >= nextAmbientRippleSeconds) {
+            nextAmbientRippleSeconds =
+              elapsedTime +
+              AMBIENT_RIPPLE_INTERVAL_SECONDS * gsap.utils.random(0.75, 1.35);
+            emitRipple(
+              gsap.utils.random(0.08, 0.92),
+              gsap.utils.random(0.1, 0.44),
+              AMBIENT_RIPPLE_STRENGTH,
+            );
+          }
+          if (elapsedTime * 1000 - lastPaintTimestamp < TARGET_FRAME_INTERVAL) {
+            return;
+          }
+          lastPaintTimestamp = elapsedTime * 1000;
+          renderState.rippleList = pruneRippleList(renderState.rippleList, elapsedTime);
+          paintFrame();
+        };
+        gsap.ticker.add(tickerCallback);
+
+        const fadePointerPresence = gsap.quickTo(renderState, 'pointerPresence', {
+          duration: 0.55,
+          ease: 'power2',
+        });
+        const readPointerPlacement = (event: PointerEvent): PointerPlacement | null => {
+          const canvas = canvasReference.current;
+          if (canvas === null) {
+            return null;
+          }
+          const bounds = canvas.getBoundingClientRect();
+          if (bounds.width === 0 || bounds.height === 0) {
+            return null;
+          }
+          return {
+            normalizedX: (event.clientX - bounds.left) / bounds.width,
+            normalizedY: (event.clientY - bounds.top) / bounds.height,
+          };
+        };
+        const handlePointerMove = (event: PointerEvent) => {
+          const placement = readPointerPlacement(event);
+          if (placement === null || !isInsideField(placement)) {
+            fadePointerPresence(0);
+            return;
+          }
+          renderState.pointerX = placement.normalizedX;
+          renderState.pointerY = placement.normalizedY;
+          fadePointerPresence(1);
+        };
+        const handlePointerDown = (event: PointerEvent) => {
+          const placement = readPointerPlacement(event);
+          if (placement === null || !isInsideField(placement)) {
+            return;
+          }
+          emitRipple(
+            placement.normalizedX,
+            placement.normalizedY,
+            POINTER_RIPPLE_STRENGTH,
+          );
+        };
+        window.addEventListener('pointermove', handlePointerMove, { passive: true });
+        window.addEventListener('pointerdown', handlePointerDown, { passive: true });
+
+        return () => {
+          gsap.ticker.remove(tickerCallback);
+          window.removeEventListener('pointermove', handlePointerMove);
+          window.removeEventListener('pointerdown', handlePointerDown);
+        };
+      });
+      responsiveMotion.add(REDUCED_MOTION_QUERY, () => {
+        renderState.elapsedSeconds = STATIC_FRAME_SECONDS;
+        paintFrame();
+      });
+    },
+    { scope: canvasReference },
+  );
+
+  useGSAP(
+    () => {
+      if (wakeSignal === 0 || prefersReducedMotion()) {
+        return;
+      }
+      emitRipple(WAKE_RIPPLE_ORIGIN_X, WAKE_RIPPLE_ORIGIN_Y, WAKE_RIPPLE_STRENGTH);
+    },
+    { dependencies: [wakeSignal] },
+  );
+
+  return <canvas ref={canvasReference} className={className} aria-hidden />;
+}

--- a/apps/console/src/landing/field/geometry.ts
+++ b/apps/console/src/landing/field/geometry.ts
@@ -1,0 +1,172 @@
+export interface FieldRipple {
+  readonly originX: number;
+  readonly originY: number;
+  readonly emittedSeconds: number;
+  readonly strength: number;
+}
+
+export interface FieldRenderState {
+  elapsedSeconds: number;
+  pointerX: number;
+  pointerY: number;
+  pointerPresence: number;
+  rippleList: FieldRipple[];
+}
+
+export interface FieldCell {
+  readonly columnIndex: number;
+  readonly rowIndex: number;
+  readonly glyph: string;
+  readonly inkAlpha: number;
+}
+
+export const FIELD_GLYPH_RAMP = '.:-=+*#%@';
+export const FIELD_CELL_SIZE = 16;
+export const RIPPLE_LIFETIME_SECONDS = 5.2;
+
+const RIPPLE_SPEED = 0.3;
+const RIPPLE_BAND_WIDTH = 0.075;
+const RIPPLE_ONSET_SECONDS = 0.35;
+
+const POINTER_RADIUS = 0.2;
+const POINTER_WEIGHT = 0.55;
+
+const AMBIENT_WEIGHT = 0.34;
+const AMBIENT_CREST_EXPONENT = 3;
+
+const MASK_TOP_EDGE = 0.03;
+const MASK_TOP_PLATEAU = 0.16;
+const MASK_FADE_START = 0.28;
+const MASK_FADE_END = 0.62;
+const MASK_RESIDUAL = 0.16;
+
+const INTENSITY_FLOOR = 0.085;
+const MINIMUM_INK_ALPHA = 0.06;
+const MAXIMUM_INK_ALPHA = 0.6;
+
+function smoothStep(edgeStart: number, edgeEnd: number, value: number): number {
+  if (edgeStart === edgeEnd) {
+    return value < edgeStart ? 0 : 1;
+  }
+  const normalized = Math.max(
+    0,
+    Math.min(1, (value - edgeStart) / (edgeEnd - edgeStart)),
+  );
+  return normalized * normalized * (3 - 2 * normalized);
+}
+
+// The headline is bottom-anchored in a full-height hero, so the field owns the
+// empty upper half and thins to a residue underneath the type rather than
+// stopping dead: a hard edge across the viewport reads as a seam.
+export function computeVerticalMask(normalizedY: number): number {
+  const topEdge = smoothStep(MASK_TOP_EDGE, MASK_TOP_PLATEAU, normalizedY);
+  const bodyFade = 1 - smoothStep(MASK_FADE_START, MASK_FADE_END, normalizedY);
+  return topEdge * (MASK_RESIDUAL + (1 - MASK_RESIDUAL) * bodyFade);
+}
+
+export function computeAmbientValue(
+  fieldX: number,
+  fieldY: number,
+  elapsedSeconds: number,
+): number {
+  const interference =
+    Math.sin(fieldX * 5.3 + elapsedSeconds * 0.32) +
+    Math.sin(fieldY * 4.1 - elapsedSeconds * 0.24) +
+    Math.sin((fieldX + fieldY) * 3.1 + elapsedSeconds * 0.17);
+  return (interference / 3 + 1) / 2;
+}
+
+export function computeRippleContribution(
+  ripple: FieldRipple,
+  elapsedSeconds: number,
+  fieldX: number,
+  fieldY: number,
+  aspectRatio: number,
+): number {
+  const age = elapsedSeconds - ripple.emittedSeconds;
+  if (age < 0 || age > RIPPLE_LIFETIME_SECONDS) {
+    return 0;
+  }
+  const deltaX = fieldX - ripple.originX * aspectRatio;
+  const deltaY = fieldY - ripple.originY;
+  const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+  const bandOffset = (distance - age * RIPPLE_SPEED) / RIPPLE_BAND_WIDTH;
+  const onset = Math.min(1, age / RIPPLE_ONSET_SECONDS);
+  const decay = 1 - age / RIPPLE_LIFETIME_SECONDS;
+  return Math.exp(-bandOffset * bandOffset) * onset * decay * decay * ripple.strength;
+}
+
+export function computePointerContribution(
+  state: FieldRenderState,
+  fieldX: number,
+  fieldY: number,
+  aspectRatio: number,
+): number {
+  if (state.pointerPresence <= 0) {
+    return 0;
+  }
+  const deltaX = fieldX - state.pointerX * aspectRatio;
+  const deltaY = fieldY - state.pointerY;
+  const falloff = Math.sqrt(deltaX * deltaX + deltaY * deltaY) / POINTER_RADIUS;
+  return Math.exp(-falloff * falloff) * state.pointerPresence * POINTER_WEIGHT;
+}
+
+export function pruneRippleList(
+  rippleList: readonly FieldRipple[],
+  elapsedSeconds: number,
+): FieldRipple[] {
+  return rippleList.filter(
+    (ripple) => elapsedSeconds - ripple.emittedSeconds <= RIPPLE_LIFETIME_SECONDS,
+  );
+}
+
+export function rasterizeFieldFrame(
+  state: FieldRenderState,
+  columnCount: number,
+  rowCount: number,
+): readonly FieldCell[] {
+  const litCellList: FieldCell[] = [];
+  if (columnCount <= 0 || rowCount <= 0) {
+    return litCellList;
+  }
+  const aspectRatio = columnCount / rowCount;
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    const fieldY = (rowIndex + 0.5) / rowCount;
+    const verticalMask = computeVerticalMask(fieldY);
+    if (verticalMask <= 0) {
+      continue;
+    }
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      const fieldX = ((columnIndex + 0.5) / columnCount) * aspectRatio;
+      let energy =
+        computeAmbientValue(fieldX, fieldY, state.elapsedSeconds) **
+          AMBIENT_CREST_EXPONENT *
+        AMBIENT_WEIGHT;
+      for (const ripple of state.rippleList) {
+        energy += computeRippleContribution(
+          ripple,
+          state.elapsedSeconds,
+          fieldX,
+          fieldY,
+          aspectRatio,
+        );
+      }
+      energy += computePointerContribution(state, fieldX, fieldY, aspectRatio);
+      const intensity = Math.min(1, energy) * verticalMask;
+      if (intensity < INTENSITY_FLOOR) {
+        continue;
+      }
+      const glyphIndex = Math.min(
+        FIELD_GLYPH_RAMP.length - 1,
+        Math.floor(intensity * FIELD_GLYPH_RAMP.length),
+      );
+      litCellList.push({
+        columnIndex,
+        rowIndex,
+        glyph: FIELD_GLYPH_RAMP.charAt(glyphIndex),
+        inkAlpha: MINIMUM_INK_ALPHA + intensity * (MAXIMUM_INK_ALPHA - MINIMUM_INK_ALPHA),
+      });
+    }
+  }
+  return litCellList;
+}

--- a/apps/console/src/landing/hero.tsx
+++ b/apps/console/src/landing/hero.tsx
@@ -2,12 +2,15 @@ import { useRef } from 'react';
 
 import { LandingCommand } from '@/landing/command';
 import { LANDING_MESSAGE_CATALOG } from '@/landing/copy/catalog';
+import { FieldCanvas } from '@/landing/field/canvas';
 import { REDUCED_MOTION_SAFE_QUERY, RISE_EASE, gsap, useGSAP } from '@/landing/motion';
+import { useWakeEcho } from '@/landing/wake';
 import { useMessages } from '@/locale/context';
 
 export function LandingHero() {
   const landingMessages = useMessages(LANDING_MESSAGE_CATALOG);
   const heroReference = useRef<HTMLElement | null>(null);
+  const { wakeSignal } = useWakeEcho();
 
   useGSAP(
     () => {
@@ -31,7 +34,11 @@ export function LandingHero() {
       ref={heroReference}
       className="relative flex min-h-svh flex-col justify-end pb-16 pt-[120px]"
     >
-      <div className="mx-auto w-full max-w-[1180px] px-8">
+      <FieldCanvas
+        wakeSignal={wakeSignal}
+        className="pointer-events-none absolute inset-0 size-full"
+      />
+      <div className="relative mx-auto w-full max-w-[1180px] px-8">
         <h1 className="font-serif text-[clamp(44px,11.5vw,156px)] leading-[0.98] tracking-[-0.02em]">
           <span className="-mb-[0.12em] block overflow-hidden pb-[0.12em]">
             <span data-hero-line className="block">


### PR DESCRIPTION
The hero is a full-height header with the headline anchored to the bottom, which left the upper half of the viewport empty. This fills it with the same glyph language the desk agent already speaks further down the page — canvas 2D, no WebGL, no new dependency.

## The field

`landing/field/geometry.ts` is pure and tested. Per-cell energy is three terms summed, then masked and mapped to the `.:-=+*#%@` ramp:

- **Wavefronts** — `exp(-((distance - radius)/band)²)` with `radius = age × 0.3`, a 5.2s life and quadratic decay. A gaussian band rather than a filled disc, which is what makes it read as a wave instead of a blob.
- **Ambient** — three summed sines, cubed so only the crests light. Without it the hero dies between ripples.
- **Pointer** — a gaussian halo of radius 0.2.

Ripple origins are scaled by the aspect ratio inside field space so the front stays circular on wide viewports; there is a test pinning that.

**The vertical mask is the design decision worth reviewing.** It is 0 at the very top so the nav row stays clear, plateaus from 0.16, and instead of cutting to 0 behind the headline it settles to a residue of 0.16. Under the h1 the field survives as dust — only `.` and `:` at ~0.07 alpha — rather than ending in a horizontal seam across the middle of the viewport.

## Cost

`landing/field/canvas.tsx` uses a 16px cell on the same `gsap.ticker` idiom as `device/canvas.tsx`, capped at 30fps. Two things keep it cheap: an `IntersectionObserver` stops painting the moment the hero scrolls away (this is a long page — no sense repainting behind five other sections), and the intensity floor discards most cells before they ever reach `fillText`. Reduced motion paints a single static frame.

Ripples fire on mount, on a jittered ~5.5s ambient cadence, on `pointerdown` inside the hero, and on the typed wake word.

## Worth a look before merging

**The wake word competes with itself.** The hero now consumes `useWakeEcho`, but `showcase.tsx` already scrolls the desk into view when you type "heyapolo". From the top of the page you see roughly half a second of the hero ripple before the scroll carries you down. Fixing it means teaching the showcase to skip its scroll while the hero is in viewport — that changes existing behaviour, so it is not in this PR.

**The constants are calibrated by eye, not against a screen.** A browser-automation permission issue on localhost blocked visual verification here. The knobs, all in `geometry.ts`: `MASK_RESIDUAL` (0.16, how much dust survives under the headline), `AMBIENT_WEIGHT` (0.34, liveliness between ripples), `MAXIMUM_INK_ALPHA` (0.6, how hard it pushes against the serif), `RIPPLE_SPEED` (0.3, wavefront speed).

## Verification

`bun run check` passes in a clean worktree off `origin/main` — lint, format, typecheck, and 129 tests including 5 new ones covering the mask envelope, ripple lifetime and wavefront peak, aspect correction, ramp bounds, and the degenerate grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjWK959fs6wvxsTyV9LC64

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an ASCII canvas field behind the landing hero, including ambient, pointer, timed, and wake-word ripples with reduced-motion and offscreen rendering controls.
- Adds pure field geometry and rasterization helpers.
- Adds tests for masking, ripple behavior, aspect correction, glyph bounds, and degenerate grids.
- Integrates the canvas and wake-word signal into the landing hero.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The new canvas remains decorative and accessibility-hidden, its listeners and animation resources are cleaned up, reduced-motion behavior is handled, and the geometry outputs are bounded and tested.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(console): ascii field behind the la..."](https://github.com/galfrevn/apollo/commit/245ae0dd85a46a5969b3dc593638db117bf419fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53434557)</sub>

<!-- /greptile_comment -->