### PR TITLE
ci: deploy each app only when its own sources change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'documentation/**'
+      - '.claude/**'
+      - '.vscode/**'
   workflow_dispatch:
 
 permissions:
@@ -41,7 +46,6 @@ jobs:
           filters: |
             agent:
               - 'apps/agent/**'
-              - '!apps/agent/**/*.md'
               - 'packages/**'
               - 'package.json'
               - 'bun.lock'
@@ -50,7 +54,6 @@ jobs:
               - '.github/actions/setup/**'
             console:
               - 'apps/console/**'
-              - '!apps/console/**/*.md'
               - 'packages/**'
               - 'package.json'
               - 'bun.lock'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,8 @@
-# Deploys the worker on every push to main, after a fresh test run in this
-# job — hermetic on purpose, so the gate holds even if ci.yml changes.
-# Doc-only merges skip it. Requires a `production` environment limited to the
-# main branch, holding two secrets:
+# Deploys on every push to main, after a fresh test run in the deploying job —
+# hermetic on purpose, so the gate holds even if ci.yml changes. Each app
+# deploys only when its own sources moved; doc-only merges deploy nothing, and
+# a manual dispatch deploys both. Requires a `production` environment limited
+# to the main branch, holding two secrets:
 #   CLOUDFLARE_API_TOKEN   Workers deploy rights on the account
 #   CLOUDFLARE_ACCOUNT_ID  the Cloudflare account id
 name: Deploy
@@ -10,11 +11,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'documentation/**'
-      - '.claude/**'
-      - '.vscode/**'
   workflow_dispatch:
 
 permissions:
