### PR TITLE
docs: add a contributing guide and fix triage on fork pull requests

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 name: Triage
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing
+
+Thanks for looking. Apollo is a personal agent with a body: a Cloudflare Worker does the
+thinking, an ESP32 carries it. Almost everything worth changing lives on the worker side,
+and none of it needs the hardware to work on.
+
+## Get it running
+
+```bash
+git clone --recurse-submodules https://github.com/galfrevn/apollo.git
+cd apollo
+bun install
+bunx lefthook install
+cp apps/agent/.dev.vars.example apps/agent/.dev.vars
+bun run dev
+```
+
+Two things bite people:
+
+`apps/firmware/apollo-firmware` is a git submodule. If you already cloned without it, run
+`git submodule update --init --recursive`. You only need it to build firmware.
+
+`.dev.vars` has to sit in `apps/agent/`, next to `wrangler.jsonc` — Wrangler resolves it
+relative to its own config, so a copy in the repo root is silently ignored and every
+authenticated request answers `401` with nothing in the logs. Leave `MOCK_VOICE=1` while
+you develop: it skips real STT/TTS and vector recall, so a session costs nothing.
+
+Full detail in [Setup](documentation/operations/setup.md).
+
+## Where things live
+
+| Path | What it is |
+|------|------------|
+| `apps/agent/` | the Cloudflare Worker — voice turns, tools, memory, background work |
+| `apps/console/` | the marketing landing (`/`) and management console (`/console`) |
+| `apps/wizard/` | the `create-heyapollo` setup wizard and starter generator |
+| `apps/firmware/` | ESP32 firmware, a submodule, not a workspace member |
+| `documentation/` | the handbook, meant to be read in order from [index.md](documentation/index.md) |
+
+`documentation/reference/mapping.md` maps each handbook topic to its folder under
+`apps/agent/src/`. Read the chapter before changing the behaviour it describes.
+
+## Before you open a pull request
+
+```bash
+bun run check
+```
+
+That is the gate — lint, format check, typecheck, and tests, about two seconds cold. The
+pre-push hook runs typecheck and tests as a backstop, and CI runs the whole thing again.
+
+Two more things CI enforces that are easy to miss:
+
+**The pull request title has to be a conventional commit.** `feat(console): …`,
+`fix(agent): …`, `docs(setup): …`. Allowed types are in `commitlint.config.ts`. A title
+that does not parse fails the Title check.
+
+**Lines you add need 80% test coverage.** Tests live next to the code they cover as
+`__tests__/*.spec.ts` and run on Bun. Keep them deterministic — no live network.
+
+## House style
+
+The rules in [CLAUDE.md](CLAUDE.md) apply to everyone, not just agents. The ones that
+actually come up in review:
+
+- **Names are long and descriptive.** Full words, no abbreviations, no single letters
+  outside a tight loop. Booleans start with `is`/`has`/`should`; functions start with a
+  verb; collections end in `List`/`Map`/`Set`/`Catalog`.
+- **Filenames are a single lowercase word.** Compose meaning through folders, never through
+  hyphenated names — `src/voice/countdown.ts`, not `src/voice/countdown-arc.ts`.
+- **No escape hatches.** No `any`, no `as unknown as`, no `@ts-ignore`, no non-null
+  assertions on untrusted data. Validate every external input with `zod`.
+- **No comments unless they explain a non-obvious *why*** — a workaround, a constraint, an
+  external spec. Names document the *what*.
+- **One concern per file**, under about 300 lines.
+- **Imports in two groups**, third-party then local `@/`, blank line between.
+
+Formatting is oxfmt's job — run `bun run format` and never hand-format.
+
+## Scope
+
+Small fixes, tests for untested modules, and documentation corrections are always welcome
+as a direct pull request. For anything that changes how the agent behaves, open an issue
+first so the design gets settled before you write it — `documentation/reference/roadmap.md`
+is the honest list of what is open and what is deliberately not being built.
+
+Issues labelled `good first issue` are scoped to be self-contained and server-side, so no
+device required.


### PR DESCRIPTION
Two changes aimed at the same thing: making an outside contribution work on the first try. The repo passed 200 stars with 22 forks and two merged external pull requests, and both of those contributors hit avoidable friction.

## Triage never worked for external contributors

`Triage` ran on `pull_request`. A pull request opened **from a fork** runs that event with a read-only `GITHUB_TOKEN`, so the job's `pull-requests: write` is silently downgraded and every write fails:

```
##[warning]The action requires write permission to add labels to pull requests.
##[error]Resource not accessible by integration
```

The pattern is unambiguous in the run history: both fork pull requests (#71, #72) failed; all ten internal-branch pull requests passed. Because the labeler failed the job, the two steps after it never ran either — so external contributors were the only ones getting no labels, no author assignment, and no welcome quote.

`pull_request_target` runs in the base repository's context with a write token. It is safe here because no step in the job checks out or executes pull request code: the checkout resolves to the base branch and is only read for `.github/labeler.yml` and `.github/quotes/catalog.json`. As a side effect a fork can no longer alter the labeler config that runs against it.

The diff is one word.

## CONTRIBUTING.md

A single page linking into `documentation/` rather than restating it. It documents the things that are true but not discoverable from the tree:

- `apps/firmware/apollo-firmware` is a submodule, so a plain clone is incomplete.
- **`bunx lefthook install` is required.** There is no `prepare` script in the root `package.json`, so a fresh clone plus `bun install` leaves the git hooks uninstalled.
- `.dev.vars` belongs in `apps/agent/`, not the repo root — literally the bug #72 was opened to fix.
- The **pull request title must be a conventional commit**, otherwise the `Title` check fails after the work is already done.
- **Added lines need 80% coverage**, which is enforced but was written down nowhere.
- The `CLAUDE.md` style rules that actually come up in review: descriptive names, single-word lowercase filenames, no `any`, no comments unless they explain a non-obvious why.

No README changes, no badges, no issue or pull request templates — kept deliberately minimal.

`bun run check` passes (603 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNquiqS8Qiv7jC5SvBNm6n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes triage work for pull requests from forks and adds a concise contributor guide.
- Changes the triage trigger to `pull_request_target` while retaining a trusted base-branch checkout and configuration.
- Documents setup, repository layout, validation commands, CI requirements, house style, and contribution scope.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The privileged triage workflow checks out and reads configuration from the trusted base branch, and the new contributor instructions align with the repository’s commands, CI checks, and documentation.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add a contributing guide and fix t..."](https://github.com/galfrevn/apollo/commit/bdc5f8e653bcd06e856fda7b22d8d753a9df52b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53833344)</sub>

<!-- /greptile_comment -->