### PR TITLE
test: cover dollar rate fallback responses

### DIFF
--- a/apps/agent/src/tools/__tests__/dollar.spec.ts
+++ b/apps/agent/src/tools/__tests__/dollar.spec.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 
+import { createFakeApolloEnvironment } from '@/configuration/testing';
 import type { DollarRate } from '@/rates/dollar';
 import {
+  dollarRateTool,
   formatDollarRateForSpeech,
   summarizeDollarRateListForSpeech,
 } from '@/tools/dollar';
+import type { ToolExecutionContext } from '@/tools/types';
 
 function buildRate(overrides: Partial<DollarRate> = {}): DollarRate {
   return {
@@ -36,6 +39,45 @@ describe('formatDollarRateForSpeech', () => {
     expect(formatDollarRateForSpeech(buildRate({ venta: null }))).toBe(
       'Blue: sin cotización',
     );
+  });
+});
+
+const unavailableFetch = async () =>
+  new Response('upstream unavailable', { status: 503 });
+const malformedListFetch = async () =>
+  new Response(JSON.stringify([{ casa: 'blue', nombre: 'Blue', venta: 1480 }]), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('dollarRateTool fallback responses', () => {
+  const originalFetch = globalThis.fetch;
+  const context: ToolExecutionContext = {
+    environment: createFakeApolloEnvironment(),
+    nowMilliseconds: 0,
+  };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns a speakable error when a typed rate request fails upstream', async () => {
+    globalThis.fetch = Object.assign(unavailableFetch, { preconnect: () => {} });
+
+    const response = await dollarRateTool.handler({ type: 'blue' }, context);
+
+    expect(response).toEqual({
+      ok: false,
+      summary: 'No pude traer la cotización (dolarapi request failed with status 503)',
+    });
+  });
+
+  it('returns a speakable error when the summary payload is malformed', async () => {
+    globalThis.fetch = Object.assign(malformedListFetch, { preconnect: () => {} });
+
+    const response = await dollarRateTool.handler({}, context);
+
+    expect(response.ok).toBe(false);
+    expect(response.summary).toContain('No pude traer la cotización');
   });
 });
 


### PR DESCRIPTION
## What
Add deterministic tests for the dollar-rate tool’s upstream failure and malformed-payload paths. The tests verify that the handler returns a speakable fallback response instead of throwing.

## Why
The rate tool depends on an external service, so failure and invalid-response behavior needs coverage without live network calls.

## Test plan
- `bun test apps/agent/src/tools/__tests__/dollar.spec.ts`
- `bun run --cwd apps/agent typecheck`
- `bun run format:check`
- Full repository check: 605 tests passed

Fixes #76

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic tests confirming that the dollar-rate tool returns speakable fallback responses for upstream errors and malformed payloads.
- Stubs `globalThis.fetch` for failure scenarios and restores it after each test.
- Covers a typed-rate request receiving HTTP 503.
- Covers a summary request receiving an invalid rate payload.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only adds deterministic fallback-path tests and preserves test isolation.

The fetch replacement is restored after each test, test files are isolated, and the shared context is unused by the exercised handler, leaving no concrete blocking or non-blocking defect.
</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover dollar rate fallback respons..."](https://github.com/galfrevn/apollo/commit/c67e200c43d248b6b099951bf91ae966c534820a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53843636)</sub>

<!-- /greptile_comment -->