@@ -25,13 +21,54 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      agent: ${{ steps.filter.outputs.agent }}
+      console: ${{ steps.filter.outputs.console }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Detect deployable changes
+        id: filter
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
+        with:
+          filters: |
+            agent:
+              - 'apps/agent/**'
+              - '!apps/agent/**/*.md'
+              - 'packages/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'turbo.json'
+              - '.github/workflows/deploy.yml'
+              - '.github/actions/setup/**'
+            console:
+              - 'apps/console/**'
+              - '!apps/console/**/*.md'
+              - 'packages/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'turbo.json'
+              - '.github/workflows/deploy.yml'
+              - '.github/actions/setup/**'
+
+  agent:
     name: Deploy worker
+    needs: changes
     # workflow_dispatch lets the caller pick any ref, so the job refuses
     # everything but main. The real gate is the `production` environment: its
     # branch rule rejects other refs and the credentials live only there, so a
     # branch that edits this file out of the way still can't reach them.
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (needs.changes.outputs.agent == 'true' ||
+        github.event_name == 'workflow_dispatch')
     environment: production
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -50,7 +87,35 @@ jobs:
       # wrangler builds the Sandbox container image as part of the deploy,
       # which is why this runs on the runner's Docker daemon.
       - name: Deploy
-        run: bun run deploy
+        run: bunx turbo run deploy --filter=@apollo/agent
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  console:
+    name: Deploy console
+    needs: changes
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (needs.changes.outputs.console == 'true' ||
+        github.event_name == 'workflow_dispatch')
+    environment: production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Deploy
+        run: bunx turbo run deploy --filter=@apollo/console
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/agent/CLAUDE.md
+++ b/apps/agent/CLAUDE.md
@@ -24,3 +24,14 @@ Durable Objects hold all state: `Apollo` (the agent, SQLite-backed), `ApolloBack
 Tests live beside the code they cover as `__tests__/*.spec.ts`.
 
 The device firmware is a submodule at `apps/firmware/apollo-firmware`; the contract between the two repos is `documentation/runtime/protocol.md`.
+
+## This app ships to strangers
+
+`src/` is copied verbatim into the public `apollo-starter` snapshot and into the `template/` that `create-heyapollo` clones for users (`apps/wizard/generator/build.ts`). A change here is a change to what someone else deploys on their own Cloudflare account, so it has to hold four invariants — stated in full, with the machinery behind them, in [Starter](../../documentation/reference/starter.md):
+
+1. **New binding or secret** → the starter inherits it automatically. Decide which it is: optional for a stranger (declare it in `src/configuration/environment.d.ts` and degrade gracefully) or provisioned at setup (add it to `apps/wizard/generator/assets/scripts/bootstrap.ts` and the `apollo-setup` skill).
+2. **No owner value in tracked source** — not the owner's email, the ElevenLabs voice id, or the `heyapollo` host. It belongs in `src/configuration/identity.ts` or a secret. The generator's guard fails the build if one leaks.
+3. **Changed wire constant** → update the skill in `documentation/skills/` that quotes it. `apps/wizard/__tests__/anchors.spec.ts` names the pair and runs in `bun run check`.
+4. **Reshaped `src/configuration/identity.ts`** → update the generator manifest's placeholder swap and the wizard rewriters in the same change. The swap is anchored to an exact line and drift fails the build.
+
+`.github/workflows/starter.yml` regenerates and smoke-builds the starter on every push or pull request touching this app, so drift surfaces at pull request time instead of in a stranger's terminal. Reproduce it locally with `bun apps/wizard/generator/build.ts --smoke`.

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,21 @@
+{
+  "customContext": {
+    "rules": [
+      {
+        "scope": ["apps/agent/**"],
+        "rule": "apps/agent/src is copied verbatim into the public apollo-starter snapshot and into the template that create-heyapollo clones for users, so review a change here as a change to what a stranger deploys on their own Cloudflare account. Flag when: a new binding or secret is introduced without deciding whether it degrades gracefully for a user who has not provisioned it (declared in src/configuration/environment.d.ts) or is provisioned at setup (apps/wizard/generator/assets/scripts/bootstrap.ts and the apollo-setup skill); an owner value is hardcoded in tracked source, meaning the owner's email, the ElevenLabs voice id, or the heyapollo host, all of which belong in src/configuration/identity.ts or a secret; a wire constant quoted by a skill in documentation/skills/ changes without that skill being updated in the same pull request, which apps/wizard/__tests__/anchors.spec.ts pins; or src/configuration/identity.ts is reshaped without updating the generator manifest's placeholder swap and the wizard rewriters together."
+      },
+      {
+        "scope": ["apps/wizard/generator/**"],
+        "rule": "The starter generator only copies, substitutes and deletes. A transform here that performs real code surgery on the agent source is a signal to genericize apps/agent instead, and is worth raising in review."
+      }
+    ],
+    "files": [
+      {
+        "scope": ["apps/agent/**", "apps/wizard/**"],
+        "path": "documentation/reference/starter.md",
+        "description": "How the public starter snapshot is generated from apps/agent, the transforms and guards applied to it, and the invariants a change to the agent has to hold."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## The worker was not the only thing deploying

`Deploy` ran `bun run deploy`, which is `turbo run deploy` across every workspace — and `apps/console` has a `deploy` script too, bound to `heyapollo.dev`. So every push to `main` redeployed both the worker and the site, including pushes that touched neither.

That also means the obvious fix was a trap: scoping the existing workflow to `apps/agent/**` would have quietly stopped deploying the landing, the console and the hosted handbook. So the job is split instead.

- A `changes` job resolves two path filters, following the same `dorny/paths-filter` shape `ci.yml` already uses.
- `Deploy worker` runs on `apps/agent/**`, `Deploy console` on `apps/console/**`. Each still runs the full test suite in its own job before deploying — the hermetic gate the original comment describes is unchanged.
- Shared roots (`bun.lock`, `package.json`, `turbo.json`, `packages/**`, the setup action, this workflow) count for both, since either app can be rebuilt by them.
- Exclusion stays where it already worked: the workflow-level `paths-ignore` for `**.md`, `documentation/**`, `.claude/**` and `.vscode/**`, unchanged from before. The job filters only carry positive globs, and only decide *which* app deploys.
- A manual `workflow_dispatch` still deploys both — `paths-filter` has no diff to work from on a dispatch, so the jobs `||` it explicitly rather than silently doing nothing.
- `if: github.ref == 'refs/heads/main'` and the `production` environment are unchanged on both jobs, so the credential gate is exactly as it was.

Verified the filters resolve to one package each:

```
$ turbo run deploy --filter=@apollo/agent   --dry-run=json  →  @apollo/agent#build, @apollo/agent#deploy
$ turbo run deploy --filter=@apollo/console --dry-run=json  →  @apollo/console#build, @apollo/console#deploy
```

And the routing, against the scenarios that matter:

| push contains | workflow skipped | agent | console |
|---|---|---|---|
| docs / README only | yes | — | — |
| `apps/agent/CLAUDE.md` only | yes | — | — |
| `apps/agent/src/**` | no | **deploy** | — |
| `apps/console/src/**` | no | — | **deploy** |
| docs + console source | no | — | **deploy** |
| `bun.lock` | no | **deploy** | **deploy** |
| unrelated workflow file | no | — | — |
| `.vscode/**` | yes | — | — |

### Note on the second commit

The first version of this branch excluded agent/console Markdown with negated globs (`!apps/agent/**/*.md`) inside the job filters. That was wrong, and wrong in the dangerous direction. `dorny/paths-filter` compiles each pattern in a rule into its own `picomatch` matcher and ORs them under the default `some` quantifier, so a lone `!apps/agent/**/*.md` is a matcher that returns true for *every path that is not an agent markdown file*. Both filters would have come out true on nearly every push — including doc-only ones — so both production apps would have redeployed every time, which is worse than the `paths-ignore` this PR set out to refine. The negation also failed at its own goal, since `apps/agent/CLAUDE.md` still matched `apps/agent/**` anyway.

## Agent changes are changes to what strangers clone

`apps/agent/src` is copied verbatim into the public `apollo-starter` snapshot and into the `template/` that `create-heyapollo` clones. `documentation/reference/starter.md` already documents this in full, down to a section called *Invariants when changing `apps/agent`* — but nothing pointed at it from where the work actually happens, so an agent editing the worker had no reason to find it.

Rather than duplicate the chapter, both additions are pointers to it:

- **`apps/agent/CLAUDE.md`** gains a *This app ships to strangers* section: the four invariants in summary, plus how to reproduce the check locally (`bun apps/wizard/generator/build.ts --smoke`).
- **`greptile.json`** (new) scopes the same rules to `apps/agent/**` through `customContext.rules`, and points reviews of `apps/agent/**` and `apps/wizard/**` at the starter chapter via `customContext.files`. It sets nothing else — no strictness, labels or comment types — so the dashboard settings stay in charge of everything but this context.

Both restate one contract that already had a single source of truth, and CI already enforces it: `starter.yml` regenerates and smoke-builds the starter on every change to `apps/agent/**`.

`bun run check` passes (603 + 107 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNquiqS8Qiv7jC5SvBNm6n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates worker and console deployments and gates each deployment using app-specific and shared-source path filters, while preserving manual deployments and the production environment gate.

- Adds a path-filtering job and independently scoped worker and console deployment jobs.
- Documents the public starter invariants for changes under `apps/agent`.
- Adds scoped Greptile context for agent and wizard reviews.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): drop negated globs from the dep..."](https://github.com/galfrevn/apollo/commit/f539b395f5753ef84d51c10bcd4c98ce42deb786) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53834896)</sub>

<!-- /greptile_comment -->