### PR TITLE
test: cover memory tool handlers

### DIFF
--- a/apps/agent/src/tools/__tests__/memory.spec.ts
+++ b/apps/agent/src/tools/__tests__/memory.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import {
+  createFakeApolloEnvironment,
+  createStubDeskToolEffects,
+} from '@/configuration/testing';
+import { recallMemoryTool, rememberFactTool } from '@/tools/memory';
+import type { ToolExecutionContext } from '@/tools/types';
+
+const context: ToolExecutionContext = {
+  environment: createFakeApolloEnvironment(),
+  nowMilliseconds: 0,
+  deviceId: 'desk-01',
+};
+
+mock.module('@/memory/vector', () => ({
+  embedTextWithOpenRouter: async () => [0.1, 0.2, 0.3],
+  queryMemoryVectors: async () => [
+    { id: 'memory-1', content: 'La reunión es el viernes', score: 0.95 },
+    { id: 'memory-empty', content: '', score: 0.5 },
+  ],
+}));
+
+describe('remember_fact', () => {
+  it('persists the fact and speaks the stored content', async () => {
+    const result = await rememberFactTool.handler(
+      { content: 'La reunión es el viernes' },
+      {
+        ...context,
+        effects: createStubDeskToolEffects({
+          persistMemory: async (content) => ({
+            memoryId: 'memory-1',
+            content,
+          }),
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      summary: 'Recordado: La reunión es el viernes',
+      data: { memoryId: 'memory-1', content: 'La reunión es el viernes' },
+    });
+  });
+
+  it('reports unavailable effects instead of throwing', async () => {
+    const result = await rememberFactTool.handler({ content: 'dato' }, context);
+
+    expect(result).toEqual({ ok: false, summary: 'Effects no disponibles' });
+  });
+});
+
+describe('recall_memory', () => {
+  it('summarizes only matches that contain usable content', async () => {
+    const result = await recallMemoryTool.handler(
+      { query: 'reunión', limit: 3 },
+      context,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      summary: 'Recordé 1 cosas: La reunión es el viernes',
+      data: {
+        matchList: [{ id: 'memory-1', content: 'La reunión es el viernes', score: 0.95 }],
+      },
+    });
+  });
+
+  it('returns a speakable failure when embedding fails', async () => {
+    mock.module('@/memory/vector', () => ({
+      embedTextWithOpenRouter: async () => {
+        throw new Error('embedding unavailable');
+      },
+      queryMemoryVectors: async () => [],
+    }));
+
+    const result = await recallMemoryTool.handler({ query: 'reunión' }, context);
+
+    expect(result).toEqual({
+      ok: false,
+      summary: 'No pude recordar: embedding unavailable',
+    });
+  });
+});


### PR DESCRIPTION
## What
Add deterministic tests for Apollo’s memory tools. The suite covers successful persistence, unavailable effects, semantic matches with empty results filtered out, and embedding failures returned as speakable errors.

## Why
Memory is a core agent capability and its persistence, retrieval, and degradation paths should remain covered without hardware or live network dependencies.

## Test plan
- `bun test apps/agent/src/tools/__tests__/memory.spec.ts`
- `bun run check`
- Result: 607 tests passed, lint, formatting, typecheck, and repository gates passed

Fixes #75

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic coverage for memory persistence, retrieval filtering, unavailable effects, and embedding failures.
- Tests successful fact persistence and spoken confirmation.
- Tests graceful handling when effects are unavailable.
- Tests filtering empty semantic matches and converting embedding errors into speakable failures.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only adds deterministic test coverage and no actionable failures were identified.

The added tests cover the stated success and degradation paths, and the module-mocking arrangement is compatible with the handler’s dynamic import behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover memory tool handlers"](https://github.com/galfrevn/apollo/commit/4e542aab8633ce85d50220ed844468992ebbd641) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53858383)</sub>

<!-- /greptile_comment -->