### PR TITLE
ci(labeler): label pull requests by area

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,41 @@
+agent:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/agent/**'
+
 ci:
   - changed-files:
       - any-glob-to-any-file: '.github/**'
+
+console:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/console/**'
+
+deps:
+  - changed-files:
+      - any-glob-to-any-file:
+          - bun.lock
+          - '**/package.json'
 
 docs:
   - changed-files:
       - any-glob-to-any-file:
           - documentation/**
-          - '**/*.md'
+          - '*.md'
+
+firmware:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/firmware/**'
+
+packages:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/**'
+
+skills:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .agents/**
+          - .claude/**
+
+wizard:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/wizard/**'


### PR DESCRIPTION
## Labels to create

`agent` · `console` · `wizard` · `firmware` · `deps` · `packages` · `skills` 


### Verification


  | Path | Labels |
  |---|---|
  | `apps/agent/src/agents/notify.ts` | `agent` |
  | `apps/agent/package.json` | `agent`, `deps` |
  | `apps/console/src/docs/content/setup.md` | `console` |
  | `apps/firmware/apollo-firmware` | `firmware` |
  | `packages/typescript-config/package.json` | `packages`, `deps` |
  | `.agents/skills/bun/SKILL.md` | `skills` |
  | `CONTRIBUTING.md` | `docs` |
  | `turbo.json` | *(none)* |

22 of 1052 paths end up unlabelled — all root config and `branding/` assets. `bun run check` passes unchanged.

### Note

This pull request won't be labelled by its own rules. Triage runs on  `pull_request_target`, where labeler reads its config from the base branch, so it gets the two-entry config currently on `main`. The new areas apply from the next pull request on.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands pull-request labeling from broad CI and documentation categories to application areas, packages, skills, and dependency files.
- Adds labels for agent, console, firmware, wizard, packages, skills, and dependencies.
- Narrows `docs` matching to `documentation/**` and root-level Markdown.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The labeler syntax is compatible with the consuming workflow, missing labels can be created using its existing permissions, and all currently affected nested Markdown remains covered by an area label.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(labeler): label pull requests by area"](https://github.com/galfrevn/apollo/commit/d3e8d404535509d8d56fc2fb65c8d21d78219a46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54074624)</sub>

<!-- /greptile_comment -->