### PR TITLE
docs(setup): .dev.vars lives in apps/agent, not the repo root

### DIFF
--- a/documentation/operations/setup.md
+++ b/documentation/operations/setup.md
@@ -12,8 +12,12 @@ Local development uses Bun for scripts/tests and Wrangler for the Workers runtim
 
 ```bash
 bun install
-cp .dev.vars.example .dev.vars
+cp apps/agent/.dev.vars.example apps/agent/.dev.vars
 ```
+
+`.dev.vars` has to sit next to `wrangler.jsonc`, in `apps/agent/`. Wrangler resolves it
+relative to its config file, so a copy left in the repo root is silently ignored and every
+authenticated request answers `401` with nothing in the logs to say why.
 
 Fill `.dev.vars` with at least `DEVICE_SHARED_SECRET` and `OPENROUTER_API_KEY`, and leave `MOCK_VOICE=1` — it skips real STT/TTS *and* vector recall locally, so a dev session costs nothing in ElevenLabs credits or embedding calls.
 
@@ -47,7 +51,7 @@ From `package.json`:
 ## Configuration
 
 - Worker config: `apps/agent/wrangler.jsonc`
-- Local secrets: `.dev.vars` (from `.dev.vars.example`)
+- Local secrets: `apps/agent/.dev.vars` (from `apps/agent/.dev.vars.example`)
 - Path alias `@/` → `apps/agent/src/` (see `apps/agent/tsconfig.json`)
 
 ## Navigation


### PR DESCRIPTION
Following `documentation/operations/setup.md` verbatim on a fresh clone leaves you with a worker that starts cleanly and rejects every authenticated request.

`cp .dev.vars.example .dev.vars` puts the file in the repo root, but `.dev.vars.example` only exists in `apps/agent/`, and Wrangler resolves `.dev.vars` relative to its config file (`apps/agent/wrangler.jsonc`). The root copy is silently ignored, so `DEVICE_SHARED_SECRET` is never set and `authorizeApolloConnection` answers `401` — with nothing in the logs pointing at the cause.

```
[wrangler:info] GET /agents/apollo/<id> 401 Unauthorized (2ms)
```

Moving the file to `apps/agent/` fixes it, with no other change.

This updates the copy command, adds a line saying why the location matters, and corrects the same path in the Configuration section below.

Found while bringing up a second board against a local `wrangler dev` — thanks for publishing both halves, the protocol chapter in particular is unusually good documentation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects local setup documentation so Wrangler loads development secrets from the agent workspace.
- Copies `.dev.vars.example` to `apps/agent/.dev.vars`.
- Explains why `.dev.vars` must be beside `apps/agent/wrangler.jsonc`.
- Corrects the local-secrets path in the Configuration section.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only correction appears safe to merge.

The updated source and destination paths exist in the agent workspace, align with how the repository starts Wrangler, and ensure the authentication secret is loaded during local development.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(setup): .dev.vars lives in apps/age..."](https://github.com/galfrevn/apollo/commit/36b33cf72cc67ef87a031c7489372a2e235c2f55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53662157)</sub>

<!-- /greptile_comment -